### PR TITLE
fix directory output

### DIFF
--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/mccanne/zq/pkg/zsio"
 	"github.com/mccanne/zq/pkg/zsio/text"
@@ -19,8 +20,8 @@ var (
 // Dir implements the Writer interface and sends all log lines with the
 // same descriptor to a file named <prefix><path>.<ext> in the directory indicated,
 // where <prefix> and <ext> are specificied and <path> is determined by the
-// _path field in the boom descriptor.  If more than one path exists with
-// different descriptors, the later records are ignored.
+// _path field in the boom descriptor.  Note that more than one descriptor
+// can map to the same output file.
 type Dir struct {
 	dir     string
 	prefix  string
@@ -29,7 +30,7 @@ type Dir struct {
 	stderr  io.Writer // XXX use warnings channel
 	tc      *text.Config
 	writers map[*zson.Descriptor]*zsio.Writer
-	paths   map[string]int
+	paths   map[string]*zsio.Writer
 }
 
 func unknownFormat(format string) error {
@@ -52,7 +53,7 @@ func NewDir(dir, prefix, format string, stderr io.Writer, tc *text.Config) (*Dir
 		stderr:  stderr,
 		tc:      tc,
 		writers: make(map[*zson.Descriptor]*zsio.Writer),
-		paths:   make(map[string]int),
+		paths:   make(map[string]*zsio.Writer),
 	}, nil
 }
 
@@ -61,11 +62,7 @@ func (d *Dir) Write(r *zson.Record) error {
 	if err != nil {
 		return err
 	}
-	if out != nil {
-		return out.Write(r)
-	}
-	// The descriptor is blocked if file exists.  Drop the record.
-	return nil
+	return out.Write(r)
 }
 
 func (d *Dir) lookupOutput(rec *zson.Record) (*zsio.Writer, error) {
@@ -74,13 +71,7 @@ func (d *Dir) lookupOutput(rec *zson.Record) (*zsio.Writer, error) {
 	if ok {
 		return w, nil
 	}
-	w, _, err := d.newFile(rec)
-	if err == ErrNoPath {
-		fmt.Fprintf(d.stderr, "warning: no path for descriptor %d (dropping all related records)", rec.Descriptor.ID)
-		// Block this descriptor.
-		d.writers[descriptor] = nil
-		return nil, nil
-	}
+	w, err := d.newFile(rec)
 	if err != nil {
 		return nil, err
 	}
@@ -91,29 +82,32 @@ func (d *Dir) lookupOutput(rec *zson.Record) (*zsio.Writer, error) {
 // filename returns the name of the file for the specified path. This handles
 // the case of two tds one _path, adding a # in the filename for every _path that
 // has more than one td.
-func (d *Dir) filename(path string) string {
-	filename := d.prefix + path
-	if d.paths[path]++; d.paths[path] > 1 {
-		filename += fmt.Sprintf("-%d", d.paths[path])
+func (d *Dir) filename(r *zson.Record) (string, string) {
+	colno, ok := r.Descriptor.ColumnOfField("_path")
+	var base, path string
+	if ok {
+		base = string(r.Slice(colno))
+		path = base
+	} else {
+		base = strconv.Itoa(r.Descriptor.ID)
 	}
-	filename += d.ext
-	return filepath.Join(d.dir, filename)
+	name := d.prefix + base + d.ext
+	return filepath.Join(d.dir, name), path
 }
 
-func (d *Dir) newFile(rec *zson.Record) (*zsio.Writer, string, error) {
-	// get path name from descriptor.  the td at column 0
-	// has already been stripped out.
-	i, ok := rec.Descriptor.ColumnOfField("_path")
-	if !ok {
-		return nil, "", ErrNoPath
+func (d *Dir) newFile(rec *zson.Record) (*zsio.Writer, error) {
+	filename, path := d.filename(rec)
+	if w, ok := d.paths[path]; ok {
+		return w, nil
 	}
-	path := string(rec.Slice(i))
-	filename := d.filename(path)
 	w, err := NewFile(filename, d.format, d.tc)
 	if err != nil {
-		return nil, filename, err
+		return nil, err
 	}
-	return w, filename, err
+	if path != "" {
+		d.paths[path] = w
+	}
+	return w, err
 }
 
 func (d *Dir) Close() error {


### PR DESCRIPTION
This commit takes advantage of the fact that all writers can handle
descriptor changes (the zeek writer used to not handle this) so 
data blocking does not happen anymore.

The -d flag allows creating multiple files by _path.  If there
is no _path field, then the descriptor id is used for the file
name.