### PR TITLE
Fix a bug with array index field expressions

### DIFF
--- a/expr/fieldexpr.go
+++ b/expr/fieldexpr.go
@@ -34,6 +34,10 @@ type arrayIndex struct {
 func (ai *arrayIndex) apply(e zeek.TypedEncoding) zeek.TypedEncoding {
 	el, err := e.VectorIndex(ai.idx)
 	if err != nil {
+		if err == zeek.ErrIndex {
+			typ := zeek.InnerType(e.Type)
+			return zeek.TypedEncoding{typ, nil}
+		}
 		return zeek.TypedEncoding{}
 	}
 	return el


### PR DESCRIPTION
When handling an out-of-bounds array index, compiled field expressions
were returning nil for both type and value, which is wrong.  In
particular, when groupby was grouping by an expression such as v[0],
if the first record it sees with a particular descriptor has a vector-valued
field v but the array index is out of bounds, groupby would erroneously
conclude that no records with that descriptor could ever match.
Fix the bug here by returning the proper inner type and a nil body
when an array index is out of bounds.