### PR TITLE
Fix default format

### DIFF
--- a/cmd/zq.go
+++ b/cmd/zq.go
@@ -57,7 +57,7 @@ type Command struct {
 func New(f *flag.FlagSet) (charm.Command, error) {
 	cwd, _ := os.Getwd()
 	c := &Command{dt: resolver.NewTable()}
-	f.StringVar(&c.format, "f", "text", "format for output data [text,table,zeek,json,ndjson,raw]")
+	f.StringVar(&c.format, "f", "table", "format for output data [text,table,zeek,json,ndjson,raw]")
 	f.StringVar(&c.path, "p", cwd, "path for input")
 	f.StringVar(&c.dir, "d", "", "directory for output data files")
 	f.StringVar(&c.outputFile, "o", "", "write data to output file")


### PR DESCRIPTION
PR #5 wired up zsio.LookupWriter() to the -f argument but overlooked
the fact that the default value for -f is "text" and we don't have a
text writer.  Fix it for now by making "table" the default.