### PR TITLE
Clarify sort behavior around unset / non-present values

### DIFF
--- a/pkg/zson/sort.go
+++ b/pkg/zson/sort.go
@@ -12,16 +12,25 @@ type SortFn func(a *Record, b *Record) int
 // Internal function that compares two values of compatible types.
 type comparefn func(a, b []byte) int
 
-func rawcompare(a, b []byte, dir int) int {
-	v := bytes.Compare(a, b)
-	if v < 0 {
-		return -dir
-	} else {
-		return dir
+func isUnset(typ zeek.Type, val []byte) bool {
+	if val == nil || zeek.SameType(typ, zeek.TypeNone) || zeek.SameType(typ, zeek.TypeUnset) {
+		return true
 	}
+	return false
 }
 
-func NewSortFn(dir int, fields ...string) SortFn {
+// NewSortFn() creates a function that compares a pair of Records
+// based on the provided ordered list of fields.
+// The returned function uses the same return conventions as standard
+// routines such as bytes.Compare() and strings.Compare(), so it may
+// be used with packages such as heap and sort.
+// A record in which one of the comparison fields is not present is
+// considered to be smaller than a record in which the field is present.
+// The handling of records in which a comparison field is unset is
+// governed by the unsetMax parameter.  If this parameter is true,
+// a record with unset is considered larger than a record with any other
+// value, and vice versa.
+func NewSortFn(unsetMax bool, fields ...string) SortFn {
 	sorters := make(map[*zeek.Type]comparefn)
 	return func(a *Record, b *Record) int {
 		for _, field := range fields {
@@ -29,20 +38,40 @@ func NewSortFn(dir int, fields ...string) SortFn {
 			valb, typeb, errb := b.Access(field)
 
 			// Errors indicate the field isn't present, sort
-			// these records last
+			// these records to the minimum value so they
+			// appear first in sort output.
 			if erra != nil && errb != nil { return 0 }
-			if erra != nil { return 1 }
-			if errb != nil { return -1 }
+			if erra != nil { return -1 }
+			if errb != nil { return 1 }
+
+			// Handle unset according to unsetMax
+			unsetA := isUnset(typea, vala)
+			unsetB := isUnset(typeb, valb)
+			if unsetA && unsetB { return 0 }
+			if unsetA {
+				if unsetMax {
+					return 1
+				} else {
+					return -1
+				}
+			}
+			if unsetB {
+				if unsetMax {
+					return -1
+				} else {
+					return 1
+				}
+			}
 
 			// If values are of different types, just compare
 			// the string representation of the type
 			if !zeek.SameType(typea, typeb) {
-				return rawcompare([]byte(typea.String()), []byte(typeb.String()), dir)
+				return bytes.Compare([]byte(typea.String()), []byte(typeb.String()))
 			}
 
 			sf, ok := sorters[&typea]
 			if !ok {
-				sf = lookupSorter(typea, dir)
+				sf = lookupSorter(typea)
 				sorters[&typea] = sf
 			}
 
@@ -102,34 +131,34 @@ func (s *RecordSlice) Index(i int) *Record {
 	return s.records[i]
 }
 
-func lookupSorter(typ zeek.Type, dir int) comparefn {
+func lookupSorter(typ zeek.Type) comparefn {
 	switch typ {
 	default:
 		return func(a, b []byte) int {
-			return rawcompare(a, b, dir)
+			return bytes.Compare(a, b)
 		}
 	case zeek.TypeBool:
 		return func(a, b []byte) int {
 			va, err := zeek.TypeBool.Parse(a)
 			if err != nil {
-				return -dir
+				return -1
 			}
 			vb, err := zeek.TypeBool.Parse(b)
 			if err != nil {
-				return dir
+				return 1
 			}
 			if va == vb {
 				return 0
 			}
 			if va {
-				return dir
+				return 1
 			}
-			return -dir
+			return -1
 		}
 
 	case zeek.TypeString, zeek.TypeEnum:
 		return func(a, b []byte) int {
-			return rawcompare(a, b, dir)
+			return bytes.Compare(a, b)
 		}
 
 	//XXX note zeek port type can have "/tcp" etc suffix according
@@ -140,16 +169,16 @@ func lookupSorter(typ zeek.Type, dir int) comparefn {
 		return func(a, b []byte) int {
 			va, err := zeek.TypeInt.Parse(a)
 			if err != nil {
-				return -dir
+				return -1
 			}
 			vb, err := zeek.TypeInt.Parse(b)
 			if err != nil {
-				return dir
+				return 1
 			}
 			if va < vb {
-				return -dir
+				return -1
 			} else if va > vb {
-				return dir
+				return 1
 			}
 			return 0
 		}
@@ -158,16 +187,16 @@ func lookupSorter(typ zeek.Type, dir int) comparefn {
 		return func(a, b []byte) int {
 			va, err := zeek.TypeDouble.Parse(a)
 			if err != nil {
-				return -dir
+				return -1
 			}
 			vb, err := zeek.TypeDouble.Parse(b)
 			if err != nil {
-				return dir
+				return 1
 			}
 			if va < vb {
-				return -dir
+				return -1
 			} else if va > vb {
-				return dir
+				return 1
 			}
 			return 0
 		}
@@ -176,16 +205,16 @@ func lookupSorter(typ zeek.Type, dir int) comparefn {
 		return func(a, b []byte) int {
 			va, err := zeek.TypeTime.Parse(a)
 			if err != nil {
-				return -dir
+				return -1
 			}
 			vb, err := zeek.TypeTime.Parse(b)
 			if err != nil {
-				return dir
+				return 1
 			}
 			if va < vb {
-				return -dir
+				return -1
 			} else if va > vb {
-				return dir
+				return 1
 			}
 			return 0
 		}
@@ -194,13 +223,13 @@ func lookupSorter(typ zeek.Type, dir int) comparefn {
 		return func(a, b []byte) int {
 			va, err := zeek.TypeAddr.Parse(a)
 			if err != nil {
-				return -dir
+				return -1
 			}
 			vb, err := zeek.TypeAddr.Parse(b)
 			if err != nil {
-				return dir
+				return 1
 			}
-			return bytes.Compare(va.To16(), vb.To16()) * dir
+			return bytes.Compare(va.To16(), vb.To16())
 		}
 	}
 }

--- a/proc/sort.go
+++ b/proc/sort.go
@@ -97,7 +97,10 @@ func (s *Sort) sort() zson.Batch {
 	if s.fields == nil {
 		s.fields = []string{guessSortField(out[0])}
 	}
-	sorter := zson.NewSortFn(s.dir, s.fields...)
-	zson.SortStable(out, sorter)
+	sorter := zson.NewSortFn(true, s.fields...)
+	sortWithDir := func(a, b *zson.Record) int {
+		return s.dir * sorter(a, b)
+	}
+	zson.SortStable(out, sortWithDir)
 	return zson.NewArray(out, nano.NewSpanTs(s.MinTs, s.MaxTs))
 }

--- a/proc/sort_test.go
+++ b/proc/sort_test.go
@@ -96,6 +96,11 @@ const sortedStrings = `
 1:[zzz;]
 `
 
+// A point that can be included with unsortedInts
+const unsetInt = `
+0:[-;]
+`
+
 // Some records that don't include the field "foo".  These are combined
 // with sets that include foo to test mixed records.
 const nofoo = `
@@ -187,6 +192,9 @@ func TestSort(t *testing.T) {
 
 	// Test sorting strings.
 	testOne(t, unsortedStrings, sortedStrings, 1000, fooCol, 1)
+
+	// Test that unset values are sorted to the end
+	testOne(t, unsortedInts + unsetInt, ascendingInts + unsetInt, 1000, fooCol, 1)
 
 	// Test sorting records that don't all have the requested field.
 	// XXX sort.Stable() is apparently re-ordering the nofoo records?

--- a/proc/top.go
+++ b/proc/top.go
@@ -60,8 +60,7 @@ func (s *Top) consume(rec *zson.Record) {
 		s.fields = []string{guessSortField(rec)}
 	}
 	if s.records == nil {
-		// 1 == MaxHeap
-		s.sorter = zson.NewSortFn(1, s.fields...)
+		s.sorter = zson.NewSortFn(false, s.fields...)
 		s.records = zson.NewRecordSlice(s.sorter)
 		heap.Init(s.records)
 	}


### PR DESCRIPTION
Clean up the code used by sort and top when handling records that are
missing a sort field or that have the unset value.  Also add another
simple test case to the sort tests.  The sort proc could still use some
love w.r.t. defining behavior in these cases (especially in conjunction
with the -r flag) but that can wait.