### PR TITLE
fix TS_ISO8601, TS_MILLIS handling in NewRawAndTsFromJSON

### DIFF
--- a/pkg/nano/time.go
+++ b/pkg/nano/time.go
@@ -159,6 +159,23 @@ func Parse(s []byte) (Ts, error) {
 	return Ts(v * scale), nil
 }
 
+// ParseMillis parses an unsigned integer representing milliseconds since the
+// Unix epoch.
+func ParseMillis(s []byte) (Ts, error) {
+	if len(s) == 0 {
+		return 0, fmt.Errorf("invalid time format: %s", string(s))
+	}
+	var v int64
+	for _, c := range s {
+		d := c - '0'
+		if d > 9 {
+			return 0, fmt.Errorf("invalid time format: %s", string(s))
+		}
+		v = v*10 + int64(d)
+	}
+	return Ts(v * 1_000_000), nil
+}
+
 // ParseRFC3339Nano parses a byte according to the time.RFC3339Nano
 // format into a Ts, returning an error if parsing failed.
 func ParseRFC3339Nano(s []byte) (Ts, error) {

--- a/pkg/nano/time_test.go
+++ b/pkg/nano/time_test.go
@@ -1,0 +1,30 @@
+package nano
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseMillis(t *testing.T) {
+	successCases := []struct {
+		input      string
+		expectedTs Ts
+	}{
+		{"0", 0},
+		{"00", 0},
+		{"2", 2 * 1_000_000},
+		{"03", 3 * 1_000_000},
+		{"1234567890", 1234567890 * 1_000_000},
+	}
+	for _, c := range successCases {
+		ts, err := ParseMillis([]byte(c.input))
+		assert.NoError(t, err, "input: %q", c.input)
+		assert.Exactly(t, c.expectedTs, ts, "input: %q", c.input)
+	}
+
+	for _, input := range []string{"", " ", "+1", "-1", "a", "1.2"} {
+		_, err := ParseMillis([]byte(input))
+		assert.Error(t, err, "input: %q", input)
+	}
+}

--- a/pkg/zson/raw_test.go
+++ b/pkg/zson/raw_test.go
@@ -1,0 +1,36 @@
+package zson
+
+import (
+	"testing"
+
+	"github.com/mccanne/zq/pkg/nano"
+	"github.com/mccanne/zq/pkg/zeek"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRawAndTsFromJSON(t *testing.T) {
+	typ, err := zeek.LookupType("record[b:bool,i:int,s:set[bool],ts:time,v:vector[int]]")
+	require.NoError(t, err)
+	d := NewDescriptor(typ.(*zeek.TypeRecord))
+	tsCol, ok := d.ColumnOfField("ts")
+	require.True(t, ok)
+
+	const expectedTs = nano.Ts(1573860644637486000)
+	cases := []struct {
+		input      string
+		expectedTs nano.Ts
+	}{
+		{`{"ts":"2019-11-15T23:30:44.637486Z"}`, expectedTs},  // JSON::TS_ISO8601
+		{`{"ts":1573860644.637486}`, expectedTs},              // JSON::TS_EPOCH
+		{`{"ts":1573860644637}`, expectedTs.Trunc(1_000_000)}, // JSON::TS_MILLIS
+	}
+	for _, c := range cases {
+		raw, ts, _, err := NewRawAndTsFromJSON(d, tsCol, []byte(c.input))
+		assert.NoError(t, err, "input: %s", c.input)
+		assert.Exactly(t, c.expectedTs, ts, "input: %s", c.input)
+		actualZeekValue := NewRecord(d, ts, raw).ValueByColumn(tsCol)
+		require.NotNil(t, actualZeekValue, "input: %s", c.input)
+		assert.Exactly(t, c.expectedTs, actualZeekValue.(*zeek.Time).Native, "input: %s", c.input)
+	}
+}


### PR DESCRIPTION
zson.NewRawAndTsFromJSON does not convert Zeek JSON::TS_ISO8601
timestamps to the standard Zeek format, and it does not handle
JSON:TS_MILLIS timestamps correctly.  Fix both issues.