### PR TITLE
fix bugs parsing nested containers

### DIFF
--- a/pkg/zeek/escape.go
+++ b/pkg/zeek/escape.go
@@ -23,26 +23,32 @@ func Escape(data []byte) string {
 	return string(buf)
 }
 
+func ParseEscape(data []byte) (byte, int) {
+	if len(data) >= 4 && data[1] == 'x' {
+		v1 := unhex(data[2])
+		v2 := unhex(data[3])
+		if v1 <= 0xf || v2 <= 0xf {
+			return v1<<4 | v2, 4
+		}
+	}
+	return data[1], 2
+}
+
 // Unescape is the inverse of Escape.
 func Unescape(data []byte) []byte {
 	if bytes.IndexByte(data, '\\') < 0 {
 		return data
 	}
 	var buf []byte
-	for i := 0; i < len(data); i++ {
+	i := 0
+	for i < len(data) {
 		c := data[i]
-		if c == '\\' {
-			switch {
-			case i+1 < len(data) && data[i+1] == '\\':
-				i++
-			case i+3 < len(data) && data[i+1] == 'x':
-				v1 := unhex(data[i+2])
-				v2 := unhex(data[i+3])
-				if v1 <= 0xf || v2 <= 0xf {
-					c = v1<<4 | v2
-					i += 3
-				}
-			}
+		if c == '\\' && len(data[i:]) >= 2 {
+			var n int
+			c, n = ParseEscape(data[i:])
+			i += n
+		} else {
+			i++
 		}
 		buf = append(buf, c)
 	}

--- a/pkg/zeek/escape.go
+++ b/pkg/zeek/escape.go
@@ -23,17 +23,6 @@ func Escape(data []byte) string {
 	return string(buf)
 }
 
-func ParseEscape(data []byte) (byte, int) {
-	if len(data) >= 4 && data[1] == 'x' {
-		v1 := unhex(data[2])
-		v2 := unhex(data[3])
-		if v1 <= 0xf || v2 <= 0xf {
-			return v1<<4 | v2, 4
-		}
-	}
-	return data[1], 2
-}
-
 // Unescape is the inverse of Escape.
 func Unescape(data []byte) []byte {
 	if bytes.IndexByte(data, '\\') < 0 {
@@ -53,6 +42,17 @@ func Unescape(data []byte) []byte {
 		buf = append(buf, c)
 	}
 	return buf
+}
+
+func ParseEscape(data []byte) (byte, int) {
+	if len(data) >= 4 && data[1] == 'x' {
+		v1 := unhex(data[2])
+		v2 := unhex(data[3])
+		if v1 <= 0xf || v2 <= 0xf {
+			return v1<<4 | v2, 4
+		}
+	}
+	return data[1], 2
 }
 
 func unhex(b byte) byte {

--- a/pkg/zsio/reader.go
+++ b/pkg/zsio/reader.go
@@ -50,6 +50,7 @@ type Reader struct {
 	stats     ReadStats
 	mapper    *resolver.Mapper
 	legacyVal bool
+	parser    *zson.Parser
 }
 
 func NewReader(reader io.Reader, r *resolver.Table) *Reader {
@@ -58,6 +59,7 @@ func NewReader(reader io.Reader, r *resolver.Table) *Reader {
 		scanner: skim.NewScanner(reader, buffer, MaxLineSize),
 		zeek:    zeek.NewParser(r),
 		mapper:  resolver.NewMapper(r),
+		parser:  zson.NewParser(),
 	}
 }
 
@@ -204,7 +206,7 @@ func (r *Reader) parseValue(line []byte) (*zson.Record, error) {
 		return nil, ErrInvalidDesc
 	}
 
-	raw, err := zson.NewRawFromZSON(descriptor, rest)
+	raw, err := r.parser.Parse(descriptor, rest)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zsio/writer.go
+++ b/pkg/zsio/writer.go
@@ -90,7 +90,14 @@ func (w *Writer) writeValue(val []byte) error {
 }
 
 func (w *Writer) escape(c byte) error {
-	return w.write(fmt.Sprintf("\\x%02x", c))
+	const hex = "0123456789abcdef"
+	var b [4]byte
+	b[0] = '\\'
+	b[1] = 'x'
+	b[2] = hex[c>>4]
+	b[3] = hex[c&0xf]
+	_, err := w.writer.Write(b[:])
+	return err
 }
 
 func (w *Writer) writeEscaped(val []byte) error {

--- a/pkg/zsio/writer.go
+++ b/pkg/zsio/writer.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zval"
@@ -84,19 +83,54 @@ func (w *Writer) writeValue(val []byte) error {
 	if val == nil {
 		return w.write("-;")
 	}
-	if err := w.write(zsonEscape(string(val))); err != nil {
+	if err := w.writeEscaped(val); err != nil {
 		return err
 	}
 	return w.write(";")
 }
 
-func zsonEscape(s string) string {
-	if s == "-" {
-		return "\\-"
-	}
+func (w *Writer) escape(c byte) error {
+	return w.write(fmt.Sprintf("\\x%02x", c))
+}
 
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, ";", "\\;")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	return s
+func (w *Writer) writeEscaped(val []byte) error {
+	if len(val) == 0 {
+		return nil
+	}
+	if len(val) == 1 && val[0] == '-' {
+		return w.escape('-')
+	}
+	// We escape a bracket if it appears as the first byte of a value;
+	// we otherwise don't need to escape brackets.
+	if val[0] == '[' {
+		if err := w.escape('['); err != nil {
+			return err
+		}
+		val = val[1:]
+	}
+	off := 0
+	for off < len(val) {
+		c := val[off]
+		switch c {
+		case '\\', ';', '\n':
+			if off > 0 {
+				_, err := w.writer.Write(val[:off])
+				if err != nil {
+					return err
+				}
+			}
+			if err := w.escape(c); err != nil {
+				return err
+			}
+			val = val[off+1:]
+			off = 0
+		default:
+			off++
+		}
+	}
+	var err error
+	if len(val) > 0 {
+		_, err = w.writer.Write(val)
+	}
+	return err
 }

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -43,12 +43,40 @@ const zson3 = `
 #0:record[foo:set[string]]
 0:[[-;];];`
 
+// string \x2d is "-"
 const zson4 = `
 #0:record[foo:string]
 0:[\x2d;];`
+
+// string \x5b is "[", second string is "[-]" and should pass through
+const zson5 = `
+#0:record[foo:string,bar:string]
+0:[\x5b;\x5b-];];`
+
+func repeat(c byte, n int) string {
+	b := make([]byte, n)
+	for k := 0; k < n; k++ {
+		b[k] = c
+	}
+	return string(b)
+}
+
+// generate some really big strings
+func zsonBig() string {
+	s := "#0:record[f0:string,f1:string,f2:string,f3:string]\n"
+	s += "0:["
+	s += repeat('a', 4) + ";"
+	s += repeat('b', 400) + ";"
+	s += repeat('c', 30000) + ";"
+	s += repeat('d', 2) + ";];\n"
+	return s
+}
 
 func TestZson(t *testing.T) {
 	identity(t, zson1)
 	identity(t, zson2)
 	identity(t, zson3)
+	identity(t, zson4)
+	identity(t, zson5)
+	identity(t, zsonBig())
 }

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -1,0 +1,50 @@
+package zsio
+
+//  This is really a system test dressed up as a unit test.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/mccanne/zq/pkg/zson"
+	"github.com/mccanne/zq/pkg/zson/resolver"
+	"github.com/stretchr/testify/assert"
+)
+
+type Output struct {
+	bytes.Buffer
+}
+
+func (o *Output) Close() error {
+	return nil
+}
+
+func identity(t *testing.T, logs string) {
+	var out Output
+	dst := NewWriter(&out)
+	in := []byte(strings.TrimSpace(logs) + "\n")
+	src := NewReader(bytes.NewReader(in), resolver.NewTable())
+	err := zson.Copy(dst, src)
+	if assert.NoError(t, err) {
+		assert.Equal(t, in, out.Bytes())
+	}
+}
+
+const zson1 = `
+#0:record[foo:set[string]]
+0:[["test";];];`
+
+const zson2 = `
+#0:record[foo:record[bar:string]]
+0:[[test;];];`
+
+const zson3 = `
+#0:record[foo:set[string]]
+0:[[-;];];`
+
+func TestZson(t *testing.T) {
+	identity(t, zson1)
+	identity(t, zson2)
+	identity(t, zson3)
+}

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -43,6 +43,10 @@ const zson3 = `
 #0:record[foo:set[string]]
 0:[[-;];];`
 
+const zson4 = `
+#0:record[foo:string]
+0:[\x2d;];`
+
 func TestZson(t *testing.T) {
 	identity(t, zson1)
 	identity(t, zson2)

--- a/pkg/zson/raw.go
+++ b/pkg/zson/raw.go
@@ -171,9 +171,7 @@ func (p *Parser) Parse(desc *Descriptor, zson []byte) (Raw, error) {
 		}
 		zson = rest
 	}
-	zv := builder.Encode()
-	//fmt.Println("ENCODE", Raw(zv).String())
-	return zv, nil
+	return builder.Encode(), nil
 }
 
 const (

--- a/pkg/zson/raw.go
+++ b/pkg/zson/raw.go
@@ -137,26 +137,41 @@ func NewRawAndTsFromZeekValues(d *Descriptor, tsCol int, vals [][]byte) (Raw, na
 	return raw, ts, nil
 }
 
-var ErrUnterminated = errors.New("zson parse error: unterminated container")
+var (
+	ErrUnterminated = errors.New("zson syntax error: unterminated container")
+	ErrSyntax       = errors.New("zson syntax error")
+)
 
-func NewRawFromZSON(desc *Descriptor, zson []byte) (Raw, error) {
+type Parser struct {
+	builder *zval.Builder
+}
+
+func NewParser() *Parser {
+	return &Parser{
+		builder: zval.NewBuilder(),
+	}
+}
+
+func (p *Parser) Parse(desc *Descriptor, zson []byte) (Raw, error) {
 	// XXX no validation on types from the descriptor, though we'll
 	// want to add that to support eg the bytes type.
 	// if we did this, we could also get at the ts field without
 	// making a separate pass in the parser.
-	vals, rest, err := zsonParseContainer(zson)
-	if err != nil {
-		return nil, err
+	builder := p.builder
+	builder.Reset()
+	n := len(zson)
+	if len(zson) < 3 || zson[0] != '[' || zson[n-1] != ';' || zson[n-2] != ']' {
+		return nil, ErrSyntax
 	}
-	if len(rest) != 1 || rest[0] != ';' {
-		return nil, ErrUnterminated
+	zson = zson[1 : n-2]
+	for len(zson) > 0 {
+		rest, err := zsonParseField(builder, zson)
+		if err != nil {
+			return nil, err
+		}
+		zson = rest
 	}
-
-	var raw Raw
-	for _, v := range vals {
-		raw = zval.AppendValue(raw, v)
-	}
-	return raw, nil
+	return builder.Encode(), nil
 }
 
 const (
@@ -171,51 +186,60 @@ const (
 // If there is no error, the first two return values are:
 //  1. an array of zvals corresponding to the indivdiual elements
 //  2. the passed-in byte array advanced past all the data that was parsed.
-func zsonParseContainer(b []byte) ([][]byte, []byte, error) {
+func zsonParseContainer(builder *zval.Builder, b []byte) ([]byte, error) {
+	builder.Begin()
 	// skip leftbracket
 	b = b[1:]
-
-	// XXX if we have the Type we can size this properly
-	vals := make([][]byte, 0)
 	for {
 		if len(b) == 0 {
-			return nil, nil, ErrUnterminated
+			return nil, ErrUnterminated
 		}
 		if b[0] == rightbracket {
-			return vals, b[1:], nil
+			builder.End()
+			if len(b) < 2 || b[1] != ';' {
+				return nil, ErrUnterminated
+			}
+			return b[2:], nil
 		}
-		field, rest, err := zsonParseField(b)
+		rest, err := zsonParseField(builder, b)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		vals = append(vals, field)
 		b = rest
 	}
 }
 
 // zsonParseField() parses the given bye array representing any value
 // in the zson format.
-func zsonParseField(b []byte) ([]byte, []byte, error) {
+func zsonParseField(builder *zval.Builder, b []byte) ([]byte, error) {
 	if b[0] == leftbracket {
-		vals, rest, err := zsonParseContainer(b)
-		if err != nil {
-			return nil, nil, err
-		}
-		return zval.AppendContainer(nil, vals), rest, nil
+		return zsonParseContainer(builder, b)
 	}
-	i := 0
+	to := 0
+	from := 0
 	for {
-		if i >= len(b) {
-			return nil, nil, ErrUnterminated
+		if from >= len(b) {
+			return nil, ErrUnterminated
 		}
-		switch b[i] {
+		switch b[from] {
 		case semicolon:
-			return b[:i], b[i+1:], nil
+			if to == 1 && b[0] == '-' {
+				builder.Append(nil)
+				return b[2:], nil
+			}
+			builder.Append(b[:to])
+			return b[from+1:], nil
 		case backslash:
-			// XXX need to implement full escape parsing,
-			// for now just skip one character
-			i += 1
+			e, n := zeek.ParseEscape(b[from:])
+			if n == 0 {
+				panic("zeek.ParseEscape returned 0")
+			}
+			b[to] = e
+			from += n
+		default:
+			b[to] = b[from]
+			from++
 		}
-		i += 1
+		to++
 	}
 }

--- a/pkg/zval/builder.go
+++ b/pkg/zval/builder.go
@@ -1,0 +1,127 @@
+package zval
+
+const (
+	beginContainer = -1
+	endContainer   = -2
+)
+
+type node struct {
+	innerLen int
+	outerLen int
+	dfs      int
+}
+
+// Builder implements an API for holding an intermediate representation
+// of a hierarchical set of values arranged in a tree, e.g., structured
+// values that can contain nested and recursive aggregate values.
+// We encode a DFS traversal in a flat data structure that can be
+// reused across invocations so we don't otherwise allocate a tree
+// data structure for every record parsed that would then be GC'd.
+type Builder struct {
+	nodes  []node
+	leaves [][]byte
+}
+
+func NewBuilder() *Builder {
+	return &Builder{
+		nodes:  make([]node, 0, 64),
+		leaves: make([][]byte, 0, 64),
+	}
+}
+
+func (b *Builder) Reset() {
+	b.nodes = b.nodes[:0]
+	b.leaves = b.leaves[:0]
+}
+
+func (b *Builder) Begin() {
+	b.nodes = append(b.nodes, node{dfs: beginContainer})
+}
+
+func (b *Builder) End() {
+	b.nodes = append(b.nodes, node{dfs: endContainer})
+}
+
+func (b *Builder) Append(leaf []byte) {
+	k := len(b.leaves)
+	b.leaves = append(b.leaves, leaf)
+	b.nodes = append(b.nodes, node{dfs: k})
+}
+
+func (b *Builder) measure(off int) int {
+	node := &b.nodes[off]
+	dfs := node.dfs
+	if dfs == beginContainer {
+		// skip over start token
+		off++
+		for off < len(b.nodes) {
+			next := b.measure(off)
+			if next < 0 {
+				// skip over end token
+				off++
+				break
+			}
+			node.innerLen += b.nodes[off].outerLen
+			off = next
+		}
+		node.outerLen = sizeOfContainer(node.innerLen)
+		return off
+	}
+	if dfs == endContainer {
+		return -1
+	}
+	n := len(b.leaves[dfs])
+	node.innerLen = n
+	node.outerLen = sizeOfValue(n)
+	return off + 1
+}
+
+func (b *Builder) encode(dst []byte, off int) ([]byte, int) {
+	node := &b.nodes[off]
+	dfs := node.dfs
+	if dfs == beginContainer {
+		// skip over start token
+		off++
+		if b.nodes[off].dfs == endContainer {
+			return AppendUvarint(dst, containerTagUnset), off + 1
+		}
+		dst = AppendUvarint(dst, containerTag(node.innerLen))
+		for off < len(b.nodes) {
+			var next int
+			dst, next = b.encode(dst, off)
+			if next < 0 {
+				// skip over end token
+				off++
+				break
+			}
+			off = next
+		}
+		return dst, off
+	}
+	if dfs == endContainer {
+		return dst, -1
+	}
+	return AppendValue(dst, b.leaves[dfs]), off + 1
+}
+
+func (b *Builder) Encode() []byte {
+	off := 0
+	for off < len(b.nodes) {
+		next := b.measure(off)
+		if next < 0 {
+			break
+		}
+		off = next
+	}
+	off = 0
+	var zv []byte
+	for off < len(b.nodes) {
+		var next int
+		zv, next = b.encode(zv, off)
+		if next < 0 {
+			break
+		}
+		off = next
+	}
+	return zv
+}

--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -15,6 +15,132 @@ import (
 	"fmt"
 )
 
+const (
+	beginContainer = -1
+	endContainer   = -2
+)
+
+type node struct {
+	innerLen int
+	outerLen int
+	dfs      int
+}
+
+// Builder implements an API for holding an intermediate representation
+// of a hierarchical set of values arranged in a tree, e.g., structured
+// values that can contain nested and recursive aggregate values.
+// We encode a DFS traversal in a flat data structure that can be
+// reused across invocations so we don't otherwise allocate a tree
+// data structure for every record parsed that would then be GC'd.
+type Builder struct {
+	nodes  []node
+	leaves [][]byte
+}
+
+func NewBuilder() *Builder {
+	return &Builder{
+		nodes:  make([]node, 0, 64),
+		leaves: make([][]byte, 0, 64),
+	}
+}
+
+func (b *Builder) Reset() {
+	b.nodes = b.nodes[:0]
+	b.leaves = b.leaves[:0]
+}
+
+func (b *Builder) Begin() {
+	b.nodes = append(b.nodes, node{dfs: beginContainer})
+}
+
+func (b *Builder) End() {
+	b.nodes = append(b.nodes, node{dfs: endContainer})
+}
+
+func (b *Builder) Append(leaf []byte) {
+	k := len(b.leaves)
+	b.leaves = append(b.leaves, leaf)
+	b.nodes = append(b.nodes, node{dfs: k})
+}
+
+func (b *Builder) measure(off int) int {
+	node := &b.nodes[off]
+	dfs := node.dfs
+	if dfs == beginContainer {
+		// skip over start token
+		off++
+		for off < len(b.nodes) {
+			next := b.measure(off)
+			if next < 0 {
+				// skip over end token
+				off++
+				break
+			}
+			node.innerLen += b.nodes[off].outerLen
+			off = next
+		}
+		node.outerLen = sizeOfContainer(node.innerLen)
+		return off
+	}
+	if dfs == endContainer {
+		return -1
+	}
+	n := len(b.leaves[dfs])
+	node.innerLen = n
+	node.outerLen = sizeOfValue(n)
+	return off + 1
+}
+
+func (b *Builder) encode(dst []byte, off int) ([]byte, int) {
+	node := &b.nodes[off]
+	dfs := node.dfs
+	if dfs == beginContainer {
+		// skip over start token
+		off++
+		if b.nodes[off].dfs == endContainer {
+			return AppendUvarint(dst, containerTagUnset), off + 1
+		}
+		dst = AppendUvarint(dst, containerTag(node.innerLen))
+		for off < len(b.nodes) {
+			var next int
+			dst, next = b.encode(dst, off)
+			if next < 0 {
+				// skip over end token
+				off++
+				break
+			}
+			off = next
+		}
+		return dst, off
+	}
+	if dfs == endContainer {
+		return dst, -1
+	}
+	return AppendValue(dst, b.leaves[dfs]), off + 1
+}
+
+func (b *Builder) Encode() []byte {
+	off := 0
+	for off < len(b.nodes) {
+		next := b.measure(off)
+		if next < 0 {
+			break
+		}
+		off = next
+	}
+	off = 0
+	var zv []byte
+	for off < len(b.nodes) {
+		var next int
+		zv, next = b.encode(zv, off)
+		if next < 0 {
+			break
+		}
+		off = next
+	}
+	return zv
+}
+
 // Iter iterates over a sequence of zvals.
 type Iter []byte
 
@@ -45,13 +171,13 @@ func (i *Iter) Next() ([]byte, bool, error) {
 // AppendContainer appends to dst a zval container comprising the zvals in vals.
 func AppendContainer(dst []byte, vals [][]byte) []byte {
 	if vals == nil {
-		return AppendUvarint(dst, newTagUnset(true))
+		return AppendUvarint(dst, containerTagUnset)
 	}
 	var n int
 	for _, v := range vals {
 		n += sizeBytes(v)
 	}
-	dst = AppendUvarint(dst, newTag(true, n))
+	dst = AppendUvarint(dst, containerTag(n))
 	for _, v := range vals {
 		dst = AppendValue(dst, v)
 	}
@@ -61,9 +187,9 @@ func AppendContainer(dst []byte, vals [][]byte) []byte {
 // AppendValue appends to dst the zval in val.
 func AppendValue(dst []byte, val []byte) []byte {
 	if val == nil {
-		return AppendUvarint(dst, newTagUnset(false))
+		return AppendUvarint(dst, valueTagUnset)
 	}
-	dst = AppendUvarint(dst, newTag(false, len(val)))
+	dst = AppendUvarint(dst, valueTag(len(val)))
 	return append(dst, val...)
 }
 
@@ -71,7 +197,7 @@ func AppendValue(dst []byte, val []byte) []byte {
 // the zval in val.
 func sizeBytes(val []byte) int {
 	// This really is correct even when val is nil.
-	return sizeUvarint(newTag(false, len(val))) + len(val)
+	return sizeUvarint(valueTag(len(val))) + len(val)
 }
 
 // AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead
@@ -84,32 +210,43 @@ func AppendUvarint(dst []byte, u64 uint64) []byte {
 	return append(dst, byte(u64))
 }
 
+// sizeUvarint returns the number of bytes required by AppendUvarint to
+// represent u64.
+func sizeUvarint(u64 uint64) int {
+	n := 1
+	for u64 >= 0x80 {
+		n++
+		u64 >>= 7
+	}
+	return n
+}
+
 // Uvarint just calls binary.Uvarint.  It's here for symmetry with
 // AppendUvarint.
 func Uvarint(buf []byte) (uint64, int) {
 	return binary.Uvarint(buf)
 }
 
-// sizeUvarint returns the number of bytes required by AppendUvarint to
-// represent u64.
-func sizeUvarint(u64 uint64) int {
-	return len(AppendUvarint(make([]byte, 0, binary.MaxVarintLen64), u64))
+func sizeOfContainer(length int) int {
+	return (sizeUvarint(containerTag(length))) + length
 }
 
-func newTag(container bool, length int) uint64 {
-	t := (uint64(length) + 1) << 1
-	if container {
-		t |= 1
-	}
-	return t
+func sizeOfValue(length int) int {
+	return int(sizeUvarint(valueTag(length))) + length
 }
 
-func newTagUnset(container bool) uint64 {
-	if container {
-		return 1
-	}
-	return 0
+func containerTag(length int) uint64 {
+	return (uint64(length)+1)<<1 | 1
 }
+
+func valueTag(length int) uint64 {
+	return (uint64(length) + 1) << 1
+}
+
+const (
+	valueTagUnset     = 0
+	containerTagUnset = 1
+)
 
 func tagIsContainer(t uint64) bool {
 	return t&1 == 1

--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -49,11 +49,6 @@ func AppendContainer(dst []byte, vals [][]byte) []byte {
 	}
 	var n int
 	for _, v := range vals {
-		//XXX this doesn't look like it could work right because we
-		// need to know whether the sub-zval is a container or a value,
-		// but in practice, the lengths are always the same because the
-		// variable length encoding of the size is not affected by the
-		// low bit of the tag encoding.
 		n += sizeOfValue(len(v))
 	}
 	dst = AppendUvarint(dst, containerTag(n))

--- a/pkg/zval/zval.go
+++ b/pkg/zval/zval.go
@@ -15,132 +15,6 @@ import (
 	"fmt"
 )
 
-const (
-	beginContainer = -1
-	endContainer   = -2
-)
-
-type node struct {
-	innerLen int
-	outerLen int
-	dfs      int
-}
-
-// Builder implements an API for holding an intermediate representation
-// of a hierarchical set of values arranged in a tree, e.g., structured
-// values that can contain nested and recursive aggregate values.
-// We encode a DFS traversal in a flat data structure that can be
-// reused across invocations so we don't otherwise allocate a tree
-// data structure for every record parsed that would then be GC'd.
-type Builder struct {
-	nodes  []node
-	leaves [][]byte
-}
-
-func NewBuilder() *Builder {
-	return &Builder{
-		nodes:  make([]node, 0, 64),
-		leaves: make([][]byte, 0, 64),
-	}
-}
-
-func (b *Builder) Reset() {
-	b.nodes = b.nodes[:0]
-	b.leaves = b.leaves[:0]
-}
-
-func (b *Builder) Begin() {
-	b.nodes = append(b.nodes, node{dfs: beginContainer})
-}
-
-func (b *Builder) End() {
-	b.nodes = append(b.nodes, node{dfs: endContainer})
-}
-
-func (b *Builder) Append(leaf []byte) {
-	k := len(b.leaves)
-	b.leaves = append(b.leaves, leaf)
-	b.nodes = append(b.nodes, node{dfs: k})
-}
-
-func (b *Builder) measure(off int) int {
-	node := &b.nodes[off]
-	dfs := node.dfs
-	if dfs == beginContainer {
-		// skip over start token
-		off++
-		for off < len(b.nodes) {
-			next := b.measure(off)
-			if next < 0 {
-				// skip over end token
-				off++
-				break
-			}
-			node.innerLen += b.nodes[off].outerLen
-			off = next
-		}
-		node.outerLen = sizeOfContainer(node.innerLen)
-		return off
-	}
-	if dfs == endContainer {
-		return -1
-	}
-	n := len(b.leaves[dfs])
-	node.innerLen = n
-	node.outerLen = sizeOfValue(n)
-	return off + 1
-}
-
-func (b *Builder) encode(dst []byte, off int) ([]byte, int) {
-	node := &b.nodes[off]
-	dfs := node.dfs
-	if dfs == beginContainer {
-		// skip over start token
-		off++
-		if b.nodes[off].dfs == endContainer {
-			return AppendUvarint(dst, containerTagUnset), off + 1
-		}
-		dst = AppendUvarint(dst, containerTag(node.innerLen))
-		for off < len(b.nodes) {
-			var next int
-			dst, next = b.encode(dst, off)
-			if next < 0 {
-				// skip over end token
-				off++
-				break
-			}
-			off = next
-		}
-		return dst, off
-	}
-	if dfs == endContainer {
-		return dst, -1
-	}
-	return AppendValue(dst, b.leaves[dfs]), off + 1
-}
-
-func (b *Builder) Encode() []byte {
-	off := 0
-	for off < len(b.nodes) {
-		next := b.measure(off)
-		if next < 0 {
-			break
-		}
-		off = next
-	}
-	off = 0
-	var zv []byte
-	for off < len(b.nodes) {
-		var next int
-		zv, next = b.encode(zv, off)
-		if next < 0 {
-			break
-		}
-		off = next
-	}
-	return zv
-}
-
 // Iter iterates over a sequence of zvals.
 type Iter []byte
 
@@ -175,7 +49,7 @@ func AppendContainer(dst []byte, vals [][]byte) []byte {
 	}
 	var n int
 	for _, v := range vals {
-		n += sizeBytes(v)
+		n += sizeOfByteSlice(v)
 	}
 	dst = AppendUvarint(dst, containerTag(n))
 	for _, v := range vals {
@@ -193,11 +67,11 @@ func AppendValue(dst []byte, val []byte) []byte {
 	return append(dst, val...)
 }
 
-// sizeBytes returns the number of bytes required by AppendValue to represent
+// sizeOfByteSlice returns the number of bytes required by AppendValue to represent
 // the zval in val.
-func sizeBytes(val []byte) int {
+func sizeOfByteSlice(val []byte) int {
 	// This really is correct even when val is nil.
-	return sizeUvarint(valueTag(len(val))) + len(val)
+	return sizeOfUvarint(valueTag(len(val))) + len(val)
 }
 
 // AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead
@@ -210,9 +84,9 @@ func AppendUvarint(dst []byte, u64 uint64) []byte {
 	return append(dst, byte(u64))
 }
 
-// sizeUvarint returns the number of bytes required by AppendUvarint to
+// sizeOfUvarint returns the number of bytes required by AppendUvarint to
 // represent u64.
-func sizeUvarint(u64 uint64) int {
+func sizeOfUvarint(u64 uint64) int {
 	n := 1
 	for u64 >= 0x80 {
 		n++
@@ -228,11 +102,11 @@ func Uvarint(buf []byte) (uint64, int) {
 }
 
 func sizeOfContainer(length int) int {
-	return (sizeUvarint(containerTag(length))) + length
+	return (sizeOfUvarint(containerTag(length))) + length
 }
 
 func sizeOfValue(length int) int {
-	return int(sizeUvarint(valueTag(length))) + length
+	return int(sizeOfUvarint(valueTag(length))) + length
 }
 
 func containerTag(length int) uint64 {


### PR DESCRIPTION
These changes fix bugs in the way recursive containers were
handled.  The zval code was designed to handle legacy zeek logs
that had at most one level of containers inside the top-level
record. 

To handle recursive containers, we refactored things into two passes where
the first pass unescapes the input values into an intermediary data structure
(which is allocated once per stream and reused across records),
and the second pass, computes the sizes of everything and
encodes the raw zval.

These changes also add the TBD code for unescaping escaped characters
in zson input. There is also now a check for a single "-" for a value
field, which now correctly turns into an unset column.

Finally, we are changing the zson spec to follow the zeek escaping
logic and refectored the zeek unescaping logic so it could be used
by the zson parser.