### PR TITLE
Fix rawcompare()

### DIFF
--- a/pkg/zson/sort.go
+++ b/pkg/zson/sort.go
@@ -14,9 +14,12 @@ type comparefn func(a, b []byte) int
 
 func rawcompare(a, b []byte, dir int) int {
 	v := bytes.Compare(a, b)
-	if v < 0 {
+	switch {
+	case v == 0:
+		return 0
+	case v < 0:
 		return -dir
-	} else {
+	default:
 		return dir
 	}
 }


### PR DESCRIPTION
rawcompare() was pretty badly broken in that it didn't return 0
for two equal inputs.