### PR TITLE
add ability to match with strings that include escapes

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -46,7 +46,7 @@ func searchContainer(zv zval.Encoding, pattern []byte) bool {
 }
 
 func SearchString(s string) Filter {
-	pattern := []byte(s)
+	pattern := zeek.Unescape([]byte(s))
 	return func(p *zson.Record) bool {
 		// Go implements a very efficient string search algorithm so we
 		// use it here first to rule out misses on a substring match.

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -65,7 +65,7 @@ const zsonsrc = `
 #6:record[nested:record[field:string]]
 #7:record[nested:vector[record[field:int]]]
 #8:record[nested:record[vec:vector[int]]]
-
+#9:record[s:string]
 0:[[abc;xyz;]]
 1:[[abc;xyz;]]
 1:[[a\;b;xyz;]]
@@ -76,6 +76,7 @@ const zsonsrc = `
 6:[[test;]]
 7:[[[1;][2;]]]
 8:[[[1;2;3;]]]
+9:[begin\x01\x02\xffend;]
 `
 
 func TestFilters(t *testing.T) {
@@ -84,7 +85,7 @@ func TestFilters(t *testing.T) {
 	ior := strings.NewReader(zsonsrc)
 	reader := zsio.LookupReader("zson", ior, resolver.NewTable())
 
-	nrecords := 10
+	nrecords := 11
 	records := make([]*zson.Record, 0, nrecords)
 	for {
 		rec, err := reader.Read()
@@ -149,6 +150,11 @@ func TestFilters(t *testing.T) {
 		{"nested.vec[0] = 1", records[9], true},
 		{"nested.vec[1] = 1", records[9], false},
 		{"1 in nested", records[9], false},
+
+		{"begin", records[10], true},
+		{"s=begin", records[10], false},
+		{"begin\\x01\\x02\\xffend", records[10], true},
+		{"s=begin\\x01\\x02\\xffend", records[10], true},
 	}
 
 	for _, tt := range tests {

--- a/zql/valid.zql
+++ b/zql/valid.zql
@@ -21,3 +21,6 @@ _path=conn id.resp_p=80
 count() | sort
 top -limit 1
 top -limit 1 -flush
+foo\tbar
+foo\x11bar
+foo\x11\bar

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -3899,66 +3899,97 @@ var g = &grammar{
 		},
 		{
 			name: "boomWordPart",
-			pos:  position{line: 502, col: 1, offset: 11635},
-			expr: &seqExpr{
-				pos: position{line: 503, col: 5, offset: 11652},
-				exprs: []interface{}{
-					&notExpr{
-						pos: position{line: 503, col: 5, offset: 11652},
-						expr: &choiceExpr{
-							pos: position{line: 503, col: 7, offset: 11654},
-							alternatives: []interface{}{
-								&charClassMatcher{
-									pos:        position{line: 503, col: 7, offset: 11654},
-									val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
-									chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
-									ranges:     []rune{'\x00', '\x1f'},
+			pos:  position{line: 502, col: 1, offset: 11637},
+			expr: &choiceExpr{
+				pos: position{line: 503, col: 5, offset: 11654},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 503, col: 5, offset: 11654},
+						run: (*parser).callonboomWordPart2,
+						expr: &seqExpr{
+							pos: position{line: 503, col: 5, offset: 11654},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 503, col: 5, offset: 11654},
+									val:        "\\",
 									ignoreCase: false,
-									inverted:   false,
 								},
-								&ruleRefExpr{
-									pos:  position{line: 503, col: 42, offset: 11689},
-									name: "ws",
+								&labeledExpr{
+									pos:   position{line: 503, col: 10, offset: 11659},
+									label: "s",
+									expr: &ruleRefExpr{
+										pos:  position{line: 503, col: 12, offset: 11661},
+										name: "escapeSequence",
+									},
 								},
 							},
 						},
 					},
-					&anyMatcher{
-						line: 503, col: 46, offset: 11693,
+					&actionExpr{
+						pos: position{line: 504, col: 5, offset: 11699},
+						run: (*parser).callonboomWordPart7,
+						expr: &seqExpr{
+							pos: position{line: 504, col: 5, offset: 11699},
+							exprs: []interface{}{
+								&notExpr{
+									pos: position{line: 504, col: 5, offset: 11699},
+									expr: &choiceExpr{
+										pos: position{line: 504, col: 7, offset: 11701},
+										alternatives: []interface{}{
+											&charClassMatcher{
+												pos:        position{line: 504, col: 7, offset: 11701},
+												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
+												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
+												ranges:     []rune{'\x00', '\x1f'},
+												ignoreCase: false,
+												inverted:   false,
+											},
+											&ruleRefExpr{
+												pos:  position{line: 504, col: 42, offset: 11736},
+												name: "ws",
+											},
+										},
+									},
+								},
+								&anyMatcher{
+									line: 504, col: 46, offset: 11740,
+								},
+							},
+						},
 					},
 				},
 			},
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 505, col: 1, offset: 11696},
+			pos:  position{line: 506, col: 1, offset: 11774},
 			expr: &choiceExpr{
-				pos: position{line: 506, col: 5, offset: 11713},
+				pos: position{line: 507, col: 5, offset: 11791},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 506, col: 5, offset: 11713},
+						pos: position{line: 507, col: 5, offset: 11791},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 506, col: 5, offset: 11713},
+							pos: position{line: 507, col: 5, offset: 11791},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 506, col: 5, offset: 11713},
+									pos:        position{line: 507, col: 5, offset: 11791},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 506, col: 9, offset: 11717},
+									pos:   position{line: 507, col: 9, offset: 11795},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 506, col: 11, offset: 11719},
+										pos: position{line: 507, col: 11, offset: 11797},
 										expr: &ruleRefExpr{
-											pos:  position{line: 506, col: 11, offset: 11719},
+											pos:  position{line: 507, col: 11, offset: 11797},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 506, col: 29, offset: 11737},
+									pos:        position{line: 507, col: 29, offset: 11815},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -3966,29 +3997,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 507, col: 5, offset: 11774},
+						pos: position{line: 508, col: 5, offset: 11852},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 507, col: 5, offset: 11774},
+							pos: position{line: 508, col: 5, offset: 11852},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 507, col: 5, offset: 11774},
+									pos:        position{line: 508, col: 5, offset: 11852},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 507, col: 9, offset: 11778},
+									pos:   position{line: 508, col: 9, offset: 11856},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 507, col: 11, offset: 11780},
+										pos: position{line: 508, col: 11, offset: 11858},
 										expr: &ruleRefExpr{
-											pos:  position{line: 507, col: 11, offset: 11780},
+											pos:  position{line: 508, col: 11, offset: 11858},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 507, col: 29, offset: 11798},
+									pos:        position{line: 508, col: 29, offset: 11876},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -4000,55 +4031,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 509, col: 1, offset: 11832},
+			pos:  position{line: 510, col: 1, offset: 11910},
 			expr: &choiceExpr{
-				pos: position{line: 510, col: 5, offset: 11853},
+				pos: position{line: 511, col: 5, offset: 11931},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 11853},
+						pos: position{line: 511, col: 5, offset: 11931},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 510, col: 5, offset: 11853},
+							pos: position{line: 511, col: 5, offset: 11931},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 510, col: 5, offset: 11853},
+									pos: position{line: 511, col: 5, offset: 11931},
 									expr: &choiceExpr{
-										pos: position{line: 510, col: 7, offset: 11855},
+										pos: position{line: 511, col: 7, offset: 11933},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 510, col: 7, offset: 11855},
+												pos:        position{line: 511, col: 7, offset: 11933},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 510, col: 13, offset: 11861},
+												pos:  position{line: 511, col: 13, offset: 11939},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 510, col: 26, offset: 11874,
+									line: 511, col: 26, offset: 11952,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 511, col: 5, offset: 11911},
+						pos: position{line: 512, col: 5, offset: 11989},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 511, col: 5, offset: 11911},
+							pos: position{line: 512, col: 5, offset: 11989},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 511, col: 5, offset: 11911},
+									pos:        position{line: 512, col: 5, offset: 11989},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 511, col: 10, offset: 11916},
+									pos:   position{line: 512, col: 10, offset: 11994},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 511, col: 12, offset: 11918},
+										pos:  position{line: 512, col: 12, offset: 11996},
 										name: "escapeSequence",
 									},
 								},
@@ -4060,55 +4091,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 513, col: 1, offset: 11952},
+			pos:  position{line: 514, col: 1, offset: 12030},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 11973},
+				pos: position{line: 515, col: 5, offset: 12051},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 514, col: 5, offset: 11973},
+						pos: position{line: 515, col: 5, offset: 12051},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 514, col: 5, offset: 11973},
+							pos: position{line: 515, col: 5, offset: 12051},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 514, col: 5, offset: 11973},
+									pos: position{line: 515, col: 5, offset: 12051},
 									expr: &choiceExpr{
-										pos: position{line: 514, col: 7, offset: 11975},
+										pos: position{line: 515, col: 7, offset: 12053},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 514, col: 7, offset: 11975},
+												pos:        position{line: 515, col: 7, offset: 12053},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 514, col: 13, offset: 11981},
+												pos:  position{line: 515, col: 13, offset: 12059},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 514, col: 26, offset: 11994,
+									line: 515, col: 26, offset: 12072,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 515, col: 5, offset: 12031},
+						pos: position{line: 516, col: 5, offset: 12109},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 515, col: 5, offset: 12031},
+							pos: position{line: 516, col: 5, offset: 12109},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 515, col: 5, offset: 12031},
+									pos:        position{line: 516, col: 5, offset: 12109},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 515, col: 10, offset: 12036},
+									pos:   position{line: 516, col: 10, offset: 12114},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 515, col: 12, offset: 12038},
+										pos:  position{line: 516, col: 12, offset: 12116},
 										name: "escapeSequence",
 									},
 								},
@@ -4120,16 +4151,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 517, col: 1, offset: 12072},
+			pos:  position{line: 518, col: 1, offset: 12150},
 			expr: &choiceExpr{
-				pos: position{line: 517, col: 18, offset: 12089},
+				pos: position{line: 519, col: 5, offset: 12169},
 				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 519, col: 5, offset: 12169},
+						run: (*parser).callonescapeSequence2,
+						expr: &seqExpr{
+							pos: position{line: 519, col: 5, offset: 12169},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 519, col: 5, offset: 12169},
+									val:        "x",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 519, col: 9, offset: 12173},
+									name: "hexdigit",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 519, col: 18, offset: 12182},
+									name: "hexdigit",
+								},
+							},
+						},
+					},
 					&ruleRefExpr{
-						pos:  position{line: 517, col: 18, offset: 12089},
+						pos:  position{line: 520, col: 5, offset: 12233},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 517, col: 37, offset: 12108},
+						pos:  position{line: 521, col: 5, offset: 12254},
 						name: "unicodeEscape",
 					},
 				},
@@ -4137,75 +4190,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 519, col: 1, offset: 12123},
+			pos:  position{line: 523, col: 1, offset: 12269},
 			expr: &choiceExpr{
-				pos: position{line: 520, col: 5, offset: 12144},
+				pos: position{line: 524, col: 5, offset: 12290},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 520, col: 5, offset: 12144},
+						pos:        position{line: 524, col: 5, offset: 12290},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 521, col: 5, offset: 12152},
+						pos:        position{line: 525, col: 5, offset: 12298},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 522, col: 5, offset: 12160},
+						pos:        position{line: 526, col: 5, offset: 12306},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 523, col: 5, offset: 12169},
+						pos: position{line: 527, col: 5, offset: 12315},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 523, col: 5, offset: 12169},
+							pos:        position{line: 527, col: 5, offset: 12315},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 524, col: 5, offset: 12198},
+						pos: position{line: 528, col: 5, offset: 12344},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 524, col: 5, offset: 12198},
+							pos:        position{line: 528, col: 5, offset: 12344},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 525, col: 5, offset: 12227},
+						pos: position{line: 529, col: 5, offset: 12373},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 525, col: 5, offset: 12227},
+							pos:        position{line: 529, col: 5, offset: 12373},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 526, col: 5, offset: 12256},
+						pos: position{line: 530, col: 5, offset: 12402},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 526, col: 5, offset: 12256},
+							pos:        position{line: 530, col: 5, offset: 12402},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 527, col: 5, offset: 12285},
+						pos: position{line: 531, col: 5, offset: 12431},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 527, col: 5, offset: 12285},
+							pos:        position{line: 531, col: 5, offset: 12431},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 528, col: 5, offset: 12314},
+						pos: position{line: 532, col: 5, offset: 12460},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 528, col: 5, offset: 12314},
+							pos:        position{line: 532, col: 5, offset: 12460},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -4215,29 +4268,29 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 530, col: 1, offset: 12340},
+			pos:  position{line: 534, col: 1, offset: 12486},
 			expr: &seqExpr{
-				pos: position{line: 531, col: 5, offset: 12358},
+				pos: position{line: 535, col: 5, offset: 12504},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 531, col: 5, offset: 12358},
+						pos:        position{line: 535, col: 5, offset: 12504},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 531, col: 9, offset: 12362},
+						pos:  position{line: 535, col: 9, offset: 12508},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 531, col: 18, offset: 12371},
+						pos:  position{line: 535, col: 18, offset: 12517},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 531, col: 27, offset: 12380},
+						pos:  position{line: 535, col: 27, offset: 12526},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 531, col: 36, offset: 12389},
+						pos:  position{line: 535, col: 36, offset: 12535},
 						name: "hexdigit",
 					},
 				},
@@ -4245,28 +4298,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 533, col: 1, offset: 12399},
+			pos:  position{line: 537, col: 1, offset: 12545},
 			expr: &actionExpr{
-				pos: position{line: 534, col: 5, offset: 12412},
+				pos: position{line: 538, col: 5, offset: 12558},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 534, col: 5, offset: 12412},
+					pos: position{line: 538, col: 5, offset: 12558},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 534, col: 5, offset: 12412},
+							pos:        position{line: 538, col: 5, offset: 12558},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 534, col: 9, offset: 12416},
+							pos:   position{line: 538, col: 9, offset: 12562},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 534, col: 11, offset: 12418},
+								pos:  position{line: 538, col: 11, offset: 12564},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 534, col: 18, offset: 12425},
+							pos:        position{line: 538, col: 18, offset: 12571},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4276,24 +4329,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 536, col: 1, offset: 12448},
+			pos:  position{line: 540, col: 1, offset: 12594},
 			expr: &actionExpr{
-				pos: position{line: 537, col: 5, offset: 12459},
+				pos: position{line: 541, col: 5, offset: 12605},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 537, col: 5, offset: 12459},
+					pos: position{line: 541, col: 5, offset: 12605},
 					expr: &choiceExpr{
-						pos: position{line: 537, col: 6, offset: 12460},
+						pos: position{line: 541, col: 6, offset: 12606},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 537, col: 6, offset: 12460},
+								pos:        position{line: 541, col: 6, offset: 12606},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 537, col: 13, offset: 12467},
+								pos:        position{line: 541, col: 13, offset: 12613},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -4304,9 +4357,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 539, col: 1, offset: 12507},
+			pos:  position{line: 543, col: 1, offset: 12653},
 			expr: &charClassMatcher{
-				pos:        position{line: 540, col: 5, offset: 12523},
+				pos:        position{line: 544, col: 5, offset: 12669},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -4316,37 +4369,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 542, col: 1, offset: 12538},
+			pos:  position{line: 546, col: 1, offset: 12684},
 			expr: &choiceExpr{
-				pos: position{line: 543, col: 5, offset: 12545},
+				pos: position{line: 547, col: 5, offset: 12691},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 543, col: 5, offset: 12545},
+						pos:        position{line: 547, col: 5, offset: 12691},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 544, col: 5, offset: 12554},
+						pos:        position{line: 548, col: 5, offset: 12700},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 545, col: 5, offset: 12563},
+						pos:        position{line: 549, col: 5, offset: 12709},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 546, col: 5, offset: 12572},
+						pos:        position{line: 550, col: 5, offset: 12718},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 547, col: 5, offset: 12580},
+						pos:        position{line: 551, col: 5, offset: 12726},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 548, col: 5, offset: 12593},
+						pos:        position{line: 552, col: 5, offset: 12739},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -4356,22 +4409,22 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 550, col: 1, offset: 12603},
+			pos:         position{line: 554, col: 1, offset: 12749},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 550, col: 18, offset: 12620},
+				pos: position{line: 554, col: 18, offset: 12766},
 				expr: &ruleRefExpr{
-					pos:  position{line: 550, col: 18, offset: 12620},
+					pos:  position{line: 554, col: 18, offset: 12766},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 552, col: 1, offset: 12625},
+			pos:  position{line: 556, col: 1, offset: 12771},
 			expr: &notExpr{
-				pos: position{line: 552, col: 7, offset: 12631},
+				pos: position{line: 556, col: 7, offset: 12777},
 				expr: &anyMatcher{
-					line: 552, col: 8, offset: 12632,
+					line: 556, col: 8, offset: 12778,
 				},
 			},
 		},
@@ -5653,13 +5706,33 @@ func (p *parser) callonh161() (interface{}, error) {
 }
 
 func (c *current) onboomWord1(chars interface{}) (interface{}, error) {
-	return string(c.text), nil
+	return joinChars(chars), nil
 }
 
 func (p *parser) callonboomWord1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onboomWord1(stack["chars"])
+}
+
+func (c *current) onboomWordPart2(s interface{}) (interface{}, error) {
+	return s, nil
+}
+
+func (p *parser) callonboomWordPart2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onboomWordPart2(stack["s"])
+}
+
+func (c *current) onboomWordPart7() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonboomWordPart7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onboomWordPart7()
 }
 
 func (c *current) onquotedString2(v interface{}) (interface{}, error) {
@@ -5720,6 +5793,16 @@ func (p *parser) callonsingleQuotedChar9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onsingleQuotedChar9(stack["s"])
+}
+
+func (c *current) onescapeSequence2() (interface{}, error) {
+	return "\\" + string(c.text), nil
+}
+
+func (p *parser) callonescapeSequence2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onescapeSequence2()
 }
 
 func (c *current) onsingleCharEscape5() (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -597,55 +597,59 @@ function peg$parse(input, options) {
       peg$c296 = /^[0-9a-fA-F]/,
       peg$c297 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
       peg$c298 = peg$otherExpectation("boomWord"),
-      peg$c299 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c300 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c301 = peg$anyExpectation(),
-      peg$c302 = "\"",
-      peg$c303 = peg$literalExpectation("\"", false),
-      peg$c304 = function(v) { return joinChars(v) },
-      peg$c305 = "'",
-      peg$c306 = peg$literalExpectation("'", false),
-      peg$c307 = "\\",
-      peg$c308 = peg$literalExpectation("\\", false),
-      peg$c309 = "b",
-      peg$c310 = peg$literalExpectation("b", false),
-      peg$c311 = function() { return "\b" },
-      peg$c312 = "f",
-      peg$c313 = peg$literalExpectation("f", false),
-      peg$c314 = function() { return "\f" },
-      peg$c315 = "n",
-      peg$c316 = peg$literalExpectation("n", false),
-      peg$c317 = function() { return "\n" },
-      peg$c318 = "r",
-      peg$c319 = peg$literalExpectation("r", false),
-      peg$c320 = function() { return "\r" },
-      peg$c321 = "t",
-      peg$c322 = peg$literalExpectation("t", false),
-      peg$c323 = function() { return "\t" },
-      peg$c324 = "v",
-      peg$c325 = peg$literalExpectation("v", false),
-      peg$c326 = function() { return "\v" },
-      peg$c327 = "u",
-      peg$c328 = peg$literalExpectation("u", false),
-      peg$c329 = /^[^\/\\]/,
-      peg$c330 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c331 = "\\/",
-      peg$c332 = peg$literalExpectation("\\/", false),
-      peg$c333 = /^[\0-\x1F\\]/,
-      peg$c334 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c335 = "\t",
-      peg$c336 = peg$literalExpectation("\t", false),
-      peg$c337 = "\x0B",
-      peg$c338 = peg$literalExpectation("\x0B", false),
-      peg$c339 = "\f",
-      peg$c340 = peg$literalExpectation("\f", false),
-      peg$c341 = " ",
-      peg$c342 = peg$literalExpectation(" ", false),
-      peg$c343 = "\xA0",
-      peg$c344 = peg$literalExpectation("\xA0", false),
-      peg$c345 = "\uFEFF",
-      peg$c346 = peg$literalExpectation("\uFEFF", false),
-      peg$c347 = peg$otherExpectation("whitespace"),
+      peg$c299 = function(chars) { return joinChars(chars) },
+      peg$c300 = "\\",
+      peg$c301 = peg$literalExpectation("\\", false),
+      peg$c302 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c303 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c304 = peg$anyExpectation(),
+      peg$c305 = "\"",
+      peg$c306 = peg$literalExpectation("\"", false),
+      peg$c307 = function(v) { return joinChars(v) },
+      peg$c308 = "'",
+      peg$c309 = peg$literalExpectation("'", false),
+      peg$c310 = "x",
+      peg$c311 = peg$literalExpectation("x", false),
+      peg$c312 = function() { return "\\" + text() },
+      peg$c313 = "b",
+      peg$c314 = peg$literalExpectation("b", false),
+      peg$c315 = function() { return "\b" },
+      peg$c316 = "f",
+      peg$c317 = peg$literalExpectation("f", false),
+      peg$c318 = function() { return "\f" },
+      peg$c319 = "n",
+      peg$c320 = peg$literalExpectation("n", false),
+      peg$c321 = function() { return "\n" },
+      peg$c322 = "r",
+      peg$c323 = peg$literalExpectation("r", false),
+      peg$c324 = function() { return "\r" },
+      peg$c325 = "t",
+      peg$c326 = peg$literalExpectation("t", false),
+      peg$c327 = function() { return "\t" },
+      peg$c328 = "v",
+      peg$c329 = peg$literalExpectation("v", false),
+      peg$c330 = function() { return "\v" },
+      peg$c331 = "u",
+      peg$c332 = peg$literalExpectation("u", false),
+      peg$c333 = /^[^\/\\]/,
+      peg$c334 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c335 = "\\/",
+      peg$c336 = peg$literalExpectation("\\/", false),
+      peg$c337 = /^[\0-\x1F\\]/,
+      peg$c338 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c339 = "\t",
+      peg$c340 = peg$literalExpectation("\t", false),
+      peg$c341 = "\x0B",
+      peg$c342 = peg$literalExpectation("\x0B", false),
+      peg$c343 = "\f",
+      peg$c344 = peg$literalExpectation("\f", false),
+      peg$c345 = " ",
+      peg$c346 = peg$literalExpectation(" ", false),
+      peg$c347 = "\xA0",
+      peg$c348 = peg$literalExpectation("\xA0", false),
+      peg$c349 = "\uFEFF",
+      peg$c350 = peg$literalExpectation("\uFEFF", false),
+      peg$c351 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -5419,7 +5423,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c295(s1);
+      s1 = peg$c299(s1);
     }
     s0 = s1;
     peg$silentFails--;
@@ -5435,35 +5439,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    s1 = peg$currPos;
-    peg$silentFails++;
-    if (peg$c299.test(input.charAt(peg$currPos))) {
-      s2 = input.charAt(peg$currPos);
+    if (input.charCodeAt(peg$currPos) === 92) {
+      s1 = peg$c300;
       peg$currPos++;
     } else {
-      s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
-    }
-    if (s2 === peg$FAILED) {
-      s2 = peg$parsews();
-    }
-    peg$silentFails--;
-    if (s2 === peg$FAILED) {
-      s1 = void 0;
-    } else {
-      peg$currPos = s1;
       s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c301); }
     }
     if (s1 !== peg$FAILED) {
-      if (input.length > peg$currPos) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
-      }
+      s2 = peg$parseescapeSequence();
       if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
+        peg$savedPos = s0;
+        s1 = peg$c18(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5472,6 +5459,48 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$currPos;
+      peg$silentFails++;
+      if (peg$c302.test(input.charAt(peg$currPos))) {
+        s2 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c303); }
+      }
+      if (s2 === peg$FAILED) {
+        s2 = peg$parsews();
+      }
+      peg$silentFails--;
+      if (s2 === peg$FAILED) {
+        s1 = void 0;
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+      if (s1 !== peg$FAILED) {
+        if (input.length > peg$currPos) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c304); }
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c112();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     return s0;
@@ -5482,11 +5511,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c302;
+      s1 = peg$c305;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c303); }
+      if (peg$silentFails === 0) { peg$fail(peg$c306); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -5497,15 +5526,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c302;
+          s3 = peg$c305;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          if (peg$silentFails === 0) { peg$fail(peg$c306); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c304(s2);
+          s1 = peg$c307(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5522,11 +5551,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c305;
+        s1 = peg$c308;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c306); }
+        if (peg$silentFails === 0) { peg$fail(peg$c309); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -5537,15 +5566,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c305;
+            s3 = peg$c308;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c306); }
+            if (peg$silentFails === 0) { peg$fail(peg$c309); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c304(s2);
+            s1 = peg$c307(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5571,11 +5600,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c302;
+      s2 = peg$c305;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c303); }
+      if (peg$silentFails === 0) { peg$fail(peg$c306); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -5593,7 +5622,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -5610,11 +5639,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c307;
+        s1 = peg$c300;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c308); }
+        if (peg$silentFails === 0) { peg$fail(peg$c301); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -5642,11 +5671,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c305;
+      s2 = peg$c308;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c306); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -5664,7 +5693,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -5681,11 +5710,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c307;
+        s1 = peg$c300;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c308); }
+        if (peg$silentFails === 0) { peg$fail(peg$c301); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -5707,11 +5736,41 @@ function peg$parse(input, options) {
   }
 
   function peg$parseescapeSequence() {
-    var s0;
+    var s0, s1, s2, s3;
 
-    s0 = peg$parsesingleCharEscape();
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 120) {
+      s1 = peg$c310;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c311); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parsehexdigit();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parsehexdigit();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c312();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
     if (s0 === peg$FAILED) {
-      s0 = peg$parseunicodeEscape();
+      s0 = peg$parsesingleCharEscape();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseunicodeEscape();
+      }
     }
 
     return s0;
@@ -5721,110 +5780,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c305;
+      s0 = peg$c308;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c306); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c302;
+        s0 = peg$c305;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c303); }
+        if (peg$silentFails === 0) { peg$fail(peg$c306); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c307;
+          s0 = peg$c300;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c308); }
+          if (peg$silentFails === 0) { peg$fail(peg$c301); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c309;
+            s1 = peg$c313;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c310); }
+            if (peg$silentFails === 0) { peg$fail(peg$c314); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c311();
+            s1 = peg$c315();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c312;
+              s1 = peg$c316;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c317); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c314();
+              s1 = peg$c318();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c315;
+                s1 = peg$c319;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c316); }
+                if (peg$silentFails === 0) { peg$fail(peg$c320); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c317();
+                s1 = peg$c321();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c318;
+                  s1 = peg$c322;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c323); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c320();
+                  s1 = peg$c324();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c321;
+                    s1 = peg$c325;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c322); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c326); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c323();
+                    s1 = peg$c327();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c324;
+                      s1 = peg$c328;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c329); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c326();
+                      s1 = peg$c330();
                     }
                     s0 = s1;
                   }
@@ -5844,11 +5903,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c327;
+      s1 = peg$c331;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -5931,39 +5990,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c329.test(input.charAt(peg$currPos))) {
+    if (peg$c333.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c331) {
-        s2 = peg$c331;
+      if (input.substr(peg$currPos, 2) === peg$c335) {
+        s2 = peg$c335;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c332); }
+        if (peg$silentFails === 0) { peg$fail(peg$c336); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c329.test(input.charAt(peg$currPos))) {
+        if (peg$c333.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c330); }
+          if (peg$silentFails === 0) { peg$fail(peg$c334); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c331) {
-            s2 = peg$c331;
+          if (input.substr(peg$currPos, 2) === peg$c335) {
+            s2 = peg$c335;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c332); }
+            if (peg$silentFails === 0) { peg$fail(peg$c336); }
           }
         }
       }
@@ -5982,12 +6041,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c333.test(input.charAt(peg$currPos))) {
+    if (peg$c337.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c334); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
 
     return s0;
@@ -5997,51 +6056,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c335;
+      s0 = peg$c339;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c337;
+        s0 = peg$c341;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c338); }
+        if (peg$silentFails === 0) { peg$fail(peg$c342); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c339;
+          s0 = peg$c343;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c340); }
+          if (peg$silentFails === 0) { peg$fail(peg$c344); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c341;
+            s0 = peg$c345;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c342); }
+            if (peg$silentFails === 0) { peg$fail(peg$c346); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c343;
+              s0 = peg$c347;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c344); }
+              if (peg$silentFails === 0) { peg$fail(peg$c348); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c345;
+                s0 = peg$c349;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c346); }
+                if (peg$silentFails === 0) { peg$fail(peg$c350); }
               }
             }
           }
@@ -6069,7 +6128,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c351); }
     }
 
     return s0;
@@ -6085,7 +6144,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
+      if (peg$silentFails === 0) { peg$fail(peg$c304); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -531,10 +531,11 @@ h16 = chars:hexdigit+ { RETURN(TEXT) }
 
 hexdigit = [0-9a-fA-F]
 
-boomWord "boomWord" = chars:boomWordPart+ { RETURN(TEXT) }
+boomWord "boomWord" = chars:boomWordPart+ { RETURN(joinChars(chars)) }
 
 boomWordPart
-  = !([\x00-\x1F\x5C(),!><=DQUOTE|SQUOTE;] / ws) .
+  = "\\" s:escapeSequence  { RETURN(s) }
+  / !([\x00-\x1F\x5C(),!><=DQUOTE|SQUOTE;] / ws) . { RETURN(TEXT) }
 
 quotedString
   = '"' v:doubleQuotedChar* '"' { RETURN(joinChars(v)) }
@@ -548,7 +549,10 @@ singleQuotedChar
   = !("'" / escapedChar) . { RETURN(TEXT) }
   / "\\" s:escapeSequence { RETURN(s) }
 
-escapeSequence = singleCharEscape / unicodeEscape
+escapeSequence
+  = "x" hexdigit hexdigit { RETURN("\\" + TEXT) }
+  / singleCharEscape
+  / unicodeEscape
 
 singleCharEscape
   = "'"


### PR DESCRIPTION
This commit adds support for expressing string-matching
that have embedded escapes.  Previously, the grammar would
reject any escapes for non-quoted patterns and reject
\xHH escapes (where H is a hex digit) for quoted patterns.

The grammar was changed to allow standard escape sequences
in string patterns (which can encoded over JSON as UTF strigns)
but pass through \xHH escapes as such values cannot be generally
encoded raw within UTF strings.

The filter compiler then transforms the \xHH escapes within
search patterns back into raw byte sequence to be compared aginst
values from record fields.