### PR TITLE
Readme scrub

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ zq help
 Here are a few examples.
 
 To cut the columns of a Zeek "conn" log like
-[`zeek-cut`](https://github.com/zeek/zeek-aux/tree/master/zeek-cut) does, run:
+`zeek-cut` does, run:
 ```
 zq "* | cut ts,id.orig_h,id.orig_p" conn.log
 ```

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# zq
+# `zq`
 
-zq is a command-line tool for processing
-[zeek](https://www.zeek.org) logs.  If you are familiar with
-[zeek-cut](https://github.com/zeek/zeek-aux/tree/master/zeek-cut),
-you can think of zq as zeek-cut on steroids.  If you missed
+`zq` is a command-line tool for processing
+[Zeek](https://www.zeek.org) logs.  If you are familiar with
+[`zeek-cut`](https://github.com/zeek/zeek-aux/tree/master/zeek-cut),
+you can think of `zq` as `zeek-cut` on steroids.  (If you missed
 [the name change](https://blog.zeek.org/2018/10/renaming-bro-project_11.html),
-zeek was formerly known as "bro".
+Zeek was formerly known as "Bro".)
 
-zq is comprised of
-* an [execution engine](pkg/proc) for log pattern search and analytics,
+`zq` is comprised of
+* an [execution engine](proc) for log pattern search and analytics,
 * a [query language](pkg/zql/README.md) that compiles into a program that runs on
 the execution engine, and
-* an open specification for structured logs called [zson](pkg/zson/docs/spec.md).
+* an open specification for structured logs, called [ZSON](pkg/zson/docs/spec.md).
 
-zq takes zeek/zson logs as input and filters, transforms, and performs
+`zq` takes Zeek/ZSON logs as input and filters, transforms, and performs
 analytics using the
-[zq log query language](pkg/zql/README.md),
+[zq query language](pkg/zql/README.md),
 producing a log stream as its output.
 
 ## Install
 
-We don't yet distribute pre-built binaries, so to install zq, you must
+We don't yet distribute pre-built binaries, so to install `zq`, you must
 clone the repo and compile the source.
 To install the binaries in `$GOPATH/bin`, grab this repo and
-execute a good old-fashioned make install:
+execute a good old-fashioned `make install`:
 
 ```
 git clone https://github.com/mccanne/zq
@@ -32,52 +32,63 @@ make install
 ```
 ## Usage
 
-For zq command usage, see the built-in help by running
+For `zq` command usage, see the built-in help by running
 ```
 zq help
 ```
-zq program syntax and semantics are documented in
-[zq language README](pkg/zql/README.md)
+`zq` program syntax and semantics are documented in the
+[query language README](pkg/zql/README.md)
 
 ### Examples
 
 Here are a few examples.
 
-To cut the columns of a conn log like
-[zeek-cut](https://github.com/zeek/zeek-aux/tree/master/zeek-cut) does, run:
+To cut the columns of a Zeek "conn" log like
+[`zeek-cut`](https://github.com/zeek/zeek-aux/tree/master/zeek-cut) does, run:
 ```
-zq conn.log "* | cut ts,id.orig_h,id.orig_p"
+zq "* | cut ts,id.orig_h,id.orig_p" conn.log
 ```
-The "*" tells zq to match every line, which is sent to the cut processor
-using the unix-like pipe syntax.
+The "`*`" tells `zq` to match every line, which is sent to the `cut` processor
+using the UNIX-like pipe syntax.
 
-The default output is a zson file.  If you want just the tab-separated lines
-like zeek-cut, you can specify text output:
+The default output is a ZSON file.  If you want just the tab-separated lines
+like `zeek-cut`, you can specify text output:
 ```
-zq -f text conn.log "* | cut ts,id.orig_h,id.orig_p"
+zq -f text "* | cut ts,id.orig_h,id.orig_p" conn.log
 ```
-If you want the old-style zeek log format, run the command with the -f flag
-specifying "zeek" for the output format:
+If you want the old-style Zeek [ASCII TSV](https://docs.zeek.org/en/stable/examples/logs/)
+log format, run the command with the `-f` flag specifying `zeek` for the output
+format:
 ```
-zq -f zeek conn.log "* | cut ts,id.orig_h,id.orig_p"
+zq -f zeek "* | cut ts,id.orig_h,id.orig_p" conn.log
 ```
 To summarize data, you can use an aggregate function to summarize data over one or
-more fields, e.g., summing field, counting, or computing an average.
+more fields, e.g., summing field values, counting, or computing an average.
+```
+zq "* | sum(orig_bytes)" conn.log
+zq "orig_bytes > 10000 | count()" conn.log
+zq "* | avg(orig_bytes)" conn.log
+```
 
-TBD: keep going here... explain _path, zq *.log > all.zson
+The [ZSON specification](pkg/zson/docs/spec.md) describes the significance of the
+`_path` field.  By leveraging this, diverse Zeek logs can be combined into a single
+file.
+```
+zq "*" *.log > all.zson
+```
 
 ## Development
 
-Zq is a [Go module](https://github.com/golang/go/wiki/Modules), so
-dependencies are specified in the [go.mod file](/go.mod) and managed
+`zq` is a [Go module](https://github.com/golang/go/wiki/Modules), so
+dependencies are specified in the [`go.mod` file](/go.mod) and managed
 automatically by commands like `go build` and `go test`.  No explicit
 fetch commands are necessary.  However, you must set the environment
 variable `GO111MODULE=on` if your repo is at
 `$GOPATH/src/github.com/mccanne/zq`.
 
-Zq currently requires Go 1.13 or later so make sure your install is up to date.
+`zq` currently requires Go 1.13 or later, so make sure your install is up to date.
 
-When go.mod or its companion go.sum is modified during development, run
+When `go.mod` or its companion `go.sum` are modified during development, run
 `go mod tidy` and then commit the changes to both files.
 
 To use a local checkout of a dependency, use `go mod edit`:
@@ -85,7 +96,7 @@ To use a local checkout of a dependency, use `go mod edit`:
 go mod edit -replace=github.com/org/repo=../repo
 ```
 
-Note that local checkouts must have a go.mod file, so it may be
+Note that local checkouts must have a `go.mod` file, so it may be
 necessary to create a temporary one:
 ```
 echo 'module github.com/org/repo' > ../repo/go.mod
@@ -110,7 +121,7 @@ make test-system
 To use the [Go profiler ](https://golang.org/pkg/net/http/pprof/) to see where CPU
 is being used, see the built-in help for the profiling command *-P*.
 
-This will output a pprof command that you can view as follows:
+This will output a `pprof` command that you can view as follows:
 
 ```
 go tool pprof -http localhost:8081 localhost:9867
@@ -121,18 +132,18 @@ The flame graph is usually pretty helpful.
 
 ## Contributing
 
-zq is developed on github by its community. We welcome contributions.
+`zq` is developed on GitHhub by its community. We welcome contributions.
 
 Feel free to
 [post an issue](https://github.com/mccanne/zq/issues),
 fork the repo, or send us a pull request.
 
-zq is early in its life cycle and will be expanding quickly.  Please star and/or
+`zq` is early in its life cycle and will be expanding quickly.  Please star and/or
 watch the repo so you can follow and track our progress.
 
 In particular, we will be adding many more processors and aggregate functions.
 If you want a fun small project to help out, pick some functionality that is missing and
 add a processor in
-[zq/pkg/proc](pkg/proc)
+[zq/proc](proc)
 or an aggregate function in
-[zq/pkg/reducer](pkg/reducer).
+[zq/reducer](reducer).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ format:
 ```
 zq -f zeek "* | cut ts,id.orig_h,id.orig_p" conn.log
 ```
-To summarize data, you can use an aggregate function to summarize data over one or
+You can use an aggregate function to summarize data over one or
 more fields, e.g., summing field values, counting, or computing an average.
 ```
 zq "* | sum(orig_bytes)" conn.log

--- a/README.md
+++ b/README.md
@@ -116,18 +116,6 @@ And to run system tests, execute
 make test-system
 ```
 
-### Profiling
-
-To use the [Go profiler ](https://golang.org/pkg/net/http/pprof/) to see where CPU
-is being used, see the built-in help for the profiling command *-P*.
-
-This will output a `pprof` command that you can view as follows:
-
-```
-go tool pprof -http localhost:8081 localhost:9867
-open http://localhost:8081/ui/
-```
-
 The flame graph is usually pretty helpful.
 
 ## Contributing


### PR DESCRIPTION
In this PR I've attempted to address some of the doc standards I proposed recently. This includes:

* References to `zq` are in lowercase and fixed-width. This is due to it being a UNIX-style command that will be typed.
* I made references to `zeek-cut` much the same.
* References to "Zeek" are capitalized since that's what they do in the text at [zeek.org](https://www.zeek.org/).
* "ZSON" is capitalized. This is to pattern-match with JSON.
* "ZQL" is used as shorthand for the query language. This is to pattern-match with SQL.

While I was at it, I fixed some links, adding some missing content, and made a few other formatting changes.

I also fixed some of the examples to conform to current working syntax. I know there's been talk of maybe changing how we specify the file inputs, but I figure as long as the repo is open we might as well make sure the examples work. I will also point out that many `-f` output options don't work yet, but I've left those as-is on the assumption those are going to be fixed ASAP.

I've got a lot more examples to contribute in the context of the ZQL README and those all have more verbose queries and outputs, so I've intentionally opted to keep the examples super brief here.