### PR TITLE
remove limit from table writer

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -3,10 +3,8 @@ package emitter
 import (
 	"fmt"
 	"io"
-	"os"
 	"time"
 
-	"github.com/mccanne/zq/pkg/zsio/table"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/proc"
 )
@@ -28,12 +26,7 @@ func (e *Emitter) SetWarningsWriter(w io.Writer) {
 
 func (e *Emitter) send(cid int, arr zson.Batch) error {
 	for _, r := range arr.Records() {
-		err := e.writer.Write(r)
-		if err == table.ErrTooManyLines {
-			fmt.Fprintln(os.Stderr, "output table too big")
-			os.Exit(1)
-		}
-		if err != nil {
+		if err := e.writer.Write(r); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The table writer previously would exit with an error when too 
many limes were encountered.

Instead of quitting, when the table writer reaches it limits, it
simply flushes its output and starts writing again.  This means
long outputs will periodically generate column headers.

The table writer does the same thing when the descriptor changes as
the header is no longerr consistent with the data.  So it flushes the
current data and writes a new header.