### PR TITLE
simplify naming of proc types

### DIFF
--- a/proc/cut.go
+++ b/proc/cut.go
@@ -6,21 +6,21 @@ import (
 	"github.com/mccanne/zq/pkg/zson"
 )
 
-type CutProc struct {
+type Cut struct {
 	Base
 	fields     []string
 	sawRecord  bool
 	seenFields uint64
 }
 
-func NewCutProc(c *Context, parent Proc, fields []string) *CutProc {
-	return &CutProc{Base: Base{Context: c, Parent: parent}, fields: fields}
+func NewCut(c *Context, parent Proc, fields []string) *Cut {
+	return &Cut{Base: Base{Context: c, Parent: parent}, fields: fields}
 }
 
 // Check the bitmap of fields that we've seen.  If a requested field
 // never appeared in the input, emit a warning about it.  This should be
 // called once when this proc reaches the end of the stream.
-func (c *CutProc) WarnUnseen() {
+func (c *Cut) WarnUnseen() {
 	if !c.sawRecord {
 		return
 	}
@@ -31,7 +31,7 @@ func (c *CutProc) WarnUnseen() {
 	}
 }
 
-func (c *CutProc) Pull() (zson.Batch, error) {
+func (c *Cut) Pull() (zson.Batch, error) {
 	batch, err := c.Get()
 	if EOS(batch, err) {
 		c.WarnUnseen()

--- a/proc/filter.go
+++ b/proc/filter.go
@@ -5,16 +5,16 @@ import (
 	"github.com/mccanne/zq/pkg/zson"
 )
 
-type FilterProc struct {
+type Filter struct {
 	Base
 	filter.Filter
 }
 
-func NewFilterProc(c *Context, parent Proc, f filter.Filter) *FilterProc {
-	return &FilterProc{Base{Context: c, Parent: parent}, f}
+func NewFilter(c *Context, parent Proc, f filter.Filter) *Filter {
+	return &Filter{Base{Context: c, Parent: parent}, f}
 }
 
-func (f *FilterProc) Pull() (zson.Batch, error) {
+func (f *Filter) Pull() (zson.Batch, error) {
 	batch, err := f.Get()
 	if EOS(batch, err) {
 		return nil, err

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -28,8 +28,8 @@ func IsErrTooBig(err error) bool {
 
 const defaultGroupByLimit = 1000000
 
-// GroupByProc computes aggregations using a GroupByAggregator.
-type GroupByProc struct {
+// GroupBy computes aggregations using a GroupByAggregator.
+type GroupBy struct {
 	Base
 	timeBinned bool
 	interval   time.Duration
@@ -90,13 +90,13 @@ func NewGroupByAggregator(c *Context, params *ast.GroupByProc) *GroupByAggregato
 	}
 }
 
-func NewGroupByProc(c *Context, parent Proc, params *ast.GroupByProc) *GroupByProc {
+func NewGroupBy(c *Context, parent Proc, params *ast.GroupByProc) *GroupBy {
 	// XXX in a subsequent PR we will isolate ast params and pass in
 	// ast.GroupByParams
 	agg := NewGroupByAggregator(c, params)
 	timeBinned := params.Duration.Seconds > 0
 	interval := time.Duration(params.UpdateInterval.Seconds) * time.Second
-	return &GroupByProc{
+	return &GroupBy{
 		Base:       Base{Context: c, Parent: parent},
 		timeBinned: timeBinned,
 		interval:   interval,
@@ -104,7 +104,7 @@ func NewGroupByProc(c *Context, parent Proc, params *ast.GroupByProc) *GroupByPr
 	}
 }
 
-func (g *GroupByProc) Pull() (zson.Batch, error) {
+func (g *GroupBy) Pull() (zson.Batch, error) {
 	start := time.Now()
 	for {
 		batch, err := g.Get()

--- a/proc/head.go
+++ b/proc/head.go
@@ -5,16 +5,16 @@ import (
 	"github.com/mccanne/zq/pkg/zson"
 )
 
-type HeadProc struct {
+type Head struct {
 	Base
 	limit, count int
 }
 
-func NewHeadProc(c *Context, parent Proc, limit int) *HeadProc {
-	return &HeadProc{Base{Context: c, Parent: parent}, limit, 0}
+func NewHead(c *Context, parent Proc, limit int) *Head {
+	return &Head{Base{Context: c, Parent: parent}, limit, 0}
 }
 
-func (h *HeadProc) Pull() (zson.Batch, error) {
+func (h *Head) Pull() (zson.Batch, error) {
 	remaining := h.limit - h.count
 	if remaining <= 0 {
 		return nil, nil

--- a/proc/mux.go
+++ b/proc/mux.go
@@ -15,22 +15,22 @@ type MuxResult struct {
 type MuxOutput struct {
 	ctx      *Context
 	runners  int
-	muxProcs []*MuxProc
+	muxProcs []*Mux
 	once     sync.Once
 	in       chan MuxResult
 }
 
-type MuxProc struct {
+type Mux struct {
 	Base
 	ID  int
 	out chan<- MuxResult
 }
 
-func newMuxProc(c *Context, parent Proc, id int, out chan MuxResult) *MuxProc {
-	return &MuxProc{Base: Base{Context: c, Parent: parent}, ID: id, out: out}
+func newMux(c *Context, parent Proc, id int, out chan MuxResult) *Mux {
+	return &Mux{Base: Base{Context: c, Parent: parent}, ID: id, out: out}
 }
 
-func (m *MuxProc) run() {
+func (m *Mux) run() {
 	// This loop pulls batches from the parent and pushes them
 	// downstream to the multiplexing proc.  If the mux isn't ready,
 	// the out channel will block and this  goroutine will block until
@@ -52,7 +52,7 @@ func NewMuxOutput(ctx *Context, parents []Proc) *MuxOutput {
 	c := make(chan MuxResult, n)
 	mux := &MuxOutput{ctx: ctx, runners: n, in: c}
 	for id, parent := range parents {
-		mux.muxProcs = append(mux.muxProcs, newMuxProc(ctx, parent, id, c))
+		mux.muxProcs = append(mux.muxProcs, newMux(ctx, parent, id, c))
 	}
 	return mux
 }

--- a/proc/pass.go
+++ b/proc/pass.go
@@ -2,14 +2,14 @@ package proc
 
 import "github.com/mccanne/zq/pkg/zson"
 
-type PassProc struct {
+type Pass struct {
 	Base
 }
 
-func NewPassProc(c *Context, parent Proc) *PassProc {
-	return &PassProc{Base{Context: c, Parent: parent}}
+func NewPass(c *Context, parent Proc) *Pass {
+	return &Pass{Base{Context: c, Parent: parent}}
 }
 
-func (p *PassProc) Pull() (zson.Batch, error) {
+func (p *Pass) Pull() (zson.Batch, error) {
 	return p.Get()
 }

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -106,43 +106,43 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 	}
 	switch v := node.(type) {
 	case *ast.ReducerProc:
-		return []Proc{NewReducerProc(c, parent, v)}, nil
+		return []Proc{NewReducer(c, parent, v)}, nil
 
 	case *ast.GroupByProc:
-		return []Proc{NewGroupByProc(c, parent, v)}, nil
+		return []Proc{NewGroupBy(c, parent, v)}, nil
 
 	case *ast.CutProc:
-		return []Proc{NewCutProc(c, parent, v.Fields)}, nil
+		return []Proc{NewCut(c, parent, v.Fields)}, nil
 
 	case *ast.SortProc:
-		return []Proc{NewSortProc(c, parent, v.Limit, v.Fields, v.SortDir)}, nil
+		return []Proc{NewSort(c, parent, v.Limit, v.Fields, v.SortDir)}, nil
 
 	case *ast.HeadProc:
 		limit := v.Count
 		if limit == 0 {
 			limit = 1
 		}
-		return []Proc{NewHeadProc(c, parent, limit)}, nil
+		return []Proc{NewHead(c, parent, limit)}, nil
 
 	case *ast.TailProc:
 		limit := v.Count
 		if limit == 0 {
 			limit = 1
 		}
-		return []Proc{NewTailProc(c, parent, limit)}, nil
+		return []Proc{NewTail(c, parent, limit)}, nil
 
 	case *ast.UniqProc:
-		return []Proc{NewUniqProc(c, parent, v.Cflag)}, nil
+		return []Proc{NewUniq(c, parent, v.Cflag)}, nil
 
 	case *ast.PassProc:
-		return []Proc{NewPassProc(c, parent)}, nil
+		return []Proc{NewPass(c, parent)}, nil
 
 	case *ast.FilterProc:
 		f, err := filter.Compile(v.Filter)
 		if err != nil {
 			return nil, err
 		}
-		return []Proc{NewFilterProc(c, parent, f)}, nil
+		return []Proc{NewFilter(c, parent, f)}, nil
 
 	case *ast.SequentialProc:
 		var parents []Proc
@@ -157,7 +157,7 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 			// in which case the output layer will mux
 			// into channels.
 			if len(parents) > 1 && k < n-1 {
-				parent = NewMergeProc(c, parents)
+				parent = NewMerge(c, parents)
 			} else {
 				parent = parents[0]
 			}
@@ -165,7 +165,7 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 		return parents, nil
 
 	case *ast.ParallelProc:
-		splitter := NewSplitProc(c, parent)
+		splitter := NewSplit(c, parent)
 		n := len(v.Procs)
 		var procs []Proc
 		for k := 0; k < n; k++ {

--- a/proc/reducer.go
+++ b/proc/reducer.go
@@ -9,28 +9,28 @@ import (
 	"github.com/mccanne/zq/reducer/compile"
 )
 
-type ReducerProc struct {
+type Reducer struct {
 	Base
 	n        int
 	interval time.Duration
 	columns  compile.Row
 }
 
-func NewReducerProc(c *Context, parent Proc, params *ast.ReducerProc) Proc {
+func NewReducer(c *Context, parent Proc, params *ast.ReducerProc) Proc {
 	interval := time.Duration(params.UpdateInterval.Seconds) * time.Second
-	return &ReducerProc{
+	return &Reducer{
 		Base:     Base{Context: c, Parent: parent},
 		interval: interval,
 		columns:  compile.Row{Defs: params.Reducers},
 	}
 }
 
-func (r *ReducerProc) output() *zson.Array {
+func (r *Reducer) output() *zson.Array {
 	rec := r.columns.Result(r.Context.Resolver)
 	return zson.NewArray([]*zson.Record{rec}, nano.NewSpanTs(r.MinTs, r.MaxTs))
 }
 
-func (r *ReducerProc) Pull() (zson.Batch, error) {
+func (r *Reducer) Pull() (zson.Batch, error) {
 	start := time.Now()
 	for {
 		batch, err := r.Get()
@@ -55,7 +55,7 @@ func (r *ReducerProc) Pull() (zson.Batch, error) {
 	}
 }
 
-func (r *ReducerProc) consume(rec *zson.Record) {
+func (r *Reducer) consume(rec *zson.Record) {
 	r.n++
 	r.columns.Consume(rec)
 }

--- a/proc/sort.go
+++ b/proc/sort.go
@@ -8,8 +8,7 @@ import (
 	"github.com/mccanne/zq/pkg/zson"
 )
 
-// SortProc xxx
-type SortProc struct {
+type Sort struct {
 	Base
 	dir    int
 	limit  int
@@ -22,11 +21,11 @@ type SortProc struct {
 // The value can be overridden by setting the limit param on the SortProc.
 const defaultSortLimit = 1000000
 
-func NewSortProc(c *Context, parent Proc, limit int, fields []string, dir int) *SortProc {
+func NewSort(c *Context, parent Proc, limit int, fields []string, dir int) *Sort {
 	if limit == 0 {
 		limit = defaultSortLimit
 	}
-	return &SortProc{Base: Base{Context: c, Parent: parent}, dir: dir, limit: limit, fields: fields}
+	return &Sort{Base: Base{Context: c, Parent: parent}, dir: dir, limit: limit, fields: fields}
 }
 
 func firstOf(d *zson.Descriptor, which zeek.Type) string {
@@ -64,7 +63,7 @@ func guessSortField(rec *zson.Record) string {
 	return "ts"
 }
 
-func (s *SortProc) Pull() (zson.Batch, error) {
+func (s *Sort) Pull() (zson.Batch, error) {
 	for {
 		batch, err := s.Get()
 		if err != nil {
@@ -82,14 +81,14 @@ func (s *SortProc) Pull() (zson.Batch, error) {
 	}
 }
 
-func (s *SortProc) consume(batch zson.Batch) {
+func (s *Sort) consume(batch zson.Batch) {
 	//XXX this could be made more efficient
 	for k := 0; k < batch.Length(); k++ {
 		s.out = append(s.out, batch.Index(k).Keep())
 	}
 }
 
-func (s *SortProc) sort() zson.Batch {
+func (s *Sort) sort() zson.Batch {
 	out := s.out
 	if len(out) == 0 {
 		return nil

--- a/proc/sort_test.go
+++ b/proc/sort_test.go
@@ -21,7 +21,7 @@ func TestSort(t *testing.T) {
 
 	ctx := proc.NewTestContext(nil)
 	src := proc.NewTestSource([]zson.Batch{fooBatch})
-	sort := proc.NewSortProc(ctx, src, 10000, []string{"foo"}, 1)
+	sort := proc.NewSort(ctx, src, 10000, []string{"foo"}, 1)
 	test := proc.NewProcTest(sort, ctx)
 
 	res, err := test.Pull()

--- a/proc/tail.go
+++ b/proc/tail.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mccanne/zq/pkg/zson"
 )
 
-type TailProc struct {
+type Tail struct {
 	Base
 	limit int
 	count int
@@ -13,12 +13,12 @@ type TailProc struct {
 	q     []*zson.Record
 }
 
-func NewTailProc(c *Context, parent Proc, limit int) *TailProc {
+func NewTail(c *Context, parent Proc, limit int) *Tail {
 	q := make([]*zson.Record, limit)
-	return &TailProc{Base{Context: c, Parent: parent}, limit, 0, 0, q}
+	return &Tail{Base{Context: c, Parent: parent}, limit, 0, 0, q}
 }
 
-func (t *TailProc) tail() zson.Batch {
+func (t *Tail) tail() zson.Batch {
 	if t.count <= 0 {
 		return nil
 	}
@@ -32,7 +32,7 @@ func (t *TailProc) tail() zson.Batch {
 
 }
 
-func (t *TailProc) Pull() (zson.Batch, error) {
+func (t *Tail) Pull() (zson.Batch, error) {
 	for {
 		batch, err := t.Get()
 		if EOS(batch, err) {

--- a/proc/top.go
+++ b/proc/top.go
@@ -9,12 +9,12 @@ import (
 
 const defaultTopLimit = 100
 
-// TopProc is similar to proc.SortProc with a view key differences:
+// Top is similar to proc.Sort with a view key differences:
 // - It only sorts in descending order.
 // - It utilizes a MaxHeap, immediately discarding records that are not in
 // the top N of the sort.
 // - It has a hidden option (FlushEvery) to sort and emit on every batch.
-type TopProc struct {
+type Top struct {
 	Base
 	limit      int
 	fields     []string
@@ -24,11 +24,11 @@ type TopProc struct {
 	out        []*zson.Record
 }
 
-func NewTopProc(c *Context, parent Proc, limit int, fields []string, flushEvery bool) *TopProc {
+func NewTop(c *Context, parent Proc, limit int, fields []string, flushEvery bool) *Top {
 	if limit == 0 {
 		limit = defaultTopLimit
 	}
-	return &TopProc{
+	return &Top{
 		Base:       Base{Context: c, Parent: parent},
 		limit:      limit,
 		fields:     fields,
@@ -36,7 +36,7 @@ func NewTopProc(c *Context, parent Proc, limit int, fields []string, flushEvery 
 	}
 }
 
-func (s *TopProc) Pull() (zson.Batch, error) {
+func (s *Top) Pull() (zson.Batch, error) {
 	for {
 		batch, err := s.Get()
 		if err != nil {
@@ -55,7 +55,7 @@ func (s *TopProc) Pull() (zson.Batch, error) {
 	}
 }
 
-func (s *TopProc) consume(rec *zson.Record) {
+func (s *Top) consume(rec *zson.Record) {
 	if s.fields == nil {
 		s.fields = []string{guessSortField(rec)}
 	}
@@ -73,7 +73,7 @@ func (s *TopProc) consume(rec *zson.Record) {
 	}
 }
 
-func (s *TopProc) sorted() zson.Batch {
+func (s *Top) sorted() zson.Batch {
 	if s.records == nil {
 		return nil
 	}

--- a/proc/top_test.go
+++ b/proc/top_test.go
@@ -24,7 +24,7 @@ func TestTop(t *testing.T) {
 
 	ctx := proc.NewTestContext(nil)
 	src := proc.NewTestSource([]zson.Batch{fooBatch})
-	top := proc.NewTopProc(ctx, src, 3, []string{"foo"}, false)
+	top := proc.NewTop(ctx, src, 3, []string{"foo"}, false)
 	test := proc.NewProcTest(top, ctx)
 
 	res, err := test.Pull()

--- a/proc/uniq.go
+++ b/proc/uniq.go
@@ -10,18 +10,18 @@ import (
 	"go.uber.org/zap"
 )
 
-type UniqProc struct {
+type Uniq struct {
 	Base
 	cflag bool
 	count int
 	last  *zson.Record
 }
 
-func NewUniqProc(c *Context, parent Proc, cflag bool) *UniqProc {
-	return &UniqProc{Base: Base{Context: c, Parent: parent}, cflag: cflag}
+func NewUniq(c *Context, parent Proc, cflag bool) *Uniq {
+	return &Uniq{Base: Base{Context: c, Parent: parent}, cflag: cflag}
 }
 
-func (u *UniqProc) wrap(t *zson.Record) *zson.Record {
+func (u *Uniq) wrap(t *zson.Record) *zson.Record {
 	if u.cflag {
 		cols := []zeek.Column{{Name: "_uniq", Type: zeek.TypeCount}}
 		vals := []string{strconv.FormatInt(int64(u.count), 10)}
@@ -35,7 +35,7 @@ func (u *UniqProc) wrap(t *zson.Record) *zson.Record {
 	return t
 }
 
-func (u *UniqProc) appendUniq(out []*zson.Record, t *zson.Record) []*zson.Record {
+func (u *Uniq) appendUniq(out []*zson.Record, t *zson.Record) []*zson.Record {
 	if u.count == 0 {
 		u.last = t.Keep()
 		u.count = 1
@@ -52,7 +52,7 @@ func (u *UniqProc) appendUniq(out []*zson.Record, t *zson.Record) []*zson.Record
 
 // uniq is a little bit complicated because we have to check uniqueness
 // across records between calls to Pull.
-func (u *UniqProc) Pull() (zson.Batch, error) {
+func (u *Uniq) Pull() (zson.Batch, error) {
 	batch, err := u.Get()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Instead of proc.FooProc, the new convention is proc.Foo