### PR TITLE
eliminate semicolons after right bracket in zson

### DIFF
--- a/pkg/zsio/writer.go
+++ b/pkg/zsio/writer.go
@@ -66,7 +66,7 @@ func (w *Writer) writeContainer(val []byte) error {
 			}
 		}
 	}
-	return w.write("];")
+	return w.write("]")
 }
 
 func (w *Writer) writeValue(val []byte) error {
@@ -99,8 +99,8 @@ func (w *Writer) writeEscaped(val []byte) error {
 	}
 	// We escape a bracket if it appears as the first byte of a value;
 	// we otherwise don't need to escape brackets.
-	if val[0] == '[' {
-		if err := w.escape('['); err != nil {
+	if val[0] == '[' || val[0] == ']' {
+		if err := w.escape(val[0]); err != nil {
 			return err
 		}
 		val = val[1:]

--- a/pkg/zsio/zsio_test.go
+++ b/pkg/zsio/zsio_test.go
@@ -19,12 +19,12 @@ func assertError(t *testing.T, err error, pattern, what string) {
 func TestZsonDescriptors(t *testing.T) {
 	// Step 1 - Test a simple zson descriptor and corresponding value
 	zson := "#1:record[s:string,n:int]\n"
-	zson += "1:[foo;5;];\n"
+	zson += "1:[foo;5;]\n"
 	// Step 2 - Create a second descriptor of a different type
 	zson += "#2:record[a:addr,p:port]\n"
-	zson += "2:[10.5.5.5;443;];\n"
+	zson += "2:[10.5.5.5;443;]\n"
 	// Step 3 - can still use the first descriptor
-	zson += "1:[bar;100;];\n"
+	zson += "1:[bar;100;]\n"
 	// Step 4 - Test that referencing an invalid descriptor is an error.
 	zson += "100:[something;somethingelse;]\n"
 
@@ -69,8 +69,8 @@ func TestZsonDescriptors(t *testing.T) {
 	// Test various malformed zson:
 	def1 := "#1:record[s:string,n:int]\n"
 	zsons := []string{
-		def1 + "1:string;123;\n",   // missing brackets
-		def1 + "1:[string;123];\n", // missing semicolon
+		def1 + "1:string;123;\n",  // missing brackets
+		def1 + "1:[string;123]\n", // missing semicolon
 	}
 
 	for _, z := range zsons {

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -33,25 +33,25 @@ func identity(t *testing.T, logs string) {
 
 const zson1 = `
 #0:record[foo:set[string]]
-0:[["test";];];`
+0:[["test";]]`
 
 const zson2 = `
 #0:record[foo:record[bar:string]]
-0:[[test;];];`
+0:[[test;]]`
 
 const zson3 = `
 #0:record[foo:set[string]]
-0:[[-;];];`
+0:[[-;]]`
 
 // string \x2d is "-"
 const zson4 = `
 #0:record[foo:string]
-0:[\x2d;];`
+0:[\x2d;]`
 
 // string \x5b is "[", second string is "[-]" and should pass through
 const zson5 = `
 #0:record[foo:string,bar:string]
-0:[\x5b;\x5b-];];`
+0:[\x5b;\x5b-];]`
 
 func repeat(c byte, n int) string {
 	b := make([]byte, n)
@@ -68,7 +68,7 @@ func zsonBig() string {
 	s += repeat('a', 4) + ";"
 	s += repeat('b', 400) + ";"
 	s += repeat('c', 30000) + ";"
-	s += repeat('d', 2) + ";];\n"
+	s += repeat('d', 2) + ";]\n"
 	return s
 }
 

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -235,7 +235,7 @@ defined by a descriptor directive.
 ### Character Escape Rules
 
 Any character in a value line may be escaped from the ZSON formatting rules
-using the hext escape syntax, i.e., `\xdd`.
+using the hex escape syntax, i.e., `\xdd`.
 
 Sequences of binary data can be embedded in values using these escapes but it is
 a semantic error for arbitrary binary data to be carried by any types except

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -189,14 +189,14 @@ declared `record` types:
 A regular value is encoded on a line as a type descriptor followed by `:` followed
 by a value encoding.  Here is a pseudo-grammar for value encodings:
 ```
-<line> := <descriptor> : <elem> ;
+<line> := <descriptor> : <elem>
 <elem> :=
-          <terminal>
+          <terminal> ;
         | [ <list> ]
         | [ ]
 <list> :=
-          <elem> ;
-        | <list> <elem> ;
+          <elem>
+        | <list> <elem>
 <terminal> := <char>*
 <char> := [^][;\n\\] | <esc-sequence>
 <esc-sequence> := <JavaScript character escaping rules [1]>
@@ -204,11 +204,12 @@ by a value encoding.  Here is a pseudo-grammar for value encodings:
 
 [1] - [JavaScript character escaping rules](https://tc39.es/ecma262/#prod-EscapeSequence)
 
-A value is encoded as a string of UTF-8 characters terminated
-by a semicolon (which must be escaped if it appears in the value) where
-composite values are contained in brackets as one or more such
-semicolon terminated strings.  Any escaped characters shall be processed
-and interpreted as their escaped value.
+A terminal value is encoded as a string of UTF-8 characters terminated
+by a semicolon (which must be escaped if it appears in the value).  A composite
+values is encoded as a left bracket followed by one or more values (terminal or
+composite) followed by a right bracket.
+Any escaped characters shall be processed and interpreted as their escaped value.
+
 
 Container values are encoded as
 * an open bracket,
@@ -234,21 +235,23 @@ defined by a descriptor directive.
 ### Character Escape Rules
 
 Any character in a value line may be escaped from the ZSON formatting rules
-using the JavaScript rules for escape syntax, i.e.,
-* `\ddd` for octal escapes,
-* `\xdd` for hex escapes,
-* `\udddd` for unicode escapes,
-* and the various [single character escapes of JavaScript](https://tc39.es/ecma262/#prod-SingleEscapeCharacter).
+using the hext escape syntax, i.e., `\xdd`.
 
 Sequences of binary data can be embedded in values using these escapes but it is
 a semantic error for arbitrary binary data to be carried by any types except
 `string` and `bytes` (see [Type Semantics](#type-semantics)).
 
-These special characters must be escaped if they appear within a value:
+These special characters must be hex escaped if they appear within a value:
 ```
 ; \n \\
 ```
-In addition, `-` must be escaped if representing the single ASCII byte equal to `-` as opposed to representing an unset value.
+And these characters must be escaped if they appear as the first character
+of a value:
+```
+[ ]
+```
+In addition, `-` must be escaped if representing the single ASCII byte equal
+to `-` as opposed to representing an unset value.
 
 ## Examples
 
@@ -258,8 +261,8 @@ two descriptors then uses them in three values:
 #1:string
 #2:record[a:string,b:string]
 1:hello, world;
-2:[hello;world;];
-1:this is a semicolon: \;;
+2:[hello;world;]
+1:this is a semicolon: \x3b;
 ```
 which represents a stream of the following three values:
 ```
@@ -272,10 +275,10 @@ The semicolon terminator is important.  Consider this ZSON depicting
 sets of strings:
 ```
 #3:set[string]
-3:[hello,world;];
-3:[hello;world;];
-3:[];
-3:[;];
+3:[hello,world;]
+3:[hello;world;]
+3:[]
+3:[;]
 ```
 In this example:
 * the first value is a `set` of one `string`
@@ -290,11 +293,11 @@ This scheme allows composites to be embedded in composites, e.g., a
 ```
 #4:record[compass:string,degree:double]
 #5:record[city:string,lat:4,long:4]
-5:[NYC;[NE;40.7128];[W;74.0060;];];
+5:[NYC;[NE;40.7128;][W;74.0060;]]
 ```
 An unset value indicates a field of a `record` that wasn't set by the encoder:
 ```
-5:[North Pole;[N;90];-;];
+5:[North Pole;[N;90;]-;]
 ```
 e.g., the North Pole has a latitude but no meaningful longitude.
 

--- a/pkg/zson/raw.go
+++ b/pkg/zson/raw.go
@@ -163,10 +163,10 @@ func (p *Parser) Parse(desc *Descriptor, zson []byte) (Raw, error) {
 	builder := p.builder
 	builder.Reset()
 	n := len(zson)
-	if len(zson) < 3 || zson[0] != '[' || zson[n-1] != ';' || zson[n-2] != ']' {
+	if len(zson) < 2 || zson[0] != '[' || zson[n-1] != ']' {
 		return nil, ErrSyntax
 	}
-	zson = zson[1 : n-2]
+	zson = zson[1 : n-1]
 	for len(zson) > 0 {
 		rest, err := zsonParseField(builder, zson)
 		if err != nil {
@@ -199,10 +199,7 @@ func zsonParseContainer(builder *zval.Builder, b []byte) ([]byte, error) {
 		}
 		if b[0] == rightbracket {
 			builder.End()
-			if len(b) < 2 || b[1] != ';' {
-				return nil, ErrUnterminated
-			}
-			return b[2:], nil
+			return b[1:], nil
 		}
 		rest, err := zsonParseField(builder, b)
 		if err != nil {

--- a/test/Baseline/input.ndjson/output.zeek
+++ b/test/Baseline/input.ndjson/output.zeek
@@ -1,3 +1,3 @@
 #0:record[bool1:bool,int1:int,string1:string,string2:string]
-0:[true;4;value1;value1;];
-0:[true;4;value2;value2;];
+0:[true;4;value1;value1;]
+0:[true;4;value2;value2;]


### PR DESCRIPTION
This commit changes the zson spec and the implementation to
eliminate the semicolon after a right bracket in a container.
Now, only leaf values are semicolon-terminated.  This means
that we need to escape brackets if they appear as the first
character of a terminal value.