### PR TITLE
zsonio: Conditionally trim line breaks

### DIFF
--- a/pkg/zsio/zson/reader.go
+++ b/pkg/zsio/zson/reader.go
@@ -82,7 +82,7 @@ again:
 		return nil, err
 	}
 	// remove newline
-	line = line[:len(line)-1]
+	line = bytes.TrimSpace(line)
 	if line[0] == '#' {
 		b, err := r.parseDirective(line)
 		if err != nil {

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -55,8 +55,7 @@ func boomerang(t *testing.T, logs string) {
 }
 
 func boomerangZJSON(t *testing.T, logs string) {
-	in := []byte(strings.TrimSpace(logs) + "\n")
-	zsonSrc := zsonio.NewReader(bytes.NewReader(in), resolver.NewTable())
+	zsonSrc := zsonio.NewReader(strings.NewReader(logs), resolver.NewTable())
 	var zjsonOutput Output
 	zjsonDst := zson.NopFlusher(zjson.NewWriter(&zjsonOutput))
 	err := zson.Copy(zjsonDst, zsonSrc)
@@ -67,7 +66,7 @@ func boomerangZJSON(t *testing.T, logs string) {
 	zsonDst := zson.NopFlusher(zsonio.NewWriter(&out))
 	err = zson.Copy(zsonDst, zjsonSrc)
 	if assert.NoError(t, err) {
-		assert.Equal(t, in, out.Bytes())
+		assert.Equal(t, strings.TrimSpace(logs), strings.TrimSpace(out.String()))
 	}
 }
 


### PR DESCRIPTION
If the last line of zson stream did not contain a `\n` character
the closing bracket would be removed resulting in an confounding
Syntax Error from the zson Parser. Use bytes.TrimSpace instead.