### PR TITLE
GitHub action to post event upon PR merges

### DIFF
--- a/.github/workflows/notify-pr-merge.yml
+++ b/.github/workflows/notify-pr-merge.yml
@@ -1,0 +1,20 @@
+name: Notify PR merge
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Populate "merged" variable
+      run: |
+        merged=$(cat $GITHUB_EVENT_PATH | jq '.pull_request.merged')
+        echo "::set-output name=merged::$merged"
+      id: vars
+    - name: Post PR closed event, if the close was a merge
+      if: steps.vars.outputs.merged == 'true'
+      run: |
+        cat $GITHUB_EVENT_PATH | jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.label, merge_commit_sha, number, title, url, "user": .user.login}}' > payload.json
+        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" https://api.github.com/repos/looky-cloud/boom/dispatches --data @payload.json


### PR DESCRIPTION
I developed this in a scratch personal repo and it was working there. Final step is to add the auth token as a secret to this repo.