### PR TITLE
zval.sizeBytes incorrect

### DIFF
--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -71,7 +71,7 @@ func AppendValue(dst []byte, val []byte) []byte {
 // the zval in val.
 func sizeBytes(val []byte) int {
 	// This really is correct even when data is nil.
-	return sizeUvarint((1+uint64(len(val)))<<1) + len(val)
+	return sizeUvarint((uint64(len(val)))<<1) + len(val)
 }
 
 // AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead

--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -70,7 +70,7 @@ func AppendValue(dst []byte, val []byte) []byte {
 // sizeBytes returns the number of bytes required by AppendValue to represent
 // the zval in val.
 func sizeBytes(val []byte) int {
-	// This really is correct even when data is nil.
+	// This really is correct even when val is nil.
 	return sizeUvarint(newTag(false, len(val)) + len(val)
 }
 

--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -71,7 +71,7 @@ func AppendValue(dst []byte, val []byte) []byte {
 // the zval in val.
 func sizeBytes(val []byte) int {
 	// This really is correct even when data is nil.
-	return sizeUvarint(1+uint64(len(val))) + len(val)
+	return sizeUvarint((1+uint64(len(val)))<<1) + len(val)
 }
 
 // AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead

--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -71,7 +71,7 @@ func AppendValue(dst []byte, val []byte) []byte {
 // the zval in val.
 func sizeBytes(val []byte) int {
 	// This really is correct even when val is nil.
-	return sizeUvarint(newTag(false, len(val)) + len(val)
+	return sizeUvarint(newTag(false, len(val))) + len(val)
 }
 
 // AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead

--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -71,7 +71,7 @@ func AppendValue(dst []byte, val []byte) []byte {
 // the zval in val.
 func sizeBytes(val []byte) int {
 	// This really is correct even when data is nil.
-	return sizeUvarint((uint64(len(val)))<<1) + len(val)
+	return sizeUvarint(newTag(false, len(val)) + len(val)
 }
 
 // AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead

--- a/pkg/zval/zval_test.go
+++ b/pkg/zval/zval_test.go
@@ -17,6 +17,7 @@ var appendCases = [][][]byte{
 	{[]byte("\x00\x01\x02")},
 	{[]byte("UTF-8 \b5Ὂg̀9!℃ᾭG€�")},
 	{[]byte("data"), nil, []byte("\x1a\x2b\x3c"), []byte("UTF-8 \b5Ὂg̀9!℃ᾭG€�")},
+	{[]byte("thisisareallylongstringdoyoulikereallylongstrings?Ithoughtyoumightlikethemsoiaddedthistothetest")},
 }
 
 func TestAppendContainer(t *testing.T) {


### PR DESCRIPTION
zval.sizeBytes wasn't taking into account bit shifting involved for
the container bit. As a result some values would report a Uvarint size
of 1 byte when with the container bit the size was actually
2 bytes.