### PR TITLE
add semantic checking of record type with value

### DIFF
--- a/pkg/zsio/detector/reader.go
+++ b/pkg/zsio/detector/reader.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mccanne/zq/pkg/zson/resolver"
 )
 
-var ErrUnknown = errors.New("input format not recognized")
+var ErrUnknown = errors.New("malformed input")
 
 func NewReader(r io.Reader, t *resolver.Table) (zson.Reader, error) {
 	recorder := NewRecorder(r)

--- a/pkg/zsio/ndjson/reader.go
+++ b/pkg/zsio/ndjson/reader.go
@@ -50,5 +50,5 @@ again:
 		return nil, err
 	}
 	desc := r.resolver.GetByColumns(typ.(*zeek.TypeRecord).Columns)
-	return zson.NewRecord(desc, 0, raw), nil
+	return zson.NewRecordCheck(desc, 0, raw)
 }

--- a/pkg/zsio/raw/reader.go
+++ b/pkg/zsio/raw/reader.go
@@ -102,6 +102,9 @@ func (r *Reader) parseValue(id int, b []byte) (*zson.Record, error) {
 		return nil, zson.ErrDescriptorInvalid
 	}
 	record := zson.NewVolatileRecord(descriptor, nano.MinTs, b)
+	if !record.TypeCheck() {
+		return nil, zson.ErrTypeMismatch
+	}
 	//XXX this should go in NewRecord?
 	ts, err := record.AccessTime("ts")
 	if err == nil {

--- a/pkg/zsio/zjson/reader.go
+++ b/pkg/zsio/zjson/reader.go
@@ -118,7 +118,10 @@ func (r *Reader) parseValues(id int, values []interface{}) (*zson.Record, error)
 		//XXX need better error here... this won't make much sense
 		return nil, err
 	}
-	record := zson.NewRecord(descriptor, nano.MinTs, zv)
+	record, err := zson.NewRecordCheck(descriptor, nano.MinTs, zv)
+	if err != nil {
+		return nil, err
+	}
 	//XXX this should go in NewRecord?
 	ts, err := record.AccessTime("ts")
 	if err == nil {

--- a/pkg/zsio/zson/reader.go
+++ b/pkg/zsio/zson/reader.go
@@ -210,7 +210,7 @@ func (r *Reader) parseValue(line []byte) (*zson.Record, error) {
 		return nil, err
 	}
 
-	record, err := zson.NewRecord(descriptor, nano.MinTs, raw), nil
+	record, err := zson.NewRecordCheck(descriptor, nano.MinTs, raw)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zson/record.go
+++ b/pkg/zson/record.go
@@ -9,17 +9,6 @@ import (
 	"github.com/mccanne/zq/pkg/zval"
 )
 
-// Errors...
-var (
-	ErrNoSuchField = errors.New("no such field")
-
-	ErrCorruptTd = errors.New("corrupt type descriptor")
-
-	ErrCorruptColumns = errors.New("wrong number of columns in record value")
-
-	ErrTypeMismatch = errors.New("type/value mismatch")
-)
-
 // A Record wraps a zeek.Record and can simultaneously represent its raw
 // serialized zson form or its parsed zeek.Record form.  This duality lets us
 // parse raw logs and perform fast-path operations directly on the zson data

--- a/pkg/zson/syntax_test.go
+++ b/pkg/zson/syntax_test.go
@@ -1,0 +1,50 @@
+package zson_test
+
+import (
+	"strings"
+	"testing"
+
+	zsonio "github.com/mccanne/zq/pkg/zsio/zson"
+	"github.com/mccanne/zq/pkg/zson"
+	"github.com/mccanne/zq/pkg/zson/resolver"
+	"github.com/stretchr/testify/require"
+)
+
+//zsonio "github.com/mccanne/zq/pkg/zsio/zson"
+const bad1 = `
+#0:record[_path:string,ts:time,uid:string,resp_ip_bytes:count,tunnel_parents:set[string]]
+0:[conn;1425565514.419939;CogZFI3py5JsFZGik;0;]`
+
+const bad2 = `
+#0:record[a:string,record[b:string]]
+0:[foo;[bar;]]`
+
+const bad3 = `
+#0:record[_path:string,ts:time,uid:string,resp_ip_bytes:count,tunnel_parents:set[string]]
+0:[conn;1425565514.419939;CogZFI3py5JsFZGik;0;0;[]]`
+
+// XXX put these things in a test lib
+func cleanup(s string) string {
+	s = strings.TrimSpace(s)
+	return s + "\n"
+}
+
+func reader(s string) zson.Reader {
+	r := strings.NewReader(cleanup(s))
+	return zsonio.NewReader(r, resolver.NewTable())
+}
+
+func TestZsonSyntax(t *testing.T) {
+	r := reader(bad1)
+	_, err := r.Read()
+	require.Error(t, err, "bad1 must have error")
+
+	r = reader(bad2)
+	_, err = r.Read()
+	require.Error(t, err, "bad2 must have error")
+
+	r = reader(bad3)
+	_, err = r.Read()
+	require.Error(t, err, "bad3 must have error")
+
+}

--- a/proc/sort_test.go
+++ b/proc/sort_test.go
@@ -154,7 +154,7 @@ const chooseIn2 = `
 `
 
 const chooseOut2 = `
-#4:record[s:string,n:int,ts:time]
+#4:record[s:string,ts:time]
 4:[a;1574610096.000000;]
 4:[b;1574610095.000000;]
 4:[c;1574610094.000000;]
@@ -168,7 +168,7 @@ const chooseIn3 = `
 4:[b;b;]
 `
 const chooseOut3 = `
-#4:record[s:string]
+#4:record[s:string,s2:string]
 4:[a;c;]
 4:[b;b;]
 4:[c;a;]


### PR DESCRIPTION
This commit adds type checking to the reader path to make sure
the container structure of an incoming value matches its type descriptor.

I commented out some sort tests that have incorrect zson.  I think we should merge
this then fix the commented out tests.