### PR TITLE
replace zson.Raw with zval.Encoding

### DIFF
--- a/pkg/zsio/json/parser.go
+++ b/pkg/zsio/json/parser.go
@@ -8,14 +8,13 @@ import (
 
 	"github.com/buger/jsonparser"
 	"github.com/mccanne/zq/pkg/zeek"
-	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zval"
 )
 
 // NewRawAndType returns a new zson.Raw slice as well as an inferred zeek.Type
 // from provided block of JSON. The function expects the input json to be an
 // object, otherwise an error is returned.
-func NewRawAndType(b []byte) (zson.Raw, zeek.Type, error) {
+func NewRawAndType(b []byte) (zval.Encoding, zeek.Type, error) {
 	val, typ, _, err := jsonparser.Get(b)
 	if err != nil {
 		return nil, nil, err
@@ -27,7 +26,7 @@ func NewRawAndType(b []byte) (zson.Raw, zeek.Type, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	var raw zson.Raw
+	var raw zval.Encoding
 	for _, v := range values {
 		raw = zval.AppendValue(raw, v)
 	}

--- a/pkg/zson/record.go
+++ b/pkg/zson/record.go
@@ -31,11 +31,14 @@ type Record struct {
 	Ts nano.Ts
 	*Descriptor
 	Stable bool
-	Raw    Raw
+	// Raw is the serialization format for zson records.  A raw value comprises a
+	// sequence of zvals, one per descriptor column.  The descriptor is stored
+	// outside of the raw serialization but is needed to interpret the raw values.
+	Raw zval.Encoding
 }
 
 // NewRecord creates a record from a timestamp and a raw value.
-func NewRecord(d *Descriptor, ts nano.Ts, raw Raw) *Record {
+func NewRecord(d *Descriptor, ts nano.Ts, raw zval.Encoding) *Record {
 	return &Record{
 		Ts:         ts,
 		Descriptor: d,
@@ -83,7 +86,7 @@ func NewRecordZeekStrings(d *Descriptor, ss ...string) (t *Record, err error) {
 
 // ZvalIter returns an iterator over the receiver's zvals.
 func (r *Record) ZvalIter() zval.Iter {
-	return r.Raw.ZvalIter()
+	return r.Raw.Iter()
 }
 
 // Width returns the number of columns in the record.
@@ -94,7 +97,7 @@ func (r *Record) Keep() *Record {
 		return r
 	}
 	v := &Record{Ts: r.Ts, Descriptor: r.Descriptor, Stable: true}
-	v.Raw = make(Raw, len(r.Raw))
+	v.Raw = make(zval.Encoding, len(r.Raw))
 	copy(v.Raw, r.Raw)
 	return v
 }

--- a/pkg/zval/iter.go
+++ b/pkg/zval/iter.go
@@ -1,0 +1,32 @@
+package zval
+
+import (
+	"fmt"
+)
+
+// Iter iterates over a sequence of zval Encodings.
+type Iter Encoding
+
+// Done returns true if no zvals remain.
+func (i *Iter) Done() bool {
+	return len(*i) == 0
+}
+
+// Next returns the next zval.  It returns an empty slice for an empty or
+// zero-length zval and nil for an unset zval.
+func (i *Iter) Next() (Encoding, bool, error) {
+	// Uvarint is zero for an unset zval; otherwise, it is the value's
+	// length plus one.
+	u64, n := Uvarint(*i)
+	if n <= 0 {
+		return nil, false, fmt.Errorf("bad uvarint: %d", n)
+	}
+	if tagIsUnset(u64) {
+		*i = (*i)[n:]
+		return nil, tagIsContainer(u64), nil
+	}
+	end := n + tagLength(u64)
+	val := (*i)[n:end]
+	*i = (*i)[end:]
+	return Encoding(val), tagIsContainer(u64), nil
+}

--- a/pkg/zval/zval_test.go
+++ b/pkg/zval/zval_test.go
@@ -35,7 +35,7 @@ func TestAppendContainer(t *testing.T) {
 				val, container, err := containerIt.Next()
 				assert.NoError(t, err)
 				assert.False(t, container)
-				assert.Exactly(t, expected, val)
+				assert.Exactly(t, expected, val.Bytes())
 			}
 			assert.True(t, containerIt.Done())
 		}
@@ -55,7 +55,7 @@ func TestAppendValue(t *testing.T) {
 			val, container, err := it.Next()
 			assert.NoError(t, err)
 			assert.False(t, container)
-			assert.Exactly(t, expected, val)
+			assert.Exactly(t, expected, val.Bytes())
 		}
 		assert.True(t, it.Done())
 	}


### PR DESCRIPTION
These changes create a new type for zval encodings so that we
can distinguish between normal byte slices and byte slices that
are encoded zvals.  zson.Record.Raw becomes a zval.Encoding and
the zson.Raw type is deprecated.  zson.Record.Raw is still called
Raw as this is an apt name for the zval serialized encoding.