### PR TITLE
add raw reader/writer to zsio

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/mccanne/zq/pkg/zsio/raw"
 	"github.com/mccanne/zq/pkg/zsio/table"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/proc"
@@ -50,9 +49,6 @@ func (e *Emitter) writeWarnings(msg string) error {
 }
 
 func (e *Emitter) handle(res proc.MuxResult) error {
-	if raw, ok := e.writer.(*raw.Raw); ok {
-		return raw.WriteRaw(res)
-	}
 	if res.Warning != "" {
 		e.writeWarnings(res.Warning)
 		return nil

--- a/pkg/peeker/reader.go
+++ b/pkg/peeker/reader.go
@@ -1,0 +1,83 @@
+package peeker
+
+import (
+	"errors"
+	"io"
+)
+
+type Reader struct {
+	io.Reader
+	limit  int
+	buffer []byte
+	cursor []byte
+	eof    bool
+}
+
+var (
+	ErrBufferOverflow = errors.New("buffer too big")
+	ErrTruncated      = errors.New("truncated input")
+)
+
+func NewReader(reader io.Reader, size, max int) *Reader {
+	b := make([]byte, size)
+	return &Reader{
+		Reader: reader,
+		limit:  max,
+		buffer: b,
+		cursor: b[:0],
+	}
+}
+
+func (r *Reader) fill(min int) error {
+	if min > r.limit {
+		return ErrBufferOverflow
+	}
+	if min > cap(r.buffer) {
+		r.buffer = make([]byte, min)
+	}
+	r.buffer = r.buffer[:cap(r.buffer)]
+	copy(r.buffer, r.cursor)
+	clen := len(r.cursor)
+	space := len(r.buffer) - clen
+	for space > 0 {
+		cc, err := r.Reader.Read(r.buffer[clen:])
+		if cc > 0 {
+			clen += cc
+			space -= cc
+		}
+		if err != nil {
+			if err == io.EOF {
+				r.eof = true
+				break
+			}
+			return err
+		}
+	}
+	r.buffer = r.buffer[:clen]
+	r.cursor = r.buffer
+	return nil
+}
+
+func (r *Reader) Peek(n int) ([]byte, error) {
+	if len(r.cursor) == 0 && r.eof {
+		return nil, io.EOF
+	}
+	if n > len(r.cursor) && !r.eof {
+		if err := r.fill(n); err != nil {
+			return nil, err
+		}
+	}
+	if n > len(r.cursor) {
+		return r.cursor, ErrTruncated
+	}
+	return r.cursor[:n], nil
+}
+
+func (r *Reader) Read(n int) ([]byte, error) {
+	b, err := r.Peek(n)
+	if err != nil {
+		return nil, err
+	}
+	r.cursor = r.cursor[n:]
+	return b, nil
+}

--- a/pkg/zsio/raw/header.go
+++ b/pkg/zsio/raw/header.go
@@ -1,0 +1,103 @@
+// Package raw provides an API for reading and writing zson values and
+// directives in raw format.  The Reader and Writer types implement the
+// the zson.Reader and zson.Writer interfaces.  Since these methods
+// read and write only zson.Records, but the raw format includes additional
+// functionality, other methods are available to read/write zson comments
+// and include virtual channel numbers in the stream.  Virtual channels
+// provide a way to indicate which output of a flowgraph a result came from
+// when a flowgraph computes multiple output channels.  The raw values in
+// this zson value are either "string format" (represented either as UTF-8
+// strings with zeek escaping) or "machine format" (encoded in a architecture
+// independent binary format).  The vanilla zson.Reader and zson.Writer
+// implementations ignore comments and channels.
+package raw
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"github.com/mccanne/zq/pkg/zson"
+)
+
+const (
+	TypeDescriptor = iota
+	TypeValue
+	TypeComment
+)
+
+const (
+	MachineFlag = 0x80
+	ChannelFlag = 0x40
+	TypeMask    = 0x3f
+)
+
+type header struct {
+	typ    int
+	ch     int
+	id     int
+	length int
+}
+
+const maxHeaderSize = 1 + 3*binary.MaxVarintLen64
+const minHeaderSize = 3
+
+func writeHeader(w io.Writer, typ, ch, id, length int) (int, error) {
+	var hdr [maxHeaderSize]byte
+	if ch != 0 && typ != TypeValue {
+		return 0, errors.New("raw encoding channel valid only with values")
+	}
+	if ch != 0 {
+		typ |= ChannelFlag
+	}
+	hdr[0] = byte(typ)
+	off := 1
+	if ch != 0 {
+		off += binary.PutUvarint(hdr[off:], uint64(ch))
+	}
+	if typ != TypeComment {
+		off += binary.PutUvarint(hdr[off:], uint64(id))
+	}
+	off += binary.PutUvarint(hdr[off:], uint64(length))
+	_, err := w.Write(hdr[:off])
+	return off, err
+}
+
+func parseHeader(b []byte, h *header) (int, error) {
+	if len(b) < 3 {
+		return 0, zson.ErrBadFormat
+	}
+	typ := int(b[0])
+	off := 1
+	if typ&MachineFlag != 0 {
+		return 0, errors.New("machine-format raw zson not yet implemented")
+	}
+	if typ&ChannelFlag != 0 {
+		ch, n := binary.Uvarint(b[off:])
+		if n <= 0 {
+			return 0, zson.ErrBadFormat
+		}
+		off += n
+		h.ch = int(ch)
+	}
+	typ &= TypeMask
+	h.typ = typ
+	if typ != TypeComment {
+		id, n := binary.Uvarint(b[off:])
+		if n <= 0 {
+			return 0, zson.ErrBadFormat
+		}
+		if id > zson.MaxDescriptor {
+			return 0, zson.ErrDescriptorInvalid
+		}
+		off += n
+		h.id = int(id)
+	}
+	length, n := binary.Uvarint(b[off:])
+	if n <= 0 {
+		return 0, zson.ErrBadFormat
+	}
+	off += n
+	h.length = int(length)
+	return off, nil
+}

--- a/pkg/zsio/raw/reader.go
+++ b/pkg/zsio/raw/reader.go
@@ -1,0 +1,111 @@
+package raw
+
+import (
+	"io"
+
+	"github.com/mccanne/zq/pkg/nano"
+	"github.com/mccanne/zq/pkg/peeker"
+	zeektype "github.com/mccanne/zq/pkg/zeek"
+	"github.com/mccanne/zq/pkg/zson"
+	"github.com/mccanne/zq/pkg/zson/resolver"
+)
+
+const (
+	ReadSize = 512 * 1024
+	MaxSize  = 10 * 1024 * 1024
+)
+
+type Reader struct {
+	peeker *peeker.Reader
+	mapper *resolver.Mapper
+}
+
+func NewReader(reader io.Reader, r *resolver.Table) *Reader {
+	return &Reader{
+		peeker: peeker.NewReader(reader, ReadSize, MaxSize),
+		mapper: resolver.NewMapper(r),
+	}
+}
+
+func (r *Reader) Read() (*zson.Record, error) {
+again:
+	var hdr header
+	err := r.decode(&hdr)
+	if err != nil {
+		if err == io.EOF {
+			err = nil
+		}
+		return nil, err
+	}
+	b, err := r.peeker.Read(hdr.length)
+	if err != nil {
+		return nil, err
+	}
+	switch hdr.typ {
+	case TypeDescriptor:
+		err = r.parseDescriptor(hdr.id, b)
+		if err != nil {
+			return nil, err
+		}
+		goto again
+	case TypeValue:
+		rec, err := r.parseValue(hdr.id, b)
+		if err != nil {
+			return nil, err
+		}
+		return rec, nil
+	default:
+		// skip over control comments
+		goto again
+	}
+
+}
+
+func (r *Reader) parseDescriptor(id int, b []byte) error {
+	if r.mapper.Map(id) != nil {
+		//XXX this should be ok... decide on this and update spec
+		return zson.ErrDescriptorExists
+	}
+	typ, err := zeektype.LookupType(string(b))
+	if err != nil {
+		return err
+	}
+	recordType, ok := typ.(*zeektype.TypeRecord)
+	if !ok {
+		return zson.ErrBadValue
+	}
+	if r.mapper.Enter(id, recordType) == nil {
+		// XXX this shouldn't happen
+		return zson.ErrBadValue
+	}
+	return nil
+}
+
+func (r *Reader) parseValue(id int, b []byte) (*zson.Record, error) {
+	descriptor := r.mapper.Map(id)
+	if descriptor == nil {
+		return nil, zson.ErrDescriptorInvalid
+	}
+	record := zson.NewVolatileRecord(descriptor, nano.MinTs, b)
+	//XXX this should go in NewRecord?
+	ts, err := record.AccessTime("ts")
+	if err == nil {
+		record.Ts = ts
+	}
+	return record, nil
+}
+
+func (r *Reader) decode(h *header) error {
+	b, err := r.peeker.Peek(maxHeaderSize)
+	if err == io.EOF {
+		return err
+	}
+	n, err := parseHeader(b, h)
+	if err != nil {
+		return err
+
+	}
+	// discard header from reader's stream
+	_, err = r.peeker.Read(n)
+	return err
+}

--- a/pkg/zsio/zsio.go
+++ b/pkg/zsio/zsio.go
@@ -82,9 +82,9 @@ func LookupReader(format string, r io.Reader, table *resolver.Table) zson.Reader
 					return text.NewReader(f, c.showTypes, c.showFields, c.epochDates)
 
 			case "table":
-				return table.NewReader(r, table)
-			case "raw":
-				return raw.NewReader(r, table) */
+				return table.NewReader(r, table) */
+	case "raw":
+		return raw.NewReader(r, table)
 	}
 	return nil
 }

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -45,7 +45,7 @@ func boomerang(t *testing.T, logs string) {
 
 	var out Output
 	rawSrc := raw.NewReader(bytes.NewReader(rawZson.Bytes()), resolver.NewTable())
-	zsonDst := zsonio.NewWriter(&out)
+	zsonDst := &flusher{zsonio.NewWriter(&out)}
 	err = zson.Copy(zsonDst, rawSrc)
 	if assert.NoError(t, err) {
 		assert.Equal(t, in, out.Bytes())

--- a/pkg/zson/descriptor.go
+++ b/pkg/zson/descriptor.go
@@ -6,6 +6,12 @@ import (
 	"github.com/mccanne/zq/pkg/zeek"
 )
 
+// MaxDescriptor is the largest descriptor ID allowed.  Since some tables
+// are sized based on the largest descriptor seen, very large descriptors
+// due to bugs etc could cause memory use problems.
+// XXX make this configurable
+const MaxDescriptor = 1000000
+
 // Resolver is an interface for looking up Descriptor objects from the descriptor id.
 type Resolver interface {
 	Lookup(td int) *Descriptor

--- a/pkg/zson/record.go
+++ b/pkg/zson/record.go
@@ -47,7 +47,7 @@ func NewRecord(d *Descriptor, ts nano.Ts, raw zval.Encoding) *Record {
 	}
 }
 
-// NewTempRecord creates a record from a timestamp and a raw value
+// NewVolatileRecord creates a record from a timestamp and a raw value
 // marked volatile so that Keep() must be called to make it safe.
 // This is useful for readers that allocate records whose raw body points
 // into a reusable buffer allowing the scanner to filter these records

--- a/pkg/zson/resolver/tracker.go
+++ b/pkg/zson/resolver/tracker.go
@@ -1,0 +1,23 @@
+package resolver
+
+// Map is a table of descriptors respresented as a golang map.  Map implements
+// the zson.Resolver interface.
+type Tracker struct {
+	table map[int]struct{}
+}
+
+func NewTracker() *Tracker {
+	return &Tracker{
+		table: make(map[int]struct{}),
+	}
+}
+
+// Seen returns true iff the id has been previously seen and remembers
+// it from here on out.
+func (t *Tracker) Seen(id int) bool {
+	_, ok := t.table[id]
+	if !ok {
+		t.table[id] = struct{}{}
+	}
+	return ok
+}

--- a/pkg/zson/zson.go
+++ b/pkg/zson/zson.go
@@ -2,9 +2,17 @@ package zson
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/mccanne/zq/pkg/nano"
+)
+
+var (
+	ErrDescriptorExists  = errors.New("zson descriptor exists")
+	ErrDescriptorInvalid = errors.New("zson descriptor out of range")
+	ErrBadValue          = errors.New("malformed zson value")
+	ErrBadFormat         = errors.New("malformed zson record")
 )
 
 type Reader interface {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"github.com/mccanne/zq/filter"
 	"github.com/mccanne/zq/pkg/nano"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/proc"
@@ -8,24 +9,32 @@ import (
 
 type Scanner struct {
 	reader zson.Reader
+	filter filter.Filter
 }
 
-func NewScanner(reader zson.Reader) *Scanner {
+func NewScanner(reader zson.Reader, f filter.Filter) *Scanner {
 	return &Scanner{
 		reader: reader,
+		filter: f,
 	}
 }
+
+const batchSize = 24
 
 func (s *Scanner) Pull() (zson.Batch, error) {
 	minTs, maxTs := nano.MaxTs, nano.MinTs
 	var arr []*zson.Record
-	for i := 0; i < 24; i++ {
+	match := s.filter
+	for len(arr) < batchSize {
 		rec, err := s.reader.Read()
 		if err != nil {
 			return nil, err
 		}
 		if rec == nil {
 			break
+		}
+		if match != nil && !match(rec) {
+			continue
 		}
 		if rec.Ts < minTs {
 			minTs = rec.Ts
@@ -34,7 +43,7 @@ func (s *Scanner) Pull() (zson.Batch, error) {
 			maxTs = rec.Ts
 		}
 		// Use rec.Keep() to copy underlying buffer because call to next
-		// reader.Next() will overwrite said buffer.
+		// reader.Next() may overwrite said buffer.
 		arr = append(arr, rec.Keep())
 	}
 	if arr == nil {


### PR DESCRIPTION
This commit adds support for reading and writing zson files
in a raw format, where each zson value is encoded directly
in its zval serialized encoding and each type descriptor binding
is encoded in its ascii form.  In both cases, a three element
header frames each line, where the header provides the type
(descriptor or value), the descriptor id, and the length of
the buffer.

This raw variant seems to go about 4X faster than zson scanning
for a simple count query, i.e., "* | count()".