### PR TITLE
Clarify zval.Builder api names

### DIFF
--- a/pkg/zsio/ndjson/parser.go
+++ b/pkg/zsio/ndjson/parser.go
@@ -84,7 +84,7 @@ func (p *Parser) jsonParseObject(b []byte) (zeek.Type, error) {
 		recType, isRecord := columns[colno].Type.(*zeek.TypeRecord)
 		if isRecord {
 			if nestedColno == 0 {
-				p.builder.Begin()
+				p.builder.BeginContainer()
 			}
 		}
 
@@ -97,7 +97,7 @@ func (p *Parser) jsonParseObject(b []byte) (zeek.Type, error) {
 			recType.Columns[nestedColno].Type = ztyp
 			nestedColno += 1
 			if nestedColno == len(recType.Columns) {
-				p.builder.End()
+				p.builder.EndContainer()
 				nestedColno = 0
 				colno += 1
 			}
@@ -112,12 +112,12 @@ func (p *Parser) jsonParseObject(b []byte) (zeek.Type, error) {
 func (p *Parser) jsonParseValue(raw []byte, typ jsonparser.ValueType) (zeek.Type, error) {
 	switch typ {
 	case jsonparser.Array:
-		p.builder.Begin()
-		defer p.builder.End()
+		p.builder.BeginContainer()
+		defer p.builder.EndContainer()
 		return p.jsonParseArray(raw)
 	case jsonparser.Object:
-		p.builder.Begin()
-		defer p.builder.End()
+		p.builder.BeginContainer()
+		defer p.builder.EndContainer()
 		return p.jsonParseObject(raw)
 	case jsonparser.Boolean:
 		return p.jsonParseBool(raw)

--- a/pkg/zsio/zjson/reader.go
+++ b/pkg/zsio/zjson/reader.go
@@ -175,7 +175,7 @@ func decodeType(columns []interface{}) (string, error) {
 }
 
 func decodeContainer(builder *zval.Builder, body []interface{}) error {
-	builder.Begin()
+	builder.BeginContainer()
 	for _, column := range body {
 		// each column either a string value or an array of string values
 		if column == nil {
@@ -206,6 +206,6 @@ func decodeContainer(builder *zval.Builder, body []interface{}) error {
 			return err
 		}
 	}
-	builder.End()
+	builder.EndContainer()
 	return nil
 }

--- a/pkg/zson/raw.go
+++ b/pkg/zson/raw.go
@@ -135,7 +135,7 @@ func NewRawAndTsFromZeekTSV(d *Descriptor, path []byte, data []byte) (zval.Encod
 		recType, isRec := typ.(*zeek.TypeRecord)
 		if isRec {
 			if nestedCol == 0 {
-				builder.Begin()
+				builder.BeginContainer()
 			}
 			typ = recType.Columns[nestedCol].Type
 		} else if columns[col].Name == "ts" {
@@ -156,7 +156,7 @@ func NewRawAndTsFromZeekTSV(d *Descriptor, path []byte, data []byte) (zval.Encod
 		} else {
 			switch typ.(type) {
 			case *zeek.TypeSet, *zeek.TypeVector:
-				builder.Begin()
+				builder.BeginContainer()
 				if bytes.Compare(val, []byte(emptyContainer)) != 0 {
 					cstart := 0
 					for i, ch := range val {
@@ -167,7 +167,7 @@ func NewRawAndTsFromZeekTSV(d *Descriptor, path []byte, data []byte) (zval.Encod
 					}
 					builder.Append(zeek.Unescape(val[cstart:]))
 				}
-				builder.End()
+				builder.EndContainer()
 			default:
 				// regular (non-container) value
 				builder.Append(zeek.Unescape(val))
@@ -177,7 +177,7 @@ func NewRawAndTsFromZeekTSV(d *Descriptor, path []byte, data []byte) (zval.Encod
 		if isRec {
 			nestedCol++
 			if nestedCol == len(recType.Columns) {
-				builder.End()
+				builder.EndContainer()
 				nestedCol = 0
 				col++
 			}
@@ -275,7 +275,7 @@ const (
 //  1. an array of zvals corresponding to the indivdiual elements
 //  2. the passed-in byte array advanced past all the data that was parsed.
 func zsonParseContainer(builder *zval.Builder, typ zeek.Type, b []byte) ([]byte, error) {
-	builder.Begin()
+	builder.BeginContainer()
 	// skip leftbracket
 	b = b[1:]
 	childType, columns := zeek.ContainedType(typ)
@@ -285,7 +285,7 @@ func zsonParseContainer(builder *zval.Builder, typ zeek.Type, b []byte) ([]byte,
 			return nil, ErrUnterminated
 		}
 		if b[0] == rightbracket {
-			builder.End()
+			builder.EndContainer()
 			return b[1:], nil
 		}
 		if columns != nil {

--- a/pkg/zval/builder.go
+++ b/pkg/zval/builder.go
@@ -35,11 +35,11 @@ func (b *Builder) Reset() {
 	b.leaves = b.leaves[:0]
 }
 
-func (b *Builder) Begin() {
+func (b *Builder) BeginContainer() {
 	b.nodes = append(b.nodes, node{dfs: beginContainer})
 }
 
-func (b *Builder) End() {
+func (b *Builder) EndContainer() {
 	b.nodes = append(b.nodes, node{dfs: endContainer})
 }
 


### PR DESCRIPTION
The class zval.Builder uses classic tmns (terse mccanne names).
Clarify the container apis by renaming them, no functional change.