### PR TITLE
add channel to zson spec, misc refactor

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -20,12 +20,21 @@ func NewEmitter(w zson.Writer) *Emitter {
 	}
 }
 
-func (e *Emitter) SetWarningsWriter(w io.Writer) {
+func unknownFormat(format string) error {
+	return fmt.Errorf("unknown output format: %s", format)
+}
+
+func (e *Emitter) SetWarnaingsWriter(w io.Writer) {
 	e.warnings = w
 }
 
-func (e *Emitter) send(cid int, arr zson.Batch) error {
+func (e *Emitter) Write(cid int, arr zson.Batch) error {
 	for _, r := range arr.Records() {
+		// for cid < 0, we keep the Channel that's already in
+		// the record
+		if cid >= 0 {
+			r.Channel = uint16(cid)
+		}
 		if err := e.writer.Write(r); err != nil {
 			return err
 		}
@@ -33,7 +42,7 @@ func (e *Emitter) send(cid int, arr zson.Batch) error {
 	return nil
 }
 
-func (e *Emitter) writeWarnings(msg string) error {
+func (e *Emitter) WriteWarning(msg string) error {
 	_, err := fmt.Fprintln(e.warnings, msg)
 	if err != nil {
 		return err
@@ -41,17 +50,7 @@ func (e *Emitter) writeWarnings(msg string) error {
 	return nil
 }
 
-func (e *Emitter) handle(res proc.MuxResult) error {
-	if res.Warning != "" {
-		e.writeWarnings(res.Warning)
-		return nil
-	}
-	if res.Batch != nil {
-		return e.send(res.ID, res.Batch)
-	}
-	return nil
-}
-
+//XXX this goes somewhere else
 func (e *Emitter) Run(out *proc.MuxOutput) error {
 	for !out.Complete() {
 		res := out.Pull(time.After(time.Second * 10))
@@ -61,8 +60,13 @@ func (e *Emitter) Run(out *proc.MuxOutput) error {
 		if res.Err != nil {
 			return res.Err
 		}
-		if err := e.handle(res); err != nil {
-			return err
+		if res.Warning != "" {
+			e.WriteWarning(res.Warning)
+		}
+		if res.Batch != nil {
+			if err := e.Write(res.ID, res.Batch); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -1,12 +1,12 @@
 package emitter
 
 import (
-	"fmt"
 	"io"
 	"os"
 
 	"github.com/mccanne/zq/pkg/bufwriter"
 	"github.com/mccanne/zq/pkg/zsio"
+	"github.com/mccanne/zq/pkg/zsio/text"
 )
 
 type noClose struct {
@@ -17,7 +17,7 @@ func (p *noClose) Close() error {
 	return nil
 }
 
-func OpenOutputFile(format, path string) (*zsio.Writer, error) {
+func NewFile(path, format string, tc *text.Config) (*zsio.Writer, error) {
 	var f io.WriteCloser
 	if path == "" {
 		// Don't close stdout in case we live inside something
@@ -35,9 +35,9 @@ func OpenOutputFile(format, path string) (*zsio.Writer, error) {
 	// On close, zsio.Writer.Close(), the zson WriteFlusher will be flushed
 	// then the bufwriter will closed (which will flush it's internal buffer
 	// then close the file)
-	w := zsio.LookupWriter(format, bufwriter.New(f))
+	w := zsio.LookupWriter(format, bufwriter.New(f), tc)
 	if w == nil {
-		return nil, fmt.Errorf("no such format: %s", format)
+		return nil, unknownFormat(format)
 	}
 	return w, nil
 }

--- a/pkg/zsio/raw/reader.go
+++ b/pkg/zsio/raw/reader.go
@@ -61,10 +61,13 @@ again:
 		if err != nil {
 			return nil, err
 		}
+		rec.Channel = uint16(hdr.ch)
 		return rec, nil
 	case TypeControl:
 		if r.ctrl {
-			return zson.NewControlRecord(b), nil
+			rec := zson.NewControlRecord(b)
+			rec.Channel = uint16(hdr.ch)
+			return rec, nil
 		}
 		goto again
 	default:

--- a/pkg/zsio/raw/writer.go
+++ b/pkg/zsio/raw/writer.go
@@ -21,7 +21,7 @@ func NewWriter(w io.Writer) *Writer {
 
 func (w *Writer) WriteValue(ch int, r *zson.Record) error {
 	if r.IsControl() {
-		return w.WriteControl(r.Raw)
+		return w.WriteControl(ch, r.Raw)
 	}
 	id := r.Descriptor.ID
 	if !w.tracker.Seen(id) {
@@ -34,11 +34,11 @@ func (w *Writer) WriteValue(ch int, r *zson.Record) error {
 }
 
 func (w *Writer) Write(r *zson.Record) error {
-	return w.WriteValue(0, r)
+	return w.WriteValue(int(r.Channel), r)
 }
 
-func (w *Writer) WriteControl(b []byte) error {
-	return w.encode(TypeControl, 0, 0, b)
+func (w *Writer) WriteControl(ch int, b []byte) error {
+	return w.encode(TypeControl, ch, 0, b)
 }
 
 func (w *Writer) encode(typ, ch, id int, b []byte) error {

--- a/pkg/zsio/zsio.go
+++ b/pkg/zsio/zsio.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mccanne/zq/pkg/zsio/ndjson"
 	"github.com/mccanne/zq/pkg/zsio/raw"
 	"github.com/mccanne/zq/pkg/zsio/table"
+	"github.com/mccanne/zq/pkg/zsio/text"
 	"github.com/mccanne/zq/pkg/zsio/zeek"
 	"github.com/mccanne/zq/pkg/zsio/zjson"
 	zsonio "github.com/mccanne/zq/pkg/zsio/zson"
@@ -34,7 +35,7 @@ func (w *Writer) Close() error {
 	return err
 }
 
-func LookupWriter(format string, w io.WriteCloser) *Writer {
+func LookupWriter(format string, w io.WriteCloser, tc *text.Config) *Writer {
 	var f zson.WriteFlusher
 	switch format {
 	default:
@@ -47,9 +48,8 @@ func LookupWriter(format string, w io.WriteCloser) *Writer {
 		f = zson.NopFlusher(ndjson.NewWriter(w))
 	case "zjson":
 		f = zson.NopFlusher(zjson.NewWriter(w))
-	// XXX not yet
-	//case "text":
-	//	return text.NewWriter(f, c.showTypes, c.showFields, c.epochDates)
+	case "text":
+		f = zson.NopFlusher(text.NewWriter(w, tc))
 	case "table":
 		f = table.NewWriter(w)
 	case "raw":
@@ -73,4 +73,25 @@ func LookupReader(format string, r io.Reader, table *resolver.Table) zson.Reader
 		return raw.NewReader(r, table)
 	}
 	return nil
+}
+
+func Extension(format string) string {
+	switch format {
+	case "zson":
+		return ".zson"
+	case "zeek":
+		return ".log"
+	case "ndjson":
+		return ".ndjson"
+	case "zjson":
+		return ".zjson"
+	case "text":
+		return ".txt"
+	case "table":
+		return ".tbl"
+	case "raw":
+		return ".raw"
+	default:
+		return ""
+	}
 }

--- a/pkg/zsio/zson/writer.go
+++ b/pkg/zsio/zson/writer.go
@@ -34,7 +34,13 @@ func (w *Writer) Write(r *zson.Record) error {
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w.Writer, "%d:", td)
+	var err error
+	if r.Channel == 0 {
+		_, err = fmt.Fprintf(w.Writer, "%d:", td)
+
+	} else {
+		_, err = fmt.Fprintf(w.Writer, "%d.%d:", td, r.Channel)
+	}
 	if err != nil {
 		return nil
 	}

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -187,9 +187,10 @@ declared `record` types:
 ## Regular Values
 
 A regular value is encoded on a line as a type descriptor followed by `:` followed
-by a value encoding.  Here is a pseudo-grammar for value encodings:
+by a value encoding.  The descriptor may include an option channel identifier via dotted
+notation.  Here is a pseudo-grammar for value encodings:
 ```
-<line> := <descriptor> : <elem>
+<line> := <descriptor>(.<ch>)? : <elem>
 <elem> :=
           <terminal> ;
         | [ <list> ]
@@ -203,6 +204,10 @@ by a value encoding.  Here is a pseudo-grammar for value encodings:
 ```
 
 [1] - [JavaScript character escaping rules](https://tc39.es/ecma262/#prod-EscapeSequence)
+
+A channel is a 16-bit integer used to indicate sub-streams of values within the zson stream.
+This is useful, for example, when analytics performs two or computations on the 
+same input data resulting in multiple output streams.
 
 A terminal value is encoded as a string of UTF-8 characters terminated
 by a semicolon (which must be escaped if it appears in the value).  A composite
@@ -262,7 +267,7 @@ two descriptors then uses them in three values:
 #2:record[a:string,b:string]
 1:hello, world;
 2:[hello;world;]
-1:this is a semicolon: \x3b;
+1.3:this is a semicolon: \x3b;
 ```
 which represents a stream of the following three values:
 ```
@@ -270,6 +275,7 @@ string("hello, world")
 record(a:"hello",b:"world")
 string("this is a semicolon: ;")
 ```
+The last value signals a channel identifier of 3.
 
 The semicolon terminator is important.  Consider this ZSON depicting
 sets of strings:

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -206,8 +206,9 @@ notation.  Here is a pseudo-grammar for value encodings:
 [1] - [JavaScript character escaping rules](https://tc39.es/ecma262/#prod-EscapeSequence)
 
 A channel is a 16-bit integer used to indicate sub-streams of values within the zson stream.
-This is useful, for example, when analytics performs two or computations on the 
-same input data resulting in multiple output streams.
+This is useful, for example, when analytics performs two or more computations on the
+same input data resulting in multiple result streams that are multiplexed onto a single 
+zson stream.
 
 A terminal value is encoded as a string of UTF-8 characters terminated
 by a semicolon (which must be escaped if it appears in the value).  A composite

--- a/pkg/zson/record.go
+++ b/pkg/zson/record.go
@@ -32,6 +32,7 @@ type Record struct {
 	*Descriptor
 	nonvolatile bool
 	ctrl        bool
+	Channel     uint16
 	// Raw is the serialization format for zson records.  A raw value comprises a
 	// sequence of zvals, one per descriptor column.  The descriptor is stored
 	// outside of the raw serialization but is needed to interpret the raw values.
@@ -126,7 +127,7 @@ func (r *Record) Keep() *Record {
 	if r.nonvolatile {
 		return r
 	}
-	v := &Record{Ts: r.Ts, Descriptor: r.Descriptor, nonvolatile: true}
+	v := &Record{Ts: r.Ts, Descriptor: r.Descriptor, nonvolatile: true, Channel: r.Channel}
 	v.Raw = make(zval.Encoding, len(r.Raw))
 	copy(v.Raw, r.Raw)
 	return v


### PR DESCRIPTION
This commit is a bit of a potpourri.  First, it adds the channel
abstraction to the zson spec and implementation so that channel IDs
can be attached each record both in the stream and internally.

Second, it revives the text writer so one can print output
the concise text format when perusing data.

Third, it refactors the emitter package to make it a bit easier
to re-use externally.