### PR TITLE
add reader/writer for zson over json

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -233,6 +233,8 @@ func (c *Command) loadFile(path string) (zson.Reader, error) {
 	// stream.
 	var reader string
 	switch ext := filepath.Ext(path); ext {
+	case ".zjson":
+		reader = "zjson"
 	case ".ndjson":
 		reader = "ndjson"
 	case ".raw":

--- a/pkg/zsio/zjson/reader.go
+++ b/pkg/zsio/zjson/reader.go
@@ -1,0 +1,195 @@
+package zjson
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/mccanne/zq/pkg/nano"
+	"github.com/mccanne/zq/pkg/skim"
+	"github.com/mccanne/zq/pkg/zeek"
+	"github.com/mccanne/zq/pkg/zson"
+	"github.com/mccanne/zq/pkg/zson/resolver"
+	"github.com/mccanne/zq/pkg/zval"
+)
+
+const (
+	ReadSize    = 64 * 1024
+	MaxLineSize = 50 * 1024 * 1024
+)
+
+func scanErr(err error, n int) error {
+	if err == bufio.ErrTooLong {
+		return fmt.Errorf("max line size exceeded at line %d", n)
+	}
+	return fmt.Errorf("error encountered after %d lines: %s", n, err)
+}
+
+type Reader struct {
+	scanner *skim.Scanner
+	mapper  *resolver.Mapper
+	builder *zval.Builder
+}
+
+func NewReader(reader io.Reader, r *resolver.Table) *Reader {
+	buffer := make([]byte, ReadSize)
+	return &Reader{
+		scanner: skim.NewScanner(reader, buffer, MaxLineSize),
+		mapper:  resolver.NewMapper(r),
+		builder: zval.NewBuilder(),
+	}
+}
+
+func (r *Reader) Read() (*zson.Record, error) {
+	line, err := r.scanner.ScanLine()
+	if line == nil {
+		return nil, err
+	}
+	// remove newline
+	line = line[:len(line)-1]
+	var v Record
+	err = json.Unmarshal(line, &v)
+	if err != nil {
+		return nil, err
+	}
+	if v.Type != nil {
+		recType, err := LookupType(v.Type)
+		if err != nil {
+			return nil, err
+		}
+		err = r.enterDescriptor(v.Id, recType)
+		if err != nil {
+			return nil, err
+		}
+	}
+	rec, err := r.parseValues(v.Id, v.Values)
+	if err != nil {
+		return nil, err
+	}
+	return rec, nil
+}
+
+func LookupType(columns []interface{}) (*zeek.TypeRecord, error) {
+	typeName, err := decodeType(columns)
+	if err != nil {
+		return nil, err
+	}
+	typ, err := zeek.LookupType(typeName)
+	if err != nil {
+		return nil, fmt.Errorf("unknown type: \"%s\"", typeName)
+	}
+	recType, ok := typ.(*zeek.TypeRecord)
+	if !ok {
+		return nil, fmt.Errorf("zjson type not a record: \"%s\"", typeName)
+
+	}
+	return recType, nil
+}
+
+func (r *Reader) enterDescriptor(id int, typ *zeek.TypeRecord) error {
+	if r.mapper.Map(id) != nil {
+		//XXX this should be ok... decide on this and update spec
+		return zson.ErrDescriptorExists
+	}
+	if r.mapper.Enter(id, typ) == nil {
+		// XXX this shouldn't happen
+		return zson.ErrBadValue
+	}
+	return nil
+}
+
+func (r *Reader) parseValues(id int, values []interface{}) (*zson.Record, error) {
+	descriptor := r.mapper.Map(id)
+	if descriptor == nil {
+		return nil, zson.ErrDescriptorInvalid
+	}
+	// reset the builder and decode the body into the builder intermediate
+	// zson representation
+	r.builder.Reset()
+	err := decodeContainer(r.builder, values)
+	if err != nil {
+		return nil, err
+	}
+	raw := r.builder.Encode()
+	zv, err := raw.Body()
+	if err != nil {
+		//XXX need better error here... this won't make much sense
+		return nil, err
+	}
+	record := zson.NewRecord(descriptor, nano.MinTs, zv)
+	//XXX this should go in NewRecord?
+	ts, err := record.AccessTime("ts")
+	if err == nil {
+		record.Ts = ts
+	}
+	return record, nil
+}
+
+// decode a nested JSON object into a zeek type string and return the string.
+func decodeType(columns []interface{}) (string, error) {
+	s := "record["
+	comma := ""
+	for _, o := range columns {
+		// each column a json object with name and type
+		m, ok := o.(map[string]interface{})
+		if !ok {
+			return "", errors.New("zjson type not a json object")
+		}
+		nameObj, ok := m["name"]
+		if !ok {
+			return "", errors.New("zjson type object missing name field")
+		}
+		name, ok := nameObj.(string)
+		if !ok {
+			return "", errors.New("zjson type object has non-string name field")
+		}
+		typeObj, ok := m["type"]
+		if !ok {
+			return "", errors.New("zjson type object missing type field")
+		}
+		typeName, ok := typeObj.(string)
+		if !ok {
+			childColumns, ok := typeObj.([]interface{})
+			if !ok {
+				return "", errors.New("zjson type field contains invalid type")
+			}
+			var err error
+			typeName, err = decodeType(childColumns)
+			if err != nil {
+				return "", err
+			}
+		}
+		s += comma + name + ":" + typeName
+		comma = ","
+	}
+	return s + "]", nil
+}
+
+func decodeContainer(builder *zval.Builder, body []interface{}) error {
+	//XXX check that begin and end does the right thing for an empty thing?
+	builder.Begin()
+	for _, column := range body {
+		// each column either a string value or an array of string values
+		if column == nil {
+			// this is an unset column
+			builder.Append(nil)
+			continue
+		}
+		s, ok := column.(string)
+		if ok {
+			builder.Append(zeek.Unescape([]byte(s)))
+			continue
+		}
+		children, ok := column.([]interface{})
+		if !ok {
+			return errors.New("bad json for zjson value")
+		}
+		if err := decodeContainer(builder, children); err != nil {
+			return err
+		}
+	}
+	builder.End()
+	return nil
+}

--- a/pkg/zsio/zjson/writer.go
+++ b/pkg/zsio/zjson/writer.go
@@ -1,0 +1,123 @@
+package zjson
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/mccanne/zq/pkg/zeek"
+	"github.com/mccanne/zq/pkg/zson"
+	"github.com/mccanne/zq/pkg/zson/resolver"
+	"github.com/mccanne/zq/pkg/zval"
+)
+
+type Column struct {
+	Name string      `json:"name"`
+	Type interface{} `json:"type"`
+}
+
+type Record struct {
+	Id     int           `json:"id"`
+	Type   []interface{} `json:"type,omitempty"`
+	Values []interface{} `json:"values"`
+}
+
+type Writer struct {
+	io.Writer
+	tracker *resolver.Tracker
+}
+
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{
+		Writer:  w,
+		tracker: resolver.NewTracker(),
+	}
+}
+
+func (w *Writer) Write(r *zson.Record) error {
+	id := r.Descriptor.ID
+	var typ []interface{}
+	if !w.tracker.Seen(id) {
+		var err error
+		typ, err = EncodeType(r.Descriptor.Type)
+		if err != nil {
+			return err
+		}
+	}
+	values, err := w.encodeContainer(r.Raw)
+	if err != nil {
+		return err
+	}
+	v := Record{
+		Id:     id,
+		Type:   typ,
+		Values: values,
+	}
+	b, err := json.Marshal(&v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Writer.Write(b)
+	if err != nil {
+		return err
+	}
+	return w.write("\n")
+}
+
+func (w *Writer) write(s string) error {
+	_, err := w.Writer.Write([]byte(s))
+	return err
+}
+
+func (w *Writer) encodeContainer(val []byte) ([]interface{}, error) {
+	// We start out with a slice that contains nothing instead of nil
+	// so that an empty set encodes to JSON empty array [].
+	body := make([]interface{}, 0)
+	if len(val) > 0 {
+		for it := zval.Iter(val); !it.Done(); {
+			v, container, err := it.Next()
+			if err != nil {
+				return nil, err
+			}
+			if container {
+				child, err := w.encodeContainer(v)
+				if err != nil {
+					return nil, err
+				}
+				body = append(body, child)
+			} else {
+				// encode nil val as JSON null since
+				// zeek.Escape() returns "" for nil
+				var s interface{}
+				if v != nil {
+					s = zeek.Escape(v)
+				}
+				body = append(body, s)
+			}
+		}
+	}
+	return body, nil
+}
+
+// Encode a type as a resursive set of JSON objects.  We could simply encode
+// the top level type string, but then a javascript client would need to have
+// a type parser.  Instead, we encode recursive record types as a nested set
+// of objects so a javascript client can easily call JSON.parse() and have
+// the record structure present in an easy-to-navigate nested object.
+func EncodeType(typ *zeek.TypeRecord) ([]interface{}, error) {
+	var columns []interface{}
+	for _, c := range typ.Columns {
+		childRec, ok := c.Type.(*zeek.TypeRecord)
+		var typ interface{}
+		if ok {
+			var err error
+			typ, err = EncodeType(childRec)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			typ = c.Type.String()
+		}
+		columns = append(columns, Column{Name: c.Name, Type: typ})
+	}
+	return columns, nil
+}

--- a/pkg/zsio/zsio.go
+++ b/pkg/zsio/zsio.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mccanne/zq/pkg/zsio/raw"
 	"github.com/mccanne/zq/pkg/zsio/table"
 	"github.com/mccanne/zq/pkg/zsio/zeek"
+	"github.com/mccanne/zq/pkg/zsio/zjson"
 	zsonio "github.com/mccanne/zq/pkg/zsio/zson"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zson/resolver"
@@ -47,8 +48,11 @@ func LookupWriter(format string, w io.WriteCloser) *Writer {
 		f = zson.NopFlusher(ndjson.NewWriter(w))
 	case "json":
 		f = json.NewWriter(w)
+	case "zjson":
+		f = &flusher{zjson.NewWriter(w)}
+	// XXX not yet
 	//case "text":
-	//	return &flusher{text.NewWriter(w, c.showTypes, c.showFields, c.epochDates)}
+	//	return text.NewWriter(f, c.showTypes, c.showFields, c.epochDates)
 	case "table":
 		f = table.NewWriter(w)
 	case "raw":
@@ -66,6 +70,8 @@ func LookupReader(format string, r io.Reader, table *resolver.Table) zson.Reader
 		return zsonio.NewReader(r, table)
 	case "ndjson":
 		return ndjson.NewReader(r, table)
+	case "zjson":
+		return zjson.NewReader(r, table)
 		/* XXX not yet
 		case "json":
 			return json.NewReader(r, table)

--- a/pkg/zsio/zsio.go
+++ b/pkg/zsio/zsio.go
@@ -49,7 +49,7 @@ func LookupWriter(format string, w io.WriteCloser) *Writer {
 	case "json":
 		f = json.NewWriter(w)
 	case "zjson":
-		f = &flusher{zjson.NewWriter(w)}
+		f = zson.NopFlusher(zjson.NewWriter(w))
 	// XXX not yet
 	//case "text":
 	//	return text.NewWriter(f, c.showTypes, c.showFields, c.epochDates)

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -57,13 +57,13 @@ func boomerangZJSON(t *testing.T, logs string) {
 	in := []byte(strings.TrimSpace(logs) + "\n")
 	zsonSrc := zsonio.NewReader(bytes.NewReader(in), resolver.NewTable())
 	var zjsonOutput Output
-	zjsonDst := &flusher{zjson.NewWriter(&zjsonOutput)}
+	zjsonDst := zson.NopFlusher(zjson.NewWriter(&zjsonOutput))
 	err := zson.Copy(zjsonDst, zsonSrc)
 	require.NoError(t, err)
 
 	var out Output
 	zjsonSrc := zjson.NewReader(bytes.NewReader(zjsonOutput.Bytes()), resolver.NewTable())
-	zsonDst := &flusher{zsonio.NewWriter(&out)}
+	zsonDst := zson.NopFlusher(zsonio.NewWriter(&out))
 	err = zson.Copy(zsonDst, zjsonSrc)
 	if assert.NoError(t, err) {
 		assert.Equal(t, in, out.Bytes())

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mccanne/zq/pkg/zsio/raw"
+	"github.com/mccanne/zq/pkg/zsio/zjson"
 	zsonio "github.com/mccanne/zq/pkg/zsio/zson"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zson/resolver"
@@ -52,6 +53,23 @@ func boomerang(t *testing.T, logs string) {
 	}
 }
 
+func boomerangZJSON(t *testing.T, logs string) {
+	in := []byte(strings.TrimSpace(logs) + "\n")
+	zsonSrc := zsonio.NewReader(bytes.NewReader(in), resolver.NewTable())
+	var zjsonOutput Output
+	zjsonDst := &flusher{zjson.NewWriter(&zjsonOutput)}
+	err := zson.Copy(zjsonDst, zsonSrc)
+	require.NoError(t, err)
+
+	var out Output
+	zjsonSrc := zjson.NewReader(bytes.NewReader(zjsonOutput.Bytes()), resolver.NewTable())
+	zsonDst := &flusher{zsonio.NewWriter(&out)}
+	err = zson.Copy(zsonDst, zjsonSrc)
+	if assert.NoError(t, err) {
+		assert.Equal(t, in, out.Bytes())
+	}
+}
+
 const zson1 = `
 #0:record[foo:set[string]]
 0:[["test";]]`
@@ -64,15 +82,20 @@ const zson3 = `
 #0:record[foo:set[string]]
 0:[[-;]]`
 
-// string \x2d is "-"
+// String \x2d is "-".
 const zson4 = `
 #0:record[foo:string]
 0:[\x2d;]`
 
-// string \x5b is "[", second string is "[-]" and should pass through
+// String \x5b is "[", second string is "[-]" and should pass through.
 const zson5 = `
 #0:record[foo:string,bar:string]
 0:[\x5b;\x5b-];]`
+
+// Make sure we handle unset fields and empty sets.
+const zson6 = `
+#0:record[id:record[a:string,s:set[string]]]
+0:[[-;[]]]`
 
 func repeat(c byte, n int) string {
 	b := make([]byte, n)
@@ -99,6 +122,7 @@ func TestZson(t *testing.T) {
 	identity(t, zson3)
 	identity(t, zson4)
 	identity(t, zson5)
+	identity(t, zson6)
 	identity(t, zsonBig())
 }
 
@@ -108,6 +132,20 @@ func TestRaw(t *testing.T) {
 	boomerang(t, zson3)
 	boomerang(t, zson4)
 	boomerang(t, zson5)
+	boomerang(t, zson6)
 	boomerang(t, zsonBig())
+}
 
+func TestZjson(t *testing.T) {
+	boomerangZJSON(t, zson1)
+	boomerangZJSON(t, zson2)
+	// XXX this one doesn't work right now but it's sort of ok becaue
+	// it's a little odd to have an unset string value inside of a set.
+	// semantically this would mean the value shouldn't be in the set,
+	// but right now this turns into an empty string, which is somewhat reasonable.
+	//boomerangZJSON(t, zson3)
+	boomerangZJSON(t, zson4)
+	boomerangZJSON(t, zson5)
+	boomerangZJSON(t, zson6)
+	boomerangZJSON(t, zsonBig())
 }

--- a/pkg/zson/docs/zson-over-json.md
+++ b/pkg/zson/docs/zson-over-json.md
@@ -1,0 +1,387 @@
+# zson over http
+
+TBD: this is just an example for now.  We'll clean this up later...
+
+## Nested Example
+
+This zson...
+
+```
+#1:record[id:record[orig_h:addr,orig_p:port,resp_h:addr,resp_p:port],etc:string]
+1:[[192.168.1.1;80;192.168.2.22;6060;]foo;]
+1:[[192.168.1.2;80;192.168.2.21;5050;]bar;]
+1:[[192.168.1.3;80;192.168.2.20;4040;]hello;]
+```
+
+produces this zson over json...
+
+```
+{
+  "id": 0,
+  "type": [
+    {
+      "name": "id",
+      "type": [
+        {
+          "name": "orig_h",
+          "type": "addr"
+        },
+        {
+          "name": "orig_p",
+          "type": "port"
+        },
+        {
+          "name": "resp_h",
+          "type": "addr"
+        },
+        {
+          "name": "resp_p",
+          "type": "port"
+        }
+      ]
+    },
+    {
+      "name": "etc",
+      "type": "string"
+    }
+  ],
+  "value": [
+    [
+      "192.168.1.1",
+      "80",
+      "192.168.2.22",
+      "6060"
+    ],
+    "foo"
+  ]
+}
+{
+  "id": 0,
+  "value": [
+    [
+      "192.168.1.2",
+      "80",
+      "192.168.2.21",
+      "5050"
+    ],
+    "bar"
+  ]
+}
+{
+  "id": 0,
+  "value": [
+    [
+      "192.168.1.3",
+      "80",
+      "192.168.2.20",
+      "4040"
+    ],
+    "hello"
+  ]
+}
+```
+
+
+# Flat Example - conn, dns
+
+## ZSON
+
+```
+#0:record[_path:string,ts:time,uid:string,id.orig_h:addr,id.orig_p:port,id.resp_h:addr,id.resp_p:port,proto:enum,service:string,duration:interval,orig_bytes:count,resp_bytes:count,conn_state:string,local_orig:bool,local_resp:bool,missed_bytes:count,history:string,orig_pkts:count,orig_ip_bytes:count,resp_pkts:count,resp_ip_bytes:count,tunnel_parents:set[string]]
+0:[conn;1425565514.419939;CogZFI3py5JsFZGik;fe80::eef4:bbff:fe51:89ec;5353;ff02::fb;5353;udp;dns;15.007272;2148;0;S0;F;F;0;D;14;2820;0;0;[]]
+#1:record[_path:string,ts:time,uid:string,id.orig_h:addr,id.orig_p:port,id.resp_h:addr,id.resp_p:port,proto:enum,trans_id:count,rtt:interval,query:string,qclass:count,qclass_name:string,qtype:count,qtype_name:string,rcode:count,rcode_name:string,AA:bool,TC:bool,RD:bool,RA:bool,Z:count,answers:vector[string],TTLs:vector[interval],rejected:bool]
+1:[dns;1425565514.419939;CogZFI3py5JsFZGik;fe80::eef4:bbff:fe51:89ec;5353;ff02::fb;5353;udp;0;0.119484;_ipp._tcp.local;1;C_INTERNET;12;PTR;0;NOERROR;T;F;F;F;0;[_workstation._tcp.local;sniffer [ec:f4:bb:51:89:ec]._workstation._tcp.local;][4500.000000;4500.000000;]F;]
+0:[conn;1425565545.440378;CoJHyyAGilEHkRZJf;fe80::eef4:bbff:fe51:89ec;5353;ff02::fb;5353;udp;dns;-;-;-;S0;F;F;0;D;1;93;0;0;[]]
+```
+
+## ZSON over JSON
+
+The output below was produced by running
+```
+zq -f zjson input.zson | jq
+```
+This is pretty-printed with jq, but would otherwise be newline-delimited JSON:
+```
+{
+  "id": 0,
+  "type": [
+    {
+      "name": "_path",
+      "type": "string"
+    },
+    {
+      "name": "ts",
+      "type": "time"
+    },
+    {
+      "name": "uid",
+      "type": "string"
+    },
+    {
+      "name": "id.orig_h",
+      "type": "addr"
+    },
+    {
+      "name": "id.orig_p",
+      "type": "port"
+    },
+    {
+      "name": "id.resp_h",
+      "type": "addr"
+    },
+    {
+      "name": "id.resp_p",
+      "type": "port"
+    },
+    {
+      "name": "proto",
+      "type": "enum"
+    },
+    {
+      "name": "service",
+      "type": "string"
+    },
+    {
+      "name": "duration",
+      "type": "interval"
+    },
+    {
+      "name": "orig_bytes",
+      "type": "count"
+    },
+    {
+      "name": "resp_bytes",
+      "type": "count"
+    },
+    {
+      "name": "conn_state",
+      "type": "string"
+    },
+    {
+      "name": "local_orig",
+      "type": "bool"
+    },
+    {
+      "name": "local_resp",
+      "type": "bool"
+    },
+    {
+      "name": "missed_bytes",
+      "type": "count"
+    },
+    {
+      "name": "history",
+      "type": "string"
+    },
+    {
+      "name": "orig_pkts",
+      "type": "count"
+    },
+    {
+      "name": "orig_ip_bytes",
+      "type": "count"
+    },
+    {
+      "name": "resp_pkts",
+      "type": "count"
+    },
+    {
+      "name": "resp_ip_bytes",
+      "type": "count"
+    },
+    {
+      "name": "tunnel_parents",
+      "type": "set[string]"
+    }
+  ],
+  "value": [
+    "conn",
+    "1425565514.419939",
+    "CogZFI3py5JsFZGik",
+    "fe80::eef4:bbff:fe51:89ec",
+    "5353",
+    "ff02::fb",
+    "5353",
+    "udp",
+    "dns",
+    "15.007272",
+    "2148",
+    "0",
+    "S0",
+    "F",
+    "F",
+    "0",
+    "D",
+    "14",
+    "2820",
+    "0",
+    "0",
+    null
+  ]
+}
+{
+  "id": 1,
+  "type": [
+    {
+      "name": "_path",
+      "type": "string"
+    },
+    {
+      "name": "ts",
+      "type": "time"
+    },
+    {
+      "name": "uid",
+      "type": "string"
+    },
+    {
+      "name": "id.orig_h",
+      "type": "addr"
+    },
+    {
+      "name": "id.orig_p",
+      "type": "port"
+    },
+    {
+      "name": "id.resp_h",
+      "type": "addr"
+    },
+    {
+      "name": "id.resp_p",
+      "type": "port"
+    },
+    {
+      "name": "proto",
+      "type": "enum"
+    },
+    {
+      "name": "trans_id",
+      "type": "count"
+    },
+    {
+      "name": "rtt",
+      "type": "interval"
+    },
+    {
+      "name": "query",
+      "type": "string"
+    },
+    {
+      "name": "qclass",
+      "type": "count"
+    },
+    {
+      "name": "qclass_name",
+      "type": "string"
+    },
+    {
+      "name": "qtype",
+      "type": "count"
+    },
+    {
+      "name": "qtype_name",
+      "type": "string"
+    },
+    {
+      "name": "rcode",
+      "type": "count"
+    },
+    {
+      "name": "rcode_name",
+      "type": "string"
+    },
+    {
+      "name": "AA",
+      "type": "bool"
+    },
+    {
+      "name": "TC",
+      "type": "bool"
+    },
+    {
+      "name": "RD",
+      "type": "bool"
+    },
+    {
+      "name": "RA",
+      "type": "bool"
+    },
+    {
+      "name": "Z",
+      "type": "count"
+    },
+    {
+      "name": "answers",
+      "type": "vector[string]"
+    },
+    {
+      "name": "TTLs",
+      "type": "vector[interval]"
+    },
+    {
+      "name": "rejected",
+      "type": "bool"
+    }
+  ],
+  "value": [
+    "dns",
+    "1425565514.419939",
+    "CogZFI3py5JsFZGik",
+    "fe80::eef4:bbff:fe51:89ec",
+    "5353",
+    "ff02::fb",
+    "5353",
+    "udp",
+    "0",
+    "0.119484",
+    "_ipp._tcp.local",
+    "1",
+    "C_INTERNET",
+    "12",
+    "PTR",
+    "0",
+    "NOERROR",
+    "T",
+    "F",
+    "F",
+    "F",
+    "0",
+    [
+      "_workstation._tcp.local",
+      "sniffer [ec:f4:bb:51:89:ec]._workstation._tcp.local"
+    ],
+    [
+      "4500.000000",
+      "4500.000000"
+    ],
+    "F"
+  ]
+}
+{
+  "id": 0,
+  "value": [
+    "conn",
+    "1425565545.440378",
+    "CoJHyyAGilEHkRZJf",
+    "fe80::eef4:bbff:fe51:89ec",
+    "5353",
+    "ff02::fb",
+    "5353",
+    "udp",
+    "dns",
+    "",
+    "",
+    "",
+    "S0",
+    "F",
+    "F",
+    "0",
+    "D",
+    "1",
+    "93",
+    "0",
+    "0",
+    null
+  ]
+}
+```

--- a/pkg/zval/builder.go
+++ b/pkg/zval/builder.go
@@ -76,7 +76,7 @@ func (b *Builder) measure(off int) int {
 	return off + 1
 }
 
-func (b *Builder) encode(dst []byte, off int) ([]byte, int) {
+func (b *Builder) encode(dst []byte, off int) (Encoding, int) {
 	node := &b.nodes[off]
 	dfs := node.dfs
 	if dfs == beginContainer {
@@ -104,7 +104,7 @@ func (b *Builder) encode(dst []byte, off int) ([]byte, int) {
 	return AppendValue(dst, b.leaves[dfs]), off + 1
 }
 
-func (b *Builder) Encode() []byte {
+func (b *Builder) Encode() Encoding {
 	off := 0
 	for off < len(b.nodes) {
 		next := b.measure(off)

--- a/pkg/zval/encoding.go
+++ b/pkg/zval/encoding.go
@@ -12,6 +12,12 @@ package zval
 
 import (
 	"encoding/binary"
+	"errors"
+)
+
+var (
+	ErrNotContainer = errors.New("not a container")
+	ErrNotSingleton = errors.New("not a single container")
 )
 
 // Encoding is the serialized representation of zson values.
@@ -39,6 +45,25 @@ func (e Encoding) String() string {
 		}
 	}
 	return s
+}
+
+// Body returns the contents of an encoding that represents a container as
+// an encoding of the list of values.  If the encoding is not a container,
+// ErrNotContainer is returned.  If the encoding is not a single container,
+// ErrNotSingleton is returned.
+func (e Encoding) Body() (Encoding, error) {
+	it := Iter(e)
+	body, container, err := it.Next()
+	if err != nil {
+		return nil, err
+	}
+	if !container {
+		return nil, ErrNotContainer
+	}
+	if !it.Done() {
+		return nil, ErrNotSingleton
+	}
+	return body, nil
 }
 
 // AppendValue encodes each byte slice as a value Encoding, concatenates the


### PR DESCRIPTION
This commit implements readers and writers for sending
zson over json as ndjson.  This is a convenient format
for sending zson data to a native javascript client
(e.g., a web app).

Each value is sent as a JSON object with a field ("id") for
the descriptor id and a field ("value") that represents
an array of strings in zeek-escaped format.  The array
may contain sub-arrays of strings (and other sub-arrays)
if there are records inside of records, vectors, or sets.
If the id hasn't been transmitted previously in the stream,
then a third field ("type") encodes the zson type structure.