### PR TITLE
add support for control messages carried in zson.Record

### DIFF
--- a/pkg/zsio/raw/header.go
+++ b/pkg/zsio/raw/header.go
@@ -23,7 +23,7 @@ import (
 const (
 	TypeDescriptor = iota
 	TypeValue
-	TypeComment
+	TypeControl
 )
 
 const (
@@ -55,7 +55,7 @@ func writeHeader(w io.Writer, typ, ch, id, length int) (int, error) {
 	if ch != 0 {
 		off += binary.PutUvarint(hdr[off:], uint64(ch))
 	}
-	if typ != TypeComment {
+	if typ != TypeControl {
 		off += binary.PutUvarint(hdr[off:], uint64(id))
 	}
 	off += binary.PutUvarint(hdr[off:], uint64(length))
@@ -82,7 +82,7 @@ func parseHeader(b []byte, h *header) (int, error) {
 	}
 	typ &= TypeMask
 	h.typ = typ
-	if typ != TypeComment {
+	if typ != TypeControl {
 		id, n := binary.Uvarint(b[off:])
 		if n <= 0 {
 			return 0, zson.ErrBadFormat

--- a/pkg/zsio/raw/reader.go
+++ b/pkg/zsio/raw/reader.go
@@ -62,7 +62,7 @@ again:
 			return nil, err
 		}
 		return rec, nil
-	case TypeComment:
+	case TypeControl:
 		if r.ctrl {
 			return zson.NewControlRecord(b), nil
 		}

--- a/pkg/zsio/raw/reader.go
+++ b/pkg/zsio/raw/reader.go
@@ -1,6 +1,7 @@
 package raw
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/mccanne/zq/pkg/nano"
@@ -18,6 +19,7 @@ const (
 type Reader struct {
 	peeker *peeker.Reader
 	mapper *resolver.Mapper
+	ctrl   bool
 }
 
 func NewReader(reader io.Reader, r *resolver.Table) *Reader {
@@ -25,6 +27,12 @@ func NewReader(reader io.Reader, r *resolver.Table) *Reader {
 		peeker: peeker.NewReader(reader, ReadSize, MaxSize),
 		mapper: resolver.NewMapper(r),
 	}
+}
+
+func NewControlReader(reader io.Reader, t *resolver.Table) *Reader {
+	r := NewReader(reader, t)
+	r.ctrl = true
+	return r
 }
 
 func (r *Reader) Read() (*zson.Record, error) {
@@ -54,9 +62,13 @@ again:
 			return nil, err
 		}
 		return rec, nil
-	default:
-		// skip over control comments
+	case TypeComment:
+		if r.ctrl {
+			return zson.NewControlRecord(b), nil
+		}
 		goto again
+	default:
+		return nil, fmt.Errorf("unknown raw record type: %d", hdr.typ)
 	}
 
 }

--- a/pkg/zsio/raw/writer.go
+++ b/pkg/zsio/raw/writer.go
@@ -21,7 +21,7 @@ func NewWriter(w io.Writer) *Writer {
 
 func (w *Writer) WriteValue(ch int, r *zson.Record) error {
 	if r.IsControl() {
-		return w.WriteComment(r.Raw)
+		return w.WriteControl(r.Raw)
 	}
 	id := r.Descriptor.ID
 	if !w.tracker.Seen(id) {
@@ -37,8 +37,8 @@ func (w *Writer) Write(r *zson.Record) error {
 	return w.WriteValue(0, r)
 }
 
-func (w *Writer) WriteComment(b []byte) error {
-	return w.encode(TypeComment, 0, 0, b)
+func (w *Writer) WriteControl(b []byte) error {
+	return w.encode(TypeControl, 0, 0, b)
 }
 
 func (w *Writer) encode(typ, ch, id int, b []byte) error {

--- a/pkg/zsio/raw/writer.go
+++ b/pkg/zsio/raw/writer.go
@@ -14,12 +14,15 @@ type Writer struct {
 
 func NewWriter(w io.Writer) *Writer {
 	return &Writer{
-		Writer: w,
-		tracker:     resolver.NewTracker(),
+		Writer:  w,
+		tracker: resolver.NewTracker(),
 	}
 }
 
 func (w *Writer) WriteValue(ch int, r *zson.Record) error {
+	if r.IsControl() {
+		return w.WriteComment(r.Raw)
+	}
 	id := r.Descriptor.ID
 	if !w.tracker.Seen(id) {
 		b := []byte(r.Descriptor.Type.String())

--- a/pkg/zsio/zson/writer.go
+++ b/pkg/zsio/zson/writer.go
@@ -5,18 +5,19 @@ import (
 	"io"
 
 	"github.com/mccanne/zq/pkg/zson"
+	"github.com/mccanne/zq/pkg/zson/resolver"
 	"github.com/mccanne/zq/pkg/zval"
 )
 
 type Writer struct {
 	io.Writer
-	descriptors map[int]struct{}
+	tracker *resolver.Tracker
 }
 
 func NewWriter(w io.Writer) *Writer {
 	return &Writer{
-		Writer:      w,
-		descriptors: make(map[int]struct{}),
+		Writer:  w,
+		tracker: resolver.NewTracker(),
 	}
 }
 
@@ -27,9 +28,7 @@ func (w *Writer) Write(r *zson.Record) error {
 
 	}
 	td := r.Descriptor.ID
-	_, ok := w.descriptors[td]
-	if !ok {
-		w.descriptors[td] = struct{}{}
+	if !w.tracker.Seen(td) {
 		_, err := fmt.Fprintf(w.Writer, "#%d:%s\n", td, r.Descriptor.Type)
 		if err != nil {
 			return err

--- a/pkg/zsio/zson/writer.go
+++ b/pkg/zsio/zson/writer.go
@@ -21,6 +21,11 @@ func NewWriter(w io.Writer) *Writer {
 }
 
 func (w *Writer) Write(r *zson.Record) error {
+	if r.IsControl() {
+		_, err := fmt.Fprintf(w.Writer, "#!%s\n", string(r.Raw.Bytes()))
+		return err
+
+	}
 	td := r.Descriptor.ID
 	_, ok := w.descriptors[td]
 	if !ok {

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -56,7 +56,7 @@ Regular directives have just three forms, each with a corresponding structure.
 |---------------|-------------------------------------|
 | Descriptor    | `#<int>:<type>`                     |
 | Ordering hint | `#sort [+-]<field>,[+-]<field>,...` |
-| Comment       | `#!<comment>`                       |
+| Control       | `#!<payload>`                       |
 
 ### Descriptor Directive
 
@@ -100,24 +100,24 @@ subsequent key for values that have previous keys of equal value.
 It is an error for any such values to appear that contradicts the most
 recent ordering directives.
 
-### Comment Directive
+### Control Directive
 
-The comment directive has the following structure:
+The control directive has the following structure:
 ```
-#!<comment-text>
+#!<control-text>
 ```
-Comments may be used informatively and shall be
+Control may be used informatively and shall be
 ignored by any data receivers.
-`<comment-text>` can be any UTF-8 string exclusive of newline.
-Comments are guaranteed to be preserved
+`<control-text>` can be any UTF-8 string exclusive of newline.
+Control payloads are guaranteed to be preserved
 in order within the stream and presented to higher layer components through
 any ZSON parsing API.  In this way, senders and receivers of ZSON can embed
-protocol directives as ZSON comments rather than defining additional
+protocol directives as ZSON control payloads rather than defining additional
 encapsulating protocols.  See the
 [zson-over-http](zson-over-http.md) protocol for an example.
 
-A comment directive may also be used to resume the interpretation of line values
-as regular values instead of legacy values (as there is no legacy comment directive).
+A control directive may also be used to resume the interpretation of line values
+as regular values instead of legacy values (as there is no legacy control directive).
 
 ### Type Grammar
 

--- a/pkg/zson/record.go
+++ b/pkg/zson/record.go
@@ -31,6 +31,7 @@ type Record struct {
 	Ts nano.Ts
 	*Descriptor
 	nonvolatile bool
+	ctrl        bool
 	// Raw is the serialization format for zson records.  A raw value comprises a
 	// sequence of zvals, one per descriptor column.  The descriptor is stored
 	// outside of the raw serialization but is needed to interpret the raw values.
@@ -45,6 +46,19 @@ func NewRecord(d *Descriptor, ts nano.Ts, raw zval.Encoding) *Record {
 		nonvolatile: true,
 		Raw:         raw,
 	}
+}
+
+// NewControlRecord creates a control record from a byte slice.
+func NewControlRecord(raw []byte) *Record {
+	return &Record{
+		nonvolatile: true,
+		ctrl:        true,
+		Raw:         raw,
+	}
+}
+
+func (r *Record) IsControl() bool {
+	return r.ctrl
 }
 
 // NewVolatileRecord creates a record from a timestamp and a raw value

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -33,7 +33,7 @@ func (s *Scanner) Pull() (zson.Batch, error) {
 		if rec == nil {
 			break
 		}
-		if match != nil && !match(rec) {
+		if rec.IsControl() || (match != nil && !match(rec)) {
 			continue
 		}
 		if rec.Ts < minTs {


### PR DESCRIPTION
This commit allows for control messages (aka zson commentds)
to be carried in zson.Records and read/write to zson text and
raw formats.

Such records are not allowed into the proc flowgraph.

This mechanism is useful for higher layers to embed control
and signaling into a stream of raw zson records.  For example,
zson over http uses these messages to provide end-to-end
reliability semantics.