### PR TITLE
fix potential data race in zeek type records

### DIFF
--- a/pkg/zeek/type.go
+++ b/pkg/zeek/type.go
@@ -316,7 +316,14 @@ func LookupTypeRecord(columns []Column) *TypeRecord {
 	if ok {
 		return t.(*TypeRecord)
 	}
-	rec := &TypeRecord{Columns: columns, Key: s}
+	// Make a private copy of the columns to maintain the invariant
+	// that types are immutable and the columns can be retrieved from
+	// the type system and traversed without any data races.
+	private := make([]Column, len(columns))
+	for k, p := range columns {
+		private[k] = p
+	}
+	rec := &TypeRecord{Columns: private, Key: s}
 	typeMap[s] = rec
 	return rec
 }


### PR DESCRIPTION
When creating a new type record in package zeek, we should be
careful to copy the input record columns so the type system
has a private copy and can maintain the invariant that the
columns can be externally read (read-only) without any data
races.