### PR TITLE
remove channel id and control flag from zson.Record

### DIFF
--- a/driver/run.go
+++ b/driver/run.go
@@ -26,11 +26,6 @@ func (d *Driver) SetWarningsWriter(w io.Writer) {
 
 func (d *Driver) Write(cid int, arr zson.Batch) error {
 	for _, r := range arr.Records() {
-		// for cid < 0, we keep the Channel that's already in
-		// the record
-		if cid >= 0 {
-			r.Channel = uint16(cid)
-		}
 		if err := d.writer.Write(r); err != nil {
 			return err
 		}

--- a/pkg/zsio/bzson/writer.go
+++ b/pkg/zsio/bzson/writer.go
@@ -19,30 +19,23 @@ func NewWriter(w io.Writer) *Writer {
 	}
 }
 
-func (w *Writer) WriteValue(ch int, r *zson.Record) error {
-	if r.IsControl() {
-		return w.WriteControl(ch, r.Raw)
-	}
+func (w *Writer) Write(r *zson.Record) error {
 	id := r.Descriptor.ID
 	if !w.tracker.Seen(id) {
 		b := []byte(r.Descriptor.Type.String())
-		if err := w.encode(TypeDescriptor, 0, id, b); err != nil {
+		if err := w.encode(TypeDescriptor, id, b); err != nil {
 			return err
 		}
 	}
-	return w.encode(TypeValue, ch, id, r.Raw)
+	return w.encode(TypeValue, id, r.Raw)
 }
 
-func (w *Writer) Write(r *zson.Record) error {
-	return w.WriteValue(int(r.Channel), r)
+func (w *Writer) WriteControl(b []byte) error {
+	return w.encode(TypeControl, 0, b)
 }
 
-func (w *Writer) WriteControl(ch int, b []byte) error {
-	return w.encode(TypeControl, ch, 0, b)
-}
-
-func (w *Writer) encode(typ, ch, id int, b []byte) error {
-	writeHeader(w.Writer, typ, ch, id, len(b))
+func (w *Writer) encode(typ, id int, b []byte) error {
+	writeHeader(w.Writer, typ, id, len(b))
 	_, err := w.Writer.Write(b)
 	return err
 }

--- a/pkg/zsio/zson/writer.go
+++ b/pkg/zsio/zson/writer.go
@@ -21,12 +21,12 @@ func NewWriter(w io.Writer) *Writer {
 	}
 }
 
-func (w *Writer) Write(r *zson.Record) error {
-	if r.IsControl() {
-		_, err := fmt.Fprintf(w.Writer, "#!%s\n", string(r.Raw.Bytes()))
-		return err
+func (w *Writer) WriteControl(b []byte) error {
+	_, err := fmt.Fprintf(w.Writer, "#!%s\n", string(b))
+	return err
+}
 
-	}
+func (w *Writer) Write(r *zson.Record) error {
 	td := r.Descriptor.ID
 	if !w.tracker.Seen(td) {
 		_, err := fmt.Fprintf(w.Writer, "#%d:%s\n", td, r.Descriptor.Type)
@@ -34,17 +34,11 @@ func (w *Writer) Write(r *zson.Record) error {
 			return err
 		}
 	}
-	var err error
-	if r.Channel == 0 {
-		_, err = fmt.Fprintf(w.Writer, "%d:", td)
-
-	} else {
-		_, err = fmt.Fprintf(w.Writer, "%d.%d:", td, r.Channel)
-	}
+	_, err := fmt.Fprintf(w.Writer, "%d:", td)
 	if err != nil {
 		return nil
 	}
-	if err := w.writeContainer(r.Raw); err != nil {
+	if err = w.writeContainer(r.Raw); err != nil {
 		return err
 	}
 	return w.write("\n")

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -178,38 +178,25 @@ func TestCtrl(t *testing.T) {
 	// this tests reading of control via text zson,
 	// then writing of raw control, and reading back the result
 	in := []byte(strings.TrimSpace(ctrl) + "\n")
-	reader := bytes.NewReader(in)
-	r := zsonio.NewControlReader(reader, resolver.NewTable())
+	r := zsonio.NewReader(bytes.NewReader(in), resolver.NewTable())
 
-	var rawZson Output
-	rawDst := zson.NopFlusher(bzson.NewWriter(&rawZson))
-	err := zson.Copy(rawDst, r)
-	require.NoError(t, err)
-
-	rawReader := bzson.NewControlReader(bytes.NewReader(rawZson.Bytes()), resolver.NewTable())
-
-	rec, err := rawReader.Read()
+	_, body, err := r.ReadPayload()
 	assert.NoError(t, err)
-	assert.True(t, rec.IsControl())
-	assert.Equal(t, rec.Raw.Bytes(), []byte("message1"))
+	assert.Equal(t, body, []byte("message1"))
 
-	rec, err = rawReader.Read()
+	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
-	assert.True(t, rec.IsControl())
-	assert.Equal(t, rec.Raw.Bytes(), []byte("message2"))
+	assert.Equal(t, body, []byte("message2"))
 
-	rec, err = rawReader.Read()
+	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
-	assert.False(t, rec.IsControl())
+	assert.True(t, body == nil)
 
-	rec, err = rawReader.Read()
+	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
-	assert.True(t, rec.IsControl())
-	assert.Equal(t, rec.Raw.Bytes(), []byte("message3"))
+	assert.Equal(t, body, []byte("message3"))
 
-	rec, err = rawReader.Read()
+	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
-	assert.True(t, rec.IsControl())
-	assert.Equal(t, rec.Raw.Bytes(), []byte("message4"))
-
+	assert.Equal(t, body, []byte("message4"))
 }

--- a/pkg/zson/docs/spec.md
+++ b/pkg/zson/docs/spec.md
@@ -193,10 +193,9 @@ declared `record` types:
 ## Regular Values
 
 A regular value is encoded on a line as a type descriptor followed by `:` followed
-by a value encoding.  The descriptor may include an option channel identifier via dotted
-notation.  Here is a pseudo-grammar for value encodings:
+by a value encoding.  Here is a pseudo-grammar for value encodings:
 ```
-<line> := <descriptor>(.<ch>)? : <elem>
+<line> := <descriptor> : <elem>
 <elem> :=
           <terminal> ;
         | [ <list> ]
@@ -210,11 +209,6 @@ notation.  Here is a pseudo-grammar for value encodings:
 ```
 
 [1] - [JavaScript character escaping rules](https://tc39.es/ecma262/#prod-EscapeSequence)
-
-A channel is a 16-bit integer used to indicate sub-streams of values within the zson stream.
-This is useful, for example, when analytics performs two or more computations on the
-same input data resulting in multiple result streams that are multiplexed onto a single 
-zson stream.
 
 A terminal value is encoded as a string of UTF-8 characters terminated
 by a semicolon (which must be escaped if it appears in the value).  A composite
@@ -274,7 +268,7 @@ two descriptors then uses them in three values:
 #2:record[a:string,b:string]
 1:hello, world;
 2:[hello;world;]
-1.3:this is a semicolon: \x3b;
+1:this is a semicolon: \x3b;
 ```
 which represents a stream of the following three values:
 ```
@@ -282,7 +276,6 @@ string("hello, world")
 record(a:"hello",b:"world")
 string("this is a semicolon: ;")
 ```
-The last value signals a channel identifier of 3.
 
 The semicolon terminator is important.  Consider this ZSON depicting
 sets of strings:


### PR DESCRIPTION
This commit removes the channel ID and control flag from zson.Record.
Instead, the zson and bzson readers and writers can signal this
info via the zson control messages by using methods on the
reader/writer API aside from those in ths zson.Reader and zson.Writer
interfaces.