### PR TITLE
ZSON spec polish

### DIFF
--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -23,7 +23,7 @@ and maintains backward compatibility with the original [Zeek ASCII TSV log forma
 
 ## ZSON format
 
-ZSON is a UTF-8 encoded stream of "lines" where each line is terminated by a
+ZSON is a UTF-8 encoded stream of "lines" where each line is terminated by
 newline.  Each line is either a directive or a value.
 
 Directives and values, in turn, come in two flavors: regular and legacy.

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -1,29 +1,29 @@
-# zson specification
+# ZSON specification
 
-zson is a format for structured data values, ideally suited for streams
+ZSON is a format for structured data values, ideally suited for streams
 of heterogeneously typed records.
-zson is richly typed and thinner than json.
+ZSON is richly typed and thinner than json.
 Like [newline-delimited json (ndjson)](http://ndjson.org/),
-zson represents a sequence of data objects that can be parsed line by line.
+ZSON represents a sequence of data objects that can be parsed line by line.
 
-zson strikes a balance between the narrowly typed but flexible ndjson format and
+ZSON strikes a balance between the narrowly typed but flexible ndjson format and
 a more structured approach like
 [Apache Avro](https://avro.apache.org).
-zson is type rich and
+ZSON is type rich and
 embeds all type/schema in the stream, while having a value syntax
-independent of the schema so it is easy and efficient to parse on the fly
+independent of the schema, making it is easy and efficient to parse on the fly
 and mix and match streams from different sources with heterogeneous types.
 Like Avro,
-zson embeds schema information in the data stream but zson schema bindings
+ZSON embeds schema information in the data stream but ZSON schema bindings
 are lighter-weight and specified with a simple integer encoding that
-accompanies each each data value.
+accompanies each data value.
 
-The zson design [is also motivated by](./rationale.md)
-and maintains backward compatibility with the original zeek log format.
+The ZSON design [is also motivated by](./rationale.md)
+and maintains backward compatibility with the original [Zeek ASCII TSV log format](https://docs.zeek.org/en/stable/examples/logs/).
 
-## zson format
+## ZSON format
 
-zson is a utf-8 encoded stream of "lines" where each line is terminated by
+ZSON is a UTF-8 encoded stream of "lines" where each line is terminated by a
 newline.  Each line is either a directive or a value.
 
 Directives and values, in turn, come in two flavors: regular and legacy.
@@ -33,34 +33,30 @@ Thus, there are four types of lines:
 * legacy directives, and
 * legacy values.
 
-Any line that begins with character '#' is a directive.
-All other lines are values.  If a value line begins with '#', then this
+Any line that begins with character `#` is a directive.
+All other lines are values.  If a value line begins with `#`, then this
 character must be escaped.
 (Such lines can only exist as legacy values and not regular values
 as regular values always begin with an integer descriptor.)
 
-Directives indicate how subsequent values in the zson stream are interpreted.
+Directives indicate how subsequent values in the ZSON stream are interpreted.
 A value is a regular value if the most recent preceding directive in the stream
 is a regular directive; otherwise, it is a legacy value.
 
-Any line beginning with '#' that does not conform with the syntax of a
+Any line beginning with `#` that does not conform with the syntax of a
 directive is an error.
-When errors are encountered parsing zson, an implementation should return a
-corresponding error and allow zson parsing to proceed if desired.
+When errors are encountered parsing ZSON, an implementation should return a
+corresponding error and allow ZSON parsing to proceed if desired.
 
 ## Regular Directives
 
-Regular directives have just three forms:
-* a descriptor,
-* an ordering hint, or
-* a comment.
+Regular directives have just three forms, each with a corresponding structure.
 
-These three directives have the following structure:
-```
-#<int>:<type>
-#sort [+-]<field>,[+-]<field>,...
-#!<comment>
-```
+| Directive     | Example structure                   |
+|---------------|-------------------------------------|
+| Descriptor    | `#<int>:<type>`                     |
+| Ordering hint | `#sort [+-]<field>,[+-]<field>,...` |
+| Comment       | `#!<comment>`                       |
 
 ### Descriptor Directive
 
@@ -69,19 +65,19 @@ a "descriptor" and a type according to the following form:
 ```
 #<descriptor>:<type>
 ```
-There must be a single colon between the ascii integer descriptor
-and the type definition and the integer must be composed of string of
-ascii digits 0-9 with no leading 0 for any non-zero descriptor.
-The syntax for \<type> is described by the [type grammar](#type-grammar).
+There must be a single colon between the ASCII integer descriptor
+and the type definition, and the integer must be composed of a string of
+ASCII digits `0-9` with no leading `0` for any non-zero descriptor.
+The syntax for `<type>` is described by the [type grammar](#type-grammar).
 The same grammar applies to both regular types and legacy types (except for
-an exception regarding "." in field names).
+an exception regarding `.` in field names).
 
-The descriptor directive is the only directive that begins with an ascii decimal
+The descriptor directive is the only directive that begins with an ASCII decimal
 digit.
 
-For example, a directive that is a binding between descriptor 27
+For example, a directive that is a binding between descriptor `27`
 and a record comprised of fields
-"foo" of type string and "bar" of type int is expressed as follows:
+"foo" of type `string` and "bar" of type `int` is expressed as follows:
 ```
 #27:record[foo:string,bar:int]
 ```
@@ -92,11 +88,11 @@ The ordering directive has the following structure:
 ```
 #sort [+-]<field>,[+-]<field>,...
 ```
-where [+-] indicates either "+" or "-" and <field> refers to the top-level
+where `[+-]` indicates either `+` or `-` and `<field>` refers to the top-level
 field name in a record of any subsequent regular or legacy value.
 This directive guarantees that all subsequent value lines will
-appear sorted in the file or stream, in ascending order in the case of "+" and
-descending order in the case of "-", according to the field provided.
+appear sorted in the file or stream, in ascending order in the case of `+` and
+descending order in the case of `-`, according to the field provided.
 If more than one sort
 field is provided, then the values are guaranteed to be sorted by each
 subsequent key for values that have previous keys of equal value.
@@ -112,11 +108,11 @@ The comment directive has the following structure:
 ```
 Comments may be used informatively and shall be
 ignored by any data receivers.
-\<comment-text> can be any utf-8 string exclusive of newline.
- Comments are guaranteed to be preserved
+`<comment-text>` can be any UTF-8 string exclusive of newline.
+Comments are guaranteed to be preserved
 in order within the stream and presented to higher layer components through
-any zson parsing API.  In this way, senders and receivers of zson can embed
-protocol directives as zson comments rather than defining additional
+any ZSON parsing API.  In this way, senders and receivers of ZSON can embed
+protocol directives as ZSON comments rather than defining additional
 encapsulating protocols.  See the
 [zson-over-http](zson-over-http.md) protocol for an example.
 
@@ -125,9 +121,9 @@ as regular values instead of legacy values (as there is no legacy comment direct
 
 ### Type Grammar
 
-The syntax for zson types is a superset of the type syntax produced by zeek logs
-(zeek logs do not produce record or bytes types).
-Here is a pseudo-grammar for zson types:
+The syntax for ZSON types is a superset of the type syntax produced by Zeek logs
+(Zeek logs do not produce record or bytes types).
+Here is a pseudo-grammar for ZSON types:
 ```
 <type> :=  string | bytes | int | count | double | time |
          | interval | port | addr | subnet | enum
@@ -144,7 +140,7 @@ Here is a pseudo-grammar for zson types:
 
 <column> := <id> : <type>
 
-<id> := <identifier as defined by javascript spec>
+<id> := <identifier as defined by JavaScript spec>
 
 <descriptor> := 0 | [1-9][0-9]*
 ```
@@ -153,8 +149,8 @@ A reference implementation of this type system is embedded in
 [zq/pkg/zeek](../../zeek).
 
 Record types consist of an ordered set of columns where each column consists of
-a name and a typed value.  Unlike json, the ordering of the columns is significant
-and must be preserved through any APIs that consume, process, and emit zson records.
+a name and a typed value.  Unlike JSON, the ordering of the columns is significant
+and must be preserved through any APIs that consume, process, and emit ZSON records.
 
 #### Type Examples
 Simple types look like this:
@@ -179,7 +175,7 @@ Types can also refer to previously defined descriptors, e.g.,
 #8:string
 #9:record[s:8]
 ```
-Or more useful, descriptor references can refer to previously
+Or more usefully, descriptor references can refer to previously
 declared record types:
 ```
 #10:record[src:addr,srcport:port,dst:addr,dstport:port]
@@ -188,7 +184,7 @@ declared record types:
 
 ## Regular Values
 
-A regular value is encoded on a line as type descriptor followed by ":" followed
+A regular value is encoded on a line as a type descriptor followed by `:` followed
 by a value encoding.  Here is a pseudo-grammar for value encodings:
 ```
 <line> := <descriptor> : <elem> ;
@@ -201,12 +197,12 @@ by a value encoding.  Here is a pseudo-grammar for value encodings:
         | <list> <elem> ;
 <terminal> := <char>*
 <char> := [^\n\\;[]] | <esc-sequence>
-<esc-sequence> := <javascript character escaping rules>
+<esc-sequence> := <JavaScript character escaping rules>
 ```
-A value is encoded a string of utf-8 characters terminated
+A value is encoded as a string of UTF-8 characters terminated
 by a semicolon (which must be escaped if it appears in the value) where
 composite values are contained in brackets as one or more such
-semi-colon terminated strings.  Any escaped characters shall be processed
+semicolon terminated strings.  Any escaped characters shall be processed
 and interpreted as their escaped value.
 
 Container values are encoded as
@@ -214,11 +210,11 @@ Container values are encoded as
 * zero or more encoded values, and
 * a close bracket.
 
-Any value can be specified as "unset" with the ascii character '-'.
+Any value can be specified as "unset" with the ascii character `-`.
 This is typically used to represent columns of records where not all
-columns have been set in a given record value though any type can be
+columns have been set in a given record value, though any type can be
 validly unset.  A value that is not to be interpreted as "unset"
-but is the single-character string "-", must be escaped (e.g., "\-").
+but is the single-character string `-`, must be escaped (e.g., `\-`).
 
 Note that this syntax can be scanned and parsed independent of the
 actual type definition indicated by the descriptor (unlike legacy values,
@@ -227,32 +223,31 @@ if the parsed value does not match the indicated type in terms of number and
 sub-structure of value elements present and their interpretation as a valid
 string of the specified type.
 
-It is an error for a value to include a descriptor that has not previously
+It is an error for a value to include a descriptor that has not been previously
 defined by a descriptor directive.
 
 ### Character Escape Rules
 
-Any character in a value line may be escaped from the zson formatting rules
-using the javascript rules for escape syntax, i.e.,
-* \ddd for octal escapes,
-* \xdd for hex escapes,
-* \udddd for unicode escapes,
-* and the various single character escapes of javascript.
+Any character in a value line may be escaped from the ZSON formatting rules
+using the JavaScript rules for escape syntax, i.e.,
+* `\ddd` for octal escapes,
+* `\xdd` for hex escapes,
+* `\udddd` for unicode escapes,
+* and the various single character escapes of JavaScript.
 
-Sequences of binary data can be embedded in values using these escapes but its
+Sequences of binary data can be embedded in values using these escapes but it is
 a semantic error for arbitrary binary data to be carried by any types except
-string and bytes (see [Type Semantics](#type-semantics)).
+`string` and `bytes` (see [Type Semantics](#type-semantics)).
 
 These special characters must be escaped if they appear within a value:
 ```
 ; \n \\
 ```
-In addition, "-" must be escaped if the value is not the unset value but
-is a single ascii byte equal to "-".
+In addition, `-` must be escaped if representing the single ASCII byte equal to `-` as opposed to representing an unset value.
 
 ## Examples
 
-Here is a simple example to get the gist of this encoding.  This zson defines
+Here is a simple example to get the gist of this encoding.  This ZSON defines
 two descriptors then uses them in three values:
 ```
 #1:string
@@ -268,7 +263,7 @@ record(a:"hello",b:"world")
 string("this is a semicolon: ;")
 ```
 
-The semicolon terminator is important.  Consider this zson depicting
+The semicolon terminator is important.  Consider this ZSON depicting
 sets of strings:
 ```
 #3:set[string]
@@ -281,7 +276,7 @@ In this example:
 * the first value is a set of one string
 * the second value is a set of two strings "hello" and "world",
 * the third value is an empty set, and
-* the fourth value is a set of one string "".
+* the fourth value is a set of one zero-length string "".
 
 In this way, empty set and set of zero value can be distinguished.
 
@@ -309,7 +304,7 @@ defined above could be defined as follows:
 
 ## Legacy Directives
 
-The legacy directives are backward compatible with the zeek log format:
+The legacy directives are backward compatible with the Zeek log format:
 ```
 #separator<separator><char>
 #set_separator<separator><char>
@@ -321,27 +316,27 @@ The legacy directives are backward compatible with the zeek log format:
 #fields[<separator><string>]+
 #types[<separator><type>]+
 ```
-where \<separator> is intialized to a space character at the beginning of the
-stream, then overridden by the "#separator" directive.
+where `<separator>` is intialized to a space character at the beginning of the
+stream, then overridden by the `#separator` directive.
 
-In the legacy format, the separator character and the set_separator character
+In the legacy format, the `#separator` character and the `#set_separator` character
 define how to parse both a legacy value line and a legacy descriptor.
 
 Every legacy value line corresponds to a record type defined by the
-fields and types directives possibly modified for the #path directive
+fields and types directives possibly modified for the `#path` directive
 as described below.
 
-Record types may not be used in the types directive,
+Record types may not be used in the `#types` directive,
 which means there is no need to recursively parse the set and vector
 container values (set and vector values are split according to
-the set_separator character).
+the `#set_separator` character).
 
 ## Legacy Values
 
 A legacy value exists on any line that is not a directive and whose most
 recent directive was a legacy directive.  The legacy value is parsed by simply
-splitting the line using the separator character, then splitting each container
-value by the set_separator character.
+splitting the line using the `#separator` character, then splitting each container
+value by the `#set_separator` character.
 For example,
 ```
 #separator \t
@@ -358,20 +353,20 @@ record(
 )
 ```
 The special characters that must be escaped if they appear within a value are:
-* newline (\n)
-* backslash (\\)
-* the separator character (usually \t)
-* the set_separator character inside of set and vector values (usually ,)
-* unset_field (usually -) if it appears as a value not be interpreted as "unset",
+* newline (`\n`)
+* backslash (`\`)
+* the `#separator` character (usually `\t`)
+* the `#set_separator` character inside of set and vector values (usually `,`)
+* `#unset_field` (usually `-`) if it appears as a value not be interpreted as "unset",
 
-Similarly, a set with no values must be specified  by the empty_field string (usually "(empty)")
-to distinguish it from a set with a single value "" and this must be escaped if it
-is a single-element set with the value "(empty)", i.e., escaped as "\(empty)".
+Similarly, a set with no values must be specified by the `#empty_field` string (usually `(empty)`)
+to distinguish it from a set with a single value that's a zero-length string (""), and this must be escaped if it
+is a single-element set with the value `(empty)`, i.e., escaped as `\(empty)`.
 
-When processing legacy values, a column of type string named "_path" is
-inserted into value provided a #path directive previously appeared in the
-stream.  The contents of this _path field is set to the string value indicted
-in the #path directive and all the other columns are shifted one space to
+When processing legacy values, a column of type string named `_path` is
+inserted into each value, provided a `#path` directive previously appeared in the
+stream.  The contents of this `_path` field is set to the string value indicated
+in the `#path` directive. It becomes the leftmost column and all the other columns are shifted one space to
 the right.
 
 For example,
@@ -391,14 +386,14 @@ record(
     list: set[int](1, 2, 3)
 )
 ```
-This allows existing zeek log files to be easily
-ingested into zson-aware systems while retaining the zeek log type as the
-"_path" field.
+This allows existing Zeek log files to be easily
+ingested into ZSON-aware systems while retaining the [Zeek log type](https://docs.zeek.org/en/stable/script-reference/log-files.html) as the
+`_path` field.
 
-Note, to maintain backward compatibility where zeek uses ".", in columns that
-came from zeek records, e.g., id.orig_h, such columns shall be converted by
-a legacy parser and converted to zson records.  Likewise, emitters of legacy
-zeek files shall flatten any records in the output by converted each sub-field
+To maintain backward compatibility where Zeek uses `.` in columns that
+came from Zeek records, e.g., `id.orig_h`, such columns shall be converted by
+a legacy parser and converted to ZSON records.  Likewise, emitters of legacy
+Zeek files shall flatten any records in the output by converting each sub-field
 of a record to the corresponding flattened field name using dotted notation.
 e.g.,
 ```
@@ -406,7 +401,7 @@ e.g.,
 #fields id.orig_h,id.orig_p,id.resp_h,id.resp_p,message
 #types addr,port,addr,port,string
 ```
-would be interpreted as the following zson record:
+would be interpreted as the following ZSON record:
 ```
 record[id:record[orig_h:addr,orig_p:port,resp_h:addr,resp_p:port],message:string]
 ```
@@ -419,34 +414,34 @@ The formats for each type is as follows:
 
 Type | Format
 ---- | ------
-bool | a single characeter "t" or "f"
-string | a utf-8 string that may optionally include escape sequences
-bytes | a sequence of raw bytes encoded as base64
-int | decimal string representation of any signed, 64-bit integer
-count | decimal string of any unsigned, 64-bit integer
-double | a decimal representation of a 64-bit IEEE floating point literal as defined in javascript
-time | unsigned dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
-interval | signed dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
-port | an integer string in [0,65535] with an option suffix of "/udp" or "/tcp"
-addr | a string representing a numeric in IPv4 address form or IPv6 form
-subnet | a string in CIDR notation representing an IP address and prefix length as defined in RFC 4632 and RFC 4291.
-enum | a string representing an enum value defined outside the scope of zson
+`bool` | a single characeter `T` or `F`
+`string` | a UTF-8 string that may optionally include escape sequences
+`bytes` | a sequence of raw bytes encoded as base64
+`int` | decimal string representation of any signed, 64-bit integer
+`count` | decimal string of any unsigned, 64-bit integer
+`double` | a decimal representation of a 64-bit IEEE floating point literal as defined in JavaScript
+`time` | unsigned dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
+`interval` | signed dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
+`port` | an integer string in `[0,65535]` with an optional suffix of `/udp` or `/tcp`
+`addr` | a string representing a numeric in IPv4 address form or IPv6 form
+`subnet` | a string in CIDR notation representing an IP address and prefix length as defined in RFC 4632 and RFC 4291.
+`enum` | a string representing an enumeration value defined outside the scope of ZSON
 
-*Note: a string can embed binary data using escapes.  It's up to the receiver to determine
+* Note: A `string` can embed binary data using escapes.  It's up to the receiver to determine
 with out-of-band information whether the data is ultimately arbitrary binary data or
-a valid utf-8 string.
+a valid UTF-8 string.
 
-# Binary zson
+# Binary ZSON
 
 TBD: encode values in a protobuf-like syntax.
 
 ## Related Links
 
-* [zeek logging](https://docs.zeek.org/en/stable/examples/logs/)
-* [binary logging in zeek](https://www.zeek.org/development/projects/binary-logging.html)
-* [hadoop sequence file](https://cwiki.apache.org/confluence/display/HADOOP2/SequenceFile)
-* [avro](https://avro.apache.org)
-* [parquet](https://en.wikipedia.org/wiki/Apache_Parquet)
-* [protobufs](https://www.zeek.org/development/projects/binary-logging.html)
-* [msgpack](https://msgpack.org/index.html)
+* [Zeek ASCII logging](https://docs.zeek.org/en/stable/examples/logs/)
+* [Binary logging in Zeek](https://www.zeek.org/development/projects/binary-logging.html)
+* [Hadoop sequence file](https://cwiki.apache.org/confluence/display/HADOOP2/SequenceFile)
+* [Avro](https://avro.apache.org)
+* [Parquet](https://en.wikipedia.org/wiki/Apache_Parquet)
+* [Protobufs](https://developers.google.com/protocol-buffers)
+* [MessagePack](https://msgpack.org/index.html)
 * [gNMI](https://github.com/openconfig/reference/tree/master/rpc/gnmi)

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -274,7 +274,7 @@ sets of strings:
 ```
 In this example:
 * the first value is a `set` of one `string`
-* the second value is a set of two `string` values, `hello` and `world`,
+* the second value is a `set` of two `string` values, `hello` and `world`,
 * the third value is an empty `set`, and
 * the fourth value is a `set` of one zero-length string.
 

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -140,10 +140,12 @@ Here is a pseudo-grammar for ZSON types:
 
 <column> := <id> : <type>
 
-<id> := <identifier as defined by JavaScript spec>
+<id> := <identifier as defined by JavaScript spec [1]>
 
 <descriptor> := 0 | [1-9][0-9]*
 ```
+
+[1] - [JavaScript identifier specification](https://tc39.es/ecma262/#prod-IdentifierName)
 
 A reference implementation of this type system is embedded in
 [zq/pkg/zeek](../../zeek).
@@ -426,7 +428,7 @@ Type | Format
 `time` | unsigned dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
 `interval` | signed dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
 `port` | an integer string in `[0,65535]` with an optional suffix of `/udp` or `/tcp`
-`addr` | a string representing an IP address in IPv4 or IPv6 form
+`addr` | a string representing an IP address in [IPv4 or IPv6 format](https://tools.ietf.org/html/draft-main-ipaddr-text-rep-02#section-3)
 `subnet` | a string in CIDR notation representing an IP address and prefix length as defined in RFC 4632 and RFC 4291.
 `enum` | a string representing an enumeration value defined outside the scope of ZSON
 

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -19,11 +19,11 @@ are lighter-weight and specified with a simple integer encoding that
 accompanies each data value.
 
 The ZSON design [is also motivated by](./rationale.md)
-and maintains backward compatibility with the original [Zeek ASCII TSV log format](https://docs.zeek.org/en/stable/examples/logs/).
+and maintains backward compatibility with the original [default Zeek log format](https://docs.zeek.org/en/stable/examples/logs/).
 
 ## ZSON format
 
-ZSON is a UTF-8 encoded stream of "lines" where each line is terminated by
+ZSON is a UTF-8 encoded stream of "lines" where each line is terminated by a
 newline.  Each line is either a directive or a value.
 
 Directives and values, in turn, come in two flavors: regular and legacy.
@@ -76,7 +76,7 @@ The descriptor directive is the only directive that begins with an ASCII decimal
 digit.
 
 For example, a directive that is a binding between descriptor `27`
-and a `record` comprised of fields
+and a `record` composed of fields
 "foo" of type `string` and "bar" of type `int` is expressed as follows:
 ```
 #27:record[foo:string,bar:int]
@@ -197,8 +197,11 @@ by a value encoding.  Here is a pseudo-grammar for value encodings:
         | <list> <elem> ;
 <terminal> := <char>*
 <char> := [^\n\\;[]] | <esc-sequence>
-<esc-sequence> := <JavaScript character escaping rules>
+<esc-sequence> := <JavaScript character escaping rules [1]>
 ```
+
+[1] - [JavaScript character escaping rules](https://tc39.es/ecma262/#prod-EscapeSequence)
+
 A value is encoded as a string of UTF-8 characters terminated
 by a semicolon (which must be escaped if it appears in the value) where
 composite values are contained in brackets as one or more such
@@ -233,7 +236,7 @@ using the JavaScript rules for escape syntax, i.e.,
 * `\ddd` for octal escapes,
 * `\xdd` for hex escapes,
 * `\udddd` for unicode escapes,
-* and the various single character escapes of JavaScript.
+* and the various [single character escapes of JavaScript](https://tc39.es/ecma262/#prod-SingleEscapeCharacter).
 
 Sequences of binary data can be embedded in values using these escapes but it is
 a semantic error for arbitrary binary data to be carried by any types except
@@ -276,9 +279,9 @@ In this example:
 * the first value is a `set` of one `string`
 * the second value is a `set` of two `string` values, `hello` and `world`,
 * the third value is an empty `set`, and
-* the fourth value is a `set` of one zero-length string.
+* the fourth value is a `set` containing one `string` of zero length.
 
-In this way, empty set and set of zero-length string can be distinguished.
+In this way, an empty `set` and `set` containing only a zero-length `string` can be distinguished.
 
 This scheme allows composites to be embedded in composites, e.g., a
 `record` inside of a `record` like this:
@@ -360,7 +363,7 @@ The special characters that must be escaped if they appear within a value are:
 * `#unset_field` (usually `-`) if it appears as a value not be interpreted as "unset",
 
 Similarly, a `set` with no values must be specified by the `#empty_field` string (usually `(empty)`)
-to distinguish it from a `set` with a single value that's a zero-length string, and this must be escaped if it
+to distinguish it from a `set` containing only a zero-length `string`, and this must be escaped if it
 is a single-element set with the value `(empty)`, i.e., escaped as `\x28empty)`.
 
 When processing legacy values, a column of type `string` named `_path` is
@@ -423,7 +426,7 @@ Type | Format
 `time` | unsigned dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
 `interval` | signed dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
 `port` | an integer string in `[0,65535]` with an optional suffix of `/udp` or `/tcp`
-`addr` | a string representing an IP address IPv4 or IPv6 form
+`addr` | a string representing an IP address in IPv4 or IPv6 form
 `subnet` | a string in CIDR notation representing an IP address and prefix length as defined in RFC 4632 and RFC 4291.
 `enum` | a string representing an enumeration value defined outside the scope of ZSON
 

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -76,7 +76,7 @@ The descriptor directive is the only directive that begins with an ASCII decimal
 digit.
 
 For example, a directive that is a binding between descriptor `27`
-and a record comprised of fields
+and a `record` comprised of fields
 "foo" of type `string` and "bar" of type `int` is expressed as follows:
 ```
 #27:record[foo:string,bar:int]

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -423,7 +423,7 @@ Type | Format
 `time` | unsigned dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
 `interval` | signed dotted decimal notation of seconds (32-bit second, 32-bit nanosecond)
 `port` | an integer string in `[0,65535]` with an optional suffix of `/udp` or `/tcp`
-`addr` | a string representing a numeric in IPv4 address form or IPv6 form
+`addr` | a string representing an IP address IPv4 or IPv6 form
 `subnet` | a string in CIDR notation representing an IP address and prefix length as defined in RFC 4632 and RFC 4291.
 `enum` | a string representing an enumeration value defined outside the scope of ZSON
 

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -392,7 +392,7 @@ ingested into ZSON-aware systems while retaining the [Zeek log type](https://doc
 
 To maintain backward compatibility where Zeek uses `.` in columns that
 came from Zeek records, e.g., `id.orig_h`, such columns shall be converted by
-a legacy parser and converted to ZSON records.  Likewise, emitters of legacy
+a legacy parser into ZSON records.  Likewise, emitters of legacy
 Zeek files shall flatten any records in the output by converting each sub-field
 of a record to the corresponding flattened field name using dotted notation.
 e.g.,

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -2,16 +2,16 @@
 
 ZSON is a format for structured data values, ideally suited for streams
 of heterogeneously typed records.
-ZSON is richly typed and thinner than json.
-Like [newline-delimited json (ndjson)](http://ndjson.org/),
+ZSON is richly typed and thinner than JSON.
+Like [newline-delimited JSON (NDJSON)](http://ndjson.org/),
 ZSON represents a sequence of data objects that can be parsed line by line.
 
-ZSON strikes a balance between the narrowly typed but flexible ndjson format and
+ZSON strikes a balance between the narrowly typed but flexible NDJSON format and
 a more structured approach like
 [Apache Avro](https://avro.apache.org).
 ZSON is type rich and
 embeds all type/schema in the stream, while having a value syntax
-independent of the schema, making it is easy and efficient to parse on the fly
+independent of the schema, making it easy and efficient to parse on the fly
 and mix and match streams from different sources with heterogeneous types.
 Like Avro,
 ZSON embeds schema information in the data stream but ZSON schema bindings
@@ -122,7 +122,7 @@ as regular values instead of legacy values (as there is no legacy comment direct
 ### Type Grammar
 
 The syntax for ZSON types is a superset of the type syntax produced by Zeek logs
-(Zeek logs do not produce record or bytes types).
+(Zeek logs do not produce `record` or `bytes` types).
 Here is a pseudo-grammar for ZSON types:
 ```
 <type> :=  string | bytes | int | count | double | time |
@@ -176,7 +176,7 @@ Types can also refer to previously defined descriptors, e.g.,
 #9:record[s:8]
 ```
 Or more usefully, descriptor references can refer to previously
-declared record types:
+declared `record` types:
 ```
 #10:record[src:addr,srcport:port,dst:addr,dstport:port]
 #11:record[list:set[10],info:string]
@@ -273,29 +273,29 @@ sets of strings:
 3:[;];
 ```
 In this example:
-* the first value is a set of one string
-* the second value is a set of two strings "hello" and "world",
-* the third value is an empty set, and
-* the fourth value is a set of one zero-length string "".
+* the first value is a `set` of one `string`
+* the second value is a set of two `string` values, `hello` and `world`,
+* the third value is an empty `set`, and
+* the fourth value is a `set` of one zero-length string.
 
-In this way, empty set and set of zero value can be distinguished.
+In this way, empty set and set of zero-length string can be distinguished.
 
 This scheme allows composites to be embedded in composites, e.g., a
-record inside of a record like this:
+`record` inside of a `record` like this:
 ```
 #4:record[compass:string,degree:double]
 #5:record[city:string,lat:4,long:4]
 5:[NYC;[NE;40.7128];[W;74.0060;];];
 ```
-An unset value indicates a field of a record that wasn't set by the encoder:
+An unset value indicates a field of a `record` that wasn't set by the encoder:
 ```
 5:[North Pole;[N;90];-;];
 ```
 e.g., the North Pole has a latitude but no meaningful longitude.
 
-A record type can use shorthand notation as defined by
+A `record` type can use shorthand notation as defined by
 the [type grammar](#type-grammer), where reference can be made
-to a previously defined record via its descriptor.  e.g., the record
+to a previously defined `record` via its descriptor.  e.g., the `record`
 defined above could be defined as follows:
 ```
 #4:record[a:string,b:double,c:string]
@@ -322,13 +322,13 @@ stream, then overridden by the `#separator` directive.
 In the legacy format, the `#separator` character and the `#set_separator` character
 define how to parse both a legacy value line and a legacy descriptor.
 
-Every legacy value line corresponds to a record type defined by the
+Every legacy value line corresponds to a `record` type defined by the
 fields and types directives possibly modified for the `#path` directive
 as described below.
 
 Record types may not be used in the `#types` directive,
-which means there is no need to recursively parse the set and vector
-container values (set and vector values are split according to
+which means there is no need to recursively parse the `set` and `vector`
+container values (`set` and `vector` values are split according to
 the `#set_separator` character).
 
 ## Legacy Values
@@ -359,14 +359,14 @@ The special characters that must be escaped if they appear within a value are:
 * the `#set_separator` character inside of set and vector values (usually `,`)
 * `#unset_field` (usually `-`) if it appears as a value not be interpreted as "unset",
 
-Similarly, a set with no values must be specified by the `#empty_field` string (usually `(empty)`)
-to distinguish it from a set with a single value that's a zero-length string (""), and this must be escaped if it
-is a single-element set with the value `(empty)`, i.e., escaped as `\(empty)`.
+Similarly, a `set` with no values must be specified by the `#empty_field` string (usually `(empty)`)
+to distinguish it from a `set` with a single value that's a zero-length string, and this must be escaped if it
+is a single-element set with the value `(empty)`, i.e., escaped as `\x28empty)`.
 
-When processing legacy values, a column of type string named `_path` is
+When processing legacy values, a column of type `string` named `_path` is
 inserted into each value, provided a `#path` directive previously appeared in the
 stream.  The contents of this `_path` field is set to the string value indicated
-in the `#path` directive. It becomes the leftmost column and all the other columns are shifted one space to
+in the `#path` directive. It becomes the leftmost column in the value and all the other columns are shifted one space to
 the right.
 
 For example,
@@ -401,7 +401,7 @@ e.g.,
 #fields id.orig_h,id.orig_p,id.resp_h,id.resp_p,message
 #types addr,port,addr,port,string
 ```
-would be interpreted as the following ZSON record:
+would be interpreted as the following ZSON `record`:
 ```
 record[id:record[orig_h:addr,orig_p:port,resp_h:addr,resp_p:port],message:string]
 ```

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -196,7 +196,7 @@ by a value encoding.  Here is a pseudo-grammar for value encodings:
           <elem> ;
         | <list> <elem> ;
 <terminal> := <char>*
-<char> := [^\n\\;[]] | <esc-sequence>
+<char> := [^][;\n\\] | <esc-sequence>
 <esc-sequence> := <JavaScript character escaping rules [1]>
 ```
 


### PR DESCRIPTION
This is my attempt to apply similar formatting/style changes like I did in https://github.com/mccanne/zq/pull/4 (fixed width, capitalized acronyms, etc.) while trying to clarify some things along the way. I've also pointed out places where I think we could use some clarification but I don't feel like I can make the call solo on where we should land.

One thing I'll point out is that I've made liberal use of `fixed width` for many places where text was formerly "in quotes". I felt this made things stand out better. This includes in places where we make reference to data types (`string`, `bytes`, etc.) such as to differentiate between the type itself and the data it stores, e.g. if one were to write a sentence like "you can store string data in a `string` type". Of course, there's other ways of emphasis that we haven't used much (italics, bold) so if there's consensus around using one of those instead, I'm open to suggestion (though personally I like fixed width).

I know there's still open debate about if "ZQL" should be capitalized or lowercase. I've stuck with the capitalization I'd started out with due to https://github.com/mccanne/zq/pull/4, but I'm ready to search & replace if opinion swings the other direction.