### PR TITLE
fix problem with unset containers

### DIFF
--- a/pkg/zeek/type.go
+++ b/pkg/zeek/type.go
@@ -180,8 +180,8 @@ func parseType(in string) (string, Type, error) {
 
 // Utilities shared by compound types (ie, set and vector)
 
-// InnerType returns the type of its elements for set and vector types
-// or nil if the type  is not a set or vector.
+// InnerType returns the element type for set and vector types
+// or nil if the type is not a set or vector.
 func InnerType(typ Type) Type {
 	switch typ := typ.(type) {
 	case *TypeSet:
@@ -193,9 +193,10 @@ func InnerType(typ Type) Type {
 	}
 }
 
-// ContainerType returns the inner type for set and vector types in the first
-// argument and the columns of its of type for record types in the second column.
-// Nil is return for both values if the type is not a set, vector, or record.
+// ContainedType returns the inner type for set and vector types in the first
+// return value and the columns of its of type for record types in the second
+// return value.  ContainedType returns nil for both return values if the
+// type is not a set, vector, or record.
 func ContainedType(typ Type) (Type, []Column) {
 	switch typ := typ.(type) {
 	case *TypeSet:

--- a/pkg/zeek/type.go
+++ b/pkg/zeek/type.go
@@ -180,10 +180,9 @@ func parseType(in string) (string, Type, error) {
 
 // Utilities shared by compound types (ie, set and vector)
 
-// If the passed-in type is a container, ContainedType() returns
-// the type of individual elements (and true for the second value).
-// Otherwise, returns nil, false.
-func ContainedType(typ Type) Type {
+// InnerType returns the type of its elements for set and vector types
+// or nil if the type  is not a set or vector.
+func InnerType(typ Type) Type {
 	switch typ := typ.(type) {
 	case *TypeSet:
 		return typ.innerType
@@ -191,6 +190,22 @@ func ContainedType(typ Type) Type {
 		return typ.typ
 	default:
 		return nil
+	}
+}
+
+// ContainerType returns the inner type for set and vector types in the first
+// argument and the columns of its of type for record types in the second column.
+// Nil is return for both values if the type is not a set, vector, or record.
+func ContainedType(typ Type) (Type, []Column) {
+	switch typ := typ.(type) {
+	case *TypeSet:
+		return typ.innerType, nil
+	case *TypeVector:
+		return typ.typ, nil
+	case *TypeRecord:
+		return nil, typ.Columns
+	default:
+		return nil, nil
 	}
 }
 

--- a/pkg/zeek/value.go
+++ b/pkg/zeek/value.go
@@ -69,7 +69,9 @@ func Parse(v ast.TypedValue) (Value, error) {
 }
 
 func parseContainer(containerType Type, elementType Type, b []byte) ([]Value, error) {
-	var vals []Value
+	// We start out with a pointer instead of nil so that empty sets and vectors
+	// are properly encoded etc., e.g., by json.Marshal.
+	vals := make([]Value, 0)
 	for it := zval.Iter(b); !it.Done(); {
 		val, _, err := it.Next()
 		if err != nil {

--- a/pkg/zsio/zson/writer.go
+++ b/pkg/zsio/zson/writer.go
@@ -56,6 +56,10 @@ func (w *Writer) write(s string) error {
 }
 
 func (w *Writer) writeContainer(val []byte) error {
+	if val == nil {
+		w.write("*;")
+		return nil
+	}
 	if err := w.write("["); err != nil {
 		return err
 	}
@@ -104,8 +108,11 @@ func (w *Writer) writeEscaped(val []byte) error {
 	if len(val) == 0 {
 		return nil
 	}
-	if len(val) == 1 && val[0] == '-' {
-		return w.escape('-')
+	if len(val) == 1 {
+		switch val[0] {
+		case '-', '*':
+			return w.escape(val[0])
+		}
 	}
 	// We escape a bracket if it appears as the first byte of a value;
 	// we otherwise don't need to escape brackets.

--- a/pkg/zsio/zson/writer.go
+++ b/pkg/zsio/zson/writer.go
@@ -108,11 +108,8 @@ func (w *Writer) writeEscaped(val []byte) error {
 	if len(val) == 0 {
 		return nil
 	}
-	if len(val) == 1 {
-		switch val[0] {
-		case '-':
-			return w.escape(val[0])
-		}
+	if len(val) == 1 && val[0] == '-' {
+		return w.escape('-')
 	}
 	// We escape a bracket if it appears as the first byte of a value;
 	// we otherwise don't need to escape brackets.

--- a/pkg/zsio/zson/writer.go
+++ b/pkg/zsio/zson/writer.go
@@ -57,7 +57,7 @@ func (w *Writer) write(s string) error {
 
 func (w *Writer) writeContainer(val []byte) error {
 	if val == nil {
-		w.write("*;")
+		w.write("-;")
 		return nil
 	}
 	if err := w.write("["); err != nil {
@@ -110,7 +110,7 @@ func (w *Writer) writeEscaped(val []byte) error {
 	}
 	if len(val) == 1 {
 		switch val[0] {
-		case '-', '*':
+		case '-':
 			return w.escape(val[0])
 		}
 	}

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -135,6 +135,7 @@ func TestZson(t *testing.T) {
 	identity(t, zson5)
 	identity(t, zson6)
 	identity(t, zson7)
+	identity(t, zson8)
 	identity(t, zsonBig())
 }
 
@@ -146,6 +147,7 @@ func TestRaw(t *testing.T) {
 	boomerang(t, zson5)
 	boomerang(t, zson6)
 	boomerang(t, zson7)
+	boomerang(t, zson8)
 	boomerang(t, zsonBig())
 }
 
@@ -161,6 +163,7 @@ func TestZjson(t *testing.T) {
 	boomerangZJSON(t, zson5)
 	boomerangZJSON(t, zson6)
 	boomerangZJSON(t, zson7)
+	boomerangZJSON(t, zson8)
 	boomerangZJSON(t, zsonBig())
 }
 

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -98,6 +98,11 @@ const zson6 = `
 #0:record[id:record[a:string,s:set[string]]]
 0:[[-;[]]]`
 
+// Make sure we handle unset sets.
+const zson7 = `
+#0:record[a:string,b:set[string],c:set[string],d:int]
+0:[foo;[]*;10;]`
+
 func repeat(c byte, n int) string {
 	b := make([]byte, n)
 	for k := 0; k < n; k++ {
@@ -124,6 +129,7 @@ func TestZson(t *testing.T) {
 	identity(t, zson4)
 	identity(t, zson5)
 	identity(t, zson6)
+	identity(t, zson7)
 	identity(t, zsonBig())
 }
 
@@ -134,6 +140,7 @@ func TestRaw(t *testing.T) {
 	boomerang(t, zson4)
 	boomerang(t, zson5)
 	boomerang(t, zson6)
+	boomerang(t, zson7)
 	boomerang(t, zsonBig())
 }
 
@@ -148,6 +155,7 @@ func TestZjson(t *testing.T) {
 	boomerangZJSON(t, zson4)
 	boomerangZJSON(t, zson5)
 	boomerangZJSON(t, zson6)
+	boomerangZJSON(t, zson7)
 	boomerangZJSON(t, zsonBig())
 }
 

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -207,7 +207,7 @@ notation.  Here is a pseudo-grammar for value encodings:
 
 A channel is a 16-bit integer used to indicate sub-streams of values within the zson stream.
 This is useful, for example, when analytics performs two or more computations on the
-same input data resulting in multiple result streams that are multiplexed onto a single
+same input data resulting in multiple result streams that are multiplexed onto a single 
 zson stream.
 
 A terminal value is encoded as a string of UTF-8 characters terminated
@@ -222,12 +222,11 @@ Container values are encoded as
 * zero or more encoded values, and
 * a close bracket.
 
-A scalar value is specified as "unset" with the ascii character `-`.
-A container value is specified as "unset" with the ascii character `*`.
+Any value can be specified as "unset" with the ascii character `-`.
 This is typically used to represent columns of records where not all
 columns have been set in a given record value, though any type can be
 validly unset.  A value that is not to be interpreted as "unset"
-but is the single-character string `-` or `*`, must be escaped (e.g., `\-`).
+but is the single-character string `-`, must be escaped (e.g., `\-`).
 
 Note that this syntax can be scanned and parsed independent of the
 actual type definition indicated by the descriptor (unlike legacy values,
@@ -257,8 +256,8 @@ of a value:
 ```
 [ ]
 ```
-In addition, `-` and `*` must be escaped if representing the single ASCII byte equal
-to `-` or `*` as opposed to representing an unset value.
+In addition, `-` must be escaped if representing the single ASCII byte equal
+to `-` as opposed to representing an unset value.
 
 ## Examples
 
@@ -305,7 +304,7 @@ This scheme allows composites to be embedded in composites, e.g., a
 ```
 An unset value indicates a field of a `record` that wasn't set by the encoder:
 ```
-5:[North Pole;[N;90;]*;]
+5:[North Pole;[N;90;]-;]
 ```
 e.g., the North Pole has a latitude but no meaningful longitude.
 

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -207,7 +207,7 @@ notation.  Here is a pseudo-grammar for value encodings:
 
 A channel is a 16-bit integer used to indicate sub-streams of values within the zson stream.
 This is useful, for example, when analytics performs two or more computations on the
-same input data resulting in multiple result streams that are multiplexed onto a single 
+same input data resulting in multiple result streams that are multiplexed onto a single
 zson stream.
 
 A terminal value is encoded as a string of UTF-8 characters terminated
@@ -222,11 +222,12 @@ Container values are encoded as
 * zero or more encoded values, and
 * a close bracket.
 
-Any value can be specified as "unset" with the ascii character `-`.
+A scalar value is specified as "unset" with the ascii character `-`.
+A container value is specified as "unset" with the ascii character `*`.
 This is typically used to represent columns of records where not all
 columns have been set in a given record value, though any type can be
 validly unset.  A value that is not to be interpreted as "unset"
-but is the single-character string `-`, must be escaped (e.g., `\-`).
+but is the single-character string `-` or `*`, must be escaped (e.g., `\-`).
 
 Note that this syntax can be scanned and parsed independent of the
 actual type definition indicated by the descriptor (unlike legacy values,
@@ -256,8 +257,8 @@ of a value:
 ```
 [ ]
 ```
-In addition, `-` must be escaped if representing the single ASCII byte equal
-to `-` as opposed to representing an unset value.
+In addition, `-` and `*` must be escaped if representing the single ASCII byte equal
+to `-` or `*` as opposed to representing an unset value.
 
 ## Examples
 
@@ -304,7 +305,7 @@ This scheme allows composites to be embedded in composites, e.g., a
 ```
 An unset value indicates a field of a `record` that wasn't set by the encoder:
 ```
-5:[North Pole;[N;90;]-;]
+5:[North Pole;[N;90;]*;]
 ```
 e.g., the North Pole has a latitude but no meaningful longitude.
 

--- a/pkg/zson/record.go
+++ b/pkg/zson/record.go
@@ -180,7 +180,7 @@ func (r *Record) TypeCheck() bool {
 
 // check a vector whose inner type is a record
 func checkVector(typ *zeek.TypeVector, body zval.Encoding) bool {
-	inner := zeek.ContainedType(typ)
+	inner := zeek.InnerType(typ)
 	if inner == nil {
 		return false
 	}
@@ -213,8 +213,8 @@ func checkVector(typ *zeek.TypeVector, body zval.Encoding) bool {
 }
 
 func checkSet(typ *zeek.TypeSet, body zval.Encoding) bool {
-	inner := zeek.ContainedType(typ)
-	if zeek.ContainedType(inner) != nil {
+	inner := zeek.InnerType(typ)
+	if zeek.IsContainerType(inner) {
 		return false
 	}
 	it := zval.Iter(body)

--- a/pkg/zson/zval.go
+++ b/pkg/zson/zval.go
@@ -45,15 +45,12 @@ func appendZvalFromZeek(dst zval.Encoding, typ zeek.Type, val []byte) zval.Encod
 // ZvalToZeekString returns a Zeek ASCII string representing the zval described
 // by typ and val.
 func ZvalToZeekString(typ zeek.Type, val []byte, isContainer bool) string {
-	if val == nil && !isContainer {
+	if val == nil {
 		return "-"
 	}
 	var s string
 	switch typ.(type) {
 	case *zeek.TypeSet, *zeek.TypeVector:
-		if val == nil {
-			return "-"
-		}
 		if len(val) == 0 {
 			return "(empty)"
 		}

--- a/pkg/zson/zval.go
+++ b/pkg/zson/zval.go
@@ -51,6 +51,9 @@ func ZvalToZeekString(typ zeek.Type, val []byte, isContainer bool) string {
 	var s string
 	switch typ.(type) {
 	case *zeek.TypeSet, *zeek.TypeVector:
+		if val == nil {
+			return "-"
+		}
 		if len(val) == 0 {
 			return "(empty)"
 		}

--- a/pkg/zval/encoding.go
+++ b/pkg/zval/encoding.go
@@ -46,6 +46,12 @@ func (e Encoding) Build(b []byte) ([]byte, error) {
 			return nil, err
 		}
 		if container {
+			if v == nil {
+				b = append(b, '(')
+				b = append(b, '*')
+				b = append(b, ')')
+				continue
+			}
 			b = append(b, '[')
 			b, err = v.Build(b)
 			if err != nil {


### PR DESCRIPTION
The zeek parser was parsing unset and empty sets to the same zson.
We fixed this and realized the zson text format did not have
a way to represent an unset container.  So we added "*" to the
syntax to mean this like "-" means unset value for scalars.

Updated the parsing code to handle "*" and also updated
zson over json to encode unset containers as JSON empty object
inside of the JSON value arrays.  With the zval builder properly
handling empty container as empty container instead unset container,
a bug in ndjson was exposed where calling marshal on sets or vectors
didn't work right because the zeek value had its arrays unitialized.

Finally, updated zson spec.