### PR TITLE
add buffered writing for all writers

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mccanne/charm"
 	"github.com/mccanne/zq/ast"
 	"github.com/mccanne/zq/emitter"
+	"github.com/mccanne/zq/pkg/bufwriter"
 	"github.com/mccanne/zq/pkg/zsio"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zson/resolver"
@@ -238,7 +239,7 @@ func (c *Command) openOutput() (zson.WriteCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	writer := zsio.LookupWriter(c.format, file)
+	writer := zsio.LookupWriter(c.format, bufwriter.New(file))
 	if writer == nil {
 		return nil, fmt.Errorf("invalid format: %s", c.format)
 	}

--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mccanne/zq/pkg/bufwriter"
 	"github.com/mccanne/zq/pkg/zsio/zeek"
 	"github.com/mccanne/zq/pkg/zson"
 )
@@ -95,7 +96,7 @@ func (d *Dir) filename(path string) string {
 	return filepath.Join(d.dir, filename)
 }
 
-func (d *Dir) newFile(rec *zson.Record) (*os.File, string, error) {
+func (p *Dir) newFile(rec *zson.Record) (io.WriteCloser, string, error) {
 	// get path name from descriptor.  the td at column 0
 	// has already been stripped out.
 	i, ok := rec.Descriptor.ColumnOfField("_path")
@@ -115,7 +116,7 @@ func (d *Dir) newFile(rec *zson.Record) (*os.File, string, error) {
 		}
 		return nil, filename, err
 	}
-	return file, filename, nil
+	return bufwriter.New(file), filename, nil
 }
 
 func (d *Dir) Close() error {

--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -96,7 +96,7 @@ func (d *Dir) filename(path string) string {
 	return filepath.Join(d.dir, filename)
 }
 
-func (p *Dir) newFile(rec *zson.Record) (io.WriteCloser, string, error) {
+func (d *Dir) newFile(rec *zson.Record) (io.WriteCloser, string, error) {
 	// get path name from descriptor.  the td at column 0
 	// has already been stripped out.
 	i, ok := rec.Descriptor.ColumnOfField("_path")

--- a/pkg/bufwriter/writer.go
+++ b/pkg/bufwriter/writer.go
@@ -1,4 +1,4 @@
-// Package bufwriter provides a wrapper for io.WriteCloser that uses
+// Package bufwriter provides a wrapper for a io.WriteCloser that uses
 // buffered output via a bufio.Writer and calls Flush on close.
 // Not clear why bufio.Writer doesn't do this.
 package bufwriter
@@ -9,20 +9,20 @@ import (
 )
 
 type Writer struct {
-	io.WriteCloser
-	writer *bufio.Writer
+	closer io.Closer
+	*bufio.Writer
 }
 
-func New(w io.WriteCloser) io.WriteCloser {
+func New(w io.WriteCloser) *Writer {
 	return &Writer{
-		WriteCloser: w,
-		writer:      bufio.NewWriter(w),
+		closer: w,
+		Writer: bufio.NewWriter(w),
 	}
 }
 
 func (w *Writer) Close() error {
-	if err := w.writer.Flush(); err != nil {
+	if err := w.Writer.Flush(); err != nil {
 		return err
 	}
-	return w.WriteCloser.Close()
+	return w.closer.Close()
 }

--- a/pkg/bufwriter/writer.go
+++ b/pkg/bufwriter/writer.go
@@ -1,0 +1,28 @@
+// Package bufwriter provides a wrapper for io.WriteCloser that uses
+// buffered output via a bufio.Writer and calls Flush on close.
+// Not clear why bufio.Writer doesn't do this.
+package bufwriter
+
+import (
+	"bufio"
+	"io"
+)
+
+type Writer struct {
+	io.WriteCloser
+	writer *bufio.Writer
+}
+
+func New(w io.WriteCloser) io.WriteCloser {
+	return &Writer{
+		WriteCloser: w,
+		writer:      bufio.NewWriter(w),
+	}
+}
+
+func (w *Writer) Close() error {
+	if err := w.writer.Flush(); err != nil {
+		return err
+	}
+	return w.WriteCloser.Close()
+}


### PR DESCRIPTION
These changes introduce a wrapper package to transform a
bufio.Writer into an io.WriteCloser by calling flush on
close and arranges for all file output to be wrapped with
in this way.  Otherwise, every write on each file object
would result in a system call resulting in poor perfomance.