### PR TITLE
fix bug in group-by after restructuring its implementation

### DIFF
--- a/pkg/zson/resolver/mapper.go
+++ b/pkg/zson/resolver/mapper.go
@@ -29,3 +29,7 @@ func (m *Mapper) Enter(td int, typ *zeek.TypeRecord) *zson.Descriptor {
 	}
 	return nil
 }
+
+func (m *Mapper) EnterDescriptor(td int, d *zson.Descriptor) {
+	m.enter(td, d)
+}

--- a/pkg/zval/encoding.go
+++ b/pkg/zval/encoding.go
@@ -32,14 +32,14 @@ func (e Encoding) Iter() Iter {
 }
 
 func (e Encoding) String() string {
-	b, err := e.build(nil)
+	b, err := e.Build(nil)
 	if err != nil {
 		panic("zval encoding has bad format: " + err.Error())
 	}
 	return string(b)
 }
 
-func (e Encoding) build(b []byte) ([]byte, error) {
+func (e Encoding) Build(b []byte) ([]byte, error) {
 	for it := Iter(e); !it.Done(); {
 		v, container, err := it.Next()
 		if err != nil {
@@ -47,7 +47,7 @@ func (e Encoding) build(b []byte) ([]byte, error) {
 		}
 		if container {
 			b = append(b, '[')
-			b, err = v.build(b)
+			b, err = v.Build(b)
 			if err != nil {
 				return nil, err
 			}

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -362,7 +362,7 @@ func (g *GroupByAggregator) recordsForTable(table map[string]*GroupByRow) []*zso
 	}
 	// XXX get rid of [4:]
 	// This sort skips over the first 4 bytes which comprise the descriptor ID
-	sort.Slice(keys, func(i, j int) bool { return keys[i][4:] > keys[j][4:] })
+	sort.Slice(keys, func(i, j int) bool { return keys[i][0:] > keys[j][0:] })
 
 	n := len(g.keys) + len(g.reducerDefs)
 	if g.TimeBinDuration > 0 {

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -126,7 +126,7 @@ func NewGroupByAggregator(c *Context, params GroupByParams) *GroupByAggregator {
 		dt:          c.Resolver,
 		reducerDefs: params.reducers,
 		// keysMap maps an input descriptor to a descriptor
-		// representing the grou-by key columns.
+		// representing the group-by key columns.
 		keysMap:         resolver.NewMapper(resolver.NewTable()),
 		tables:          make(map[nano.Ts]map[string]*GroupByRow),
 		TimeBinDuration: dur,

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -349,10 +349,22 @@ func typeMatch(typeCol []zeek.TypedEncoding, rowkeys []zeek.TypedEncoding) bool 
 // recordsForTable returns a slice of records with one record per table entry in a
 // deterministic but undefined order.
 func (g *GroupByAggregator) recordsForTable(table map[string]*GroupByRow) []*zson.Record {
+
+	// XXX get rid of this
+	oldtable := table
+	table = make(map[string]*GroupByRow)
+	for key, val := range oldtable {
+		zv := zval.Encoding(key[4:])
+		oldkey := zv.String()
+		table[oldkey] = val
+	}
+	// ^^^ get rid of this
+
 	var keys []string
 	for k := range table {
 		keys = append(keys, k)
 	}
+	// XXX get rid of [4:]
 	// This sort skips over the first 4 bytes which comprise the descriptor ID
 	sort.Slice(keys, func(i, j int) bool { return keys[i][4:] > keys[j][4:] })
 

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -205,10 +205,6 @@ func keysTypeRecord(r *zson.Record, keys []GroupByKey) *zeek.TypeRecord {
 	return zeek.LookupTypeRecord(cols)
 }
 
-// XXX this could be made more efficient by using exporting zval.Encoding.build
-// and using it rowkey.Body.Build() and do something smarter with the zeek type
-// strings... otherwise we are sending lots of strings to the GC on each record
-// defeating the purpose of g.cacheKey.
 func encodeInt(dst zval.Encoding, v int) {
 	dst[0] = byte(v >> 24)
 	dst[1] = byte(v >> 16)

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -194,9 +194,9 @@ func (g *GroupByAggregator) createRow(keyd *zson.Descriptor, ts nano.Ts, vals zv
 func keysTypeRecord(r *zson.Record, keys []GroupByKey) *zeek.TypeRecord {
 	cols := make([]zeek.Column, len(keys))
 	for k, key := range keys {
-		// XXX this needs to recurse the record to find the bottom
+		// Rcurse the record to find the bottom
 		// column for group-by on record access, e.g., a.b.c should
-		// find the column for "c" by recursing descriptor.Type here
+		// find the column for "c".
 		keyVal := key.resolver(r)
 		if keyVal.Type == nil {
 			return nil
@@ -339,24 +339,11 @@ func typeMatch(typeCol []zeek.TypedEncoding, rowkeys []zeek.TypedEncoding) bool 
 // recordsForTable returns a slice of records with one record per table entry in a
 // deterministic but undefined order.
 func (g *GroupByAggregator) recordsForTable(table map[string]*GroupByRow) []*zson.Record {
-
-	// XXX get rid of this
-	oldtable := table
-	table = make(map[string]*GroupByRow)
-	for key, val := range oldtable {
-		zv := zval.Encoding(key[4:])
-		oldkey := zv.String()
-		table[oldkey] = val
-	}
-	// ^^^ get rid of this
-
 	var keys []string
 	for k := range table {
 		keys = append(keys, k)
 	}
-	// XXX get rid of [4:]
-	// This sort skips over the first 4 bytes which comprise the descriptor ID
-	sort.Slice(keys, func(i, j int) bool { return keys[i][0:] > keys[j][0:] })
+	sort.Strings(keys)
 
 	n := len(g.keys) + len(g.reducerDefs)
 	if g.TimeBinDuration > 0 {

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -1,6 +1,7 @@
 package proc
 
 import (
+	"encoding/binary"
 	"fmt"
 	"sort"
 	"time"
@@ -205,13 +206,6 @@ func keysTypeRecord(r *zson.Record, keys []GroupByKey) *zeek.TypeRecord {
 	return zeek.LookupTypeRecord(cols)
 }
 
-func encodeInt(dst zval.Encoding, v int) {
-	dst[0] = byte(v >> 24)
-	dst[1] = byte(v >> 16)
-	dst[2] = byte(v >> 8)
-	dst[3] = byte(v)
-}
-
 var blocked = &zson.Descriptor{}
 
 // Consume takes a record and adds it to the aggregation. Records
@@ -253,7 +247,7 @@ func (g *GroupByAggregator) Consume(r *zson.Record) error {
 	} else {
 		keyBytes = make(zval.Encoding, 4, 128)
 	}
-	encodeInt(keyBytes, keysDescriptor.ID)
+	binary.BigEndian.PutUint32(keyBytes, uint32(keysDescriptor.ID))
 	for _, key := range g.keys {
 		keyVal := key.resolver(r)
 		if keyVal.Type != nil {


### PR DESCRIPTION
This commit cleans up the groupby implementation in accordance
with @aswan's suggestion.

It fixes a bug with outputting zval garbage.  Rather than isolate the
bug and fix the bug, I just restructured things more cleanly and the 
bug went away.
