### PR TITLE
add type checking of record type with value

### DIFF
--- a/pkg/zsio/detector/reader.go
+++ b/pkg/zsio/detector/reader.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mccanne/zq/pkg/zson/resolver"
 )
 
-var ErrUnknown = errors.New("input format not recognized")
+var ErrUnknown = errors.New("malformed input")
 
 func NewReader(r io.Reader, t *resolver.Table) (zson.Reader, error) {
 	recorder := NewRecorder(r)

--- a/pkg/zsio/ndjson/reader.go
+++ b/pkg/zsio/ndjson/reader.go
@@ -50,5 +50,5 @@ again:
 		return nil, err
 	}
 	desc := r.resolver.GetByColumns(typ.(*zeek.TypeRecord).Columns)
-	return zson.NewRecord(desc, 0, raw), nil
+	return zson.NewRecordCheck(desc, 0, raw)
 }

--- a/pkg/zsio/raw/reader.go
+++ b/pkg/zsio/raw/reader.go
@@ -99,6 +99,9 @@ func (r *Reader) parseValue(id int, b []byte) (*zson.Record, error) {
 		return nil, zson.ErrDescriptorInvalid
 	}
 	record := zson.NewVolatileRecord(descriptor, nano.MinTs, b)
+	if !record.TypeCheck() {
+		return nil, zson.ErrTypeMismatch
+	}
 	//XXX this should go in NewRecord?
 	ts, err := record.AccessTime("ts")
 	if err == nil {

--- a/pkg/zsio/zjson/reader.go
+++ b/pkg/zsio/zjson/reader.go
@@ -118,7 +118,10 @@ func (r *Reader) parseValues(id int, values []interface{}) (*zson.Record, error)
 		//XXX need better error here... this won't make much sense
 		return nil, err
 	}
-	record := zson.NewRecord(descriptor, nano.MinTs, zv)
+	record, err := zson.NewRecordCheck(descriptor, nano.MinTs, zv)
+	if err != nil {
+		return nil, err
+	}
 	//XXX this should go in NewRecord?
 	ts, err := record.AccessTime("ts")
 	if err == nil {

--- a/pkg/zsio/zson/reader.go
+++ b/pkg/zsio/zson/reader.go
@@ -195,7 +195,7 @@ func (r *Reader) parseValue(line []byte) (*zson.Record, error) {
 		return nil, err
 	}
 
-	record, err := zson.NewRecord(descriptor, nano.MinTs, raw), nil
+	record, err := zson.NewRecordCheck(descriptor, nano.MinTs, raw)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit adds type checking to the reader path to make sure 
the container structure of an incoming value matches its type descriptor.