### PR TITLE
fix bug where ndjson writer would panic for bad zson data

### DIFF
--- a/pkg/zeek/record.go
+++ b/pkg/zeek/record.go
@@ -9,6 +9,8 @@ import (
 	"github.com/mccanne/zq/pkg/zval"
 )
 
+var ErrColumnMismatch = errors.New("zson record mismatch between columns in type and columns in value")
+
 type TypeRecord struct {
 	Columns []Column
 	Key     string
@@ -118,6 +120,9 @@ func (t *TypeRecord) New(value []byte) (Value, error) {
 	v, err := t.Parse(value)
 	if err != nil {
 		return nil, err
+	}
+	if len(v) != len(t.Columns) {
+		return nil, ErrColumnMismatch
 	}
 	return &Record{typ: t, values: v}, nil
 }


### PR DESCRIPTION
The ndjson parser would panic if the number of columns in the
values was smaller than the number of columns in the descriptor.
The fix is to return an error when creating a record value where
the values don't match the expected columns.