### PR TITLE
Simplify scalar types in package zeek by removing struct

### DIFF
--- a/pkg/zeek/addr.go
+++ b/pkg/zeek/addr.go
@@ -43,35 +43,38 @@ func (t *TypeOfAddr) New(value []byte) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Addr{Native: ip}, nil
+	return NewAddr(ip), nil
 }
 
-type Addr struct {
-	Native net.IP
+type Addr net.IP
+
+func NewAddr(a net.IP) *Addr {
+	p := Addr(a)
+	return &p
 }
 
-func (a *Addr) String() string {
-	return a.Native.String()
+func (a Addr) String() string {
+	return a.String()
 }
 
-func (a *Addr) Type() Type {
+func (a Addr) Type() Type {
 	return TypeAddr
 }
 
-func (a *Addr) Encode(dst zval.Encoding) zval.Encoding {
-	b := []byte(a.Native.String())
+func (a Addr) Encode(dst zval.Encoding) zval.Encoding {
+	b := []byte(a.String())
 	return zval.AppendValue(dst, b)
 }
 
 // Comparison returns a Predicate that compares typed byte slices that must
 // be TypeAddr with the value's address using a comparison based on op.
 // Only equality operands are allowed.
-func (a *Addr) Comparison(op string) (Predicate, error) {
+func (a Addr) Comparison(op string) (Predicate, error) {
 	compare, ok := compareAddr[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown addr comparator: %s", op)
 	}
-	pattern := a.Native
+	pattern := net.IP(a)
 	return func(e TypedEncoding) bool {
 		typeAddr, ok := e.Type.(*TypeOfAddr)
 		if !ok {
@@ -85,7 +88,7 @@ func (a *Addr) Comparison(op string) (Predicate, error) {
 	}, nil
 }
 
-func (a *Addr) Coerce(typ Type) Value {
+func (a Addr) Coerce(typ Type) Value {
 	_, ok := typ.(*TypeOfAddr)
 	if ok {
 		return a
@@ -94,7 +97,7 @@ func (a *Addr) Coerce(typ Type) Value {
 }
 
 func (a *Addr) MarshalJSON() ([]byte, error) {
-	return json.Marshal(a.Native)
+	return json.Marshal((*net.IP)(a))
 }
 
-func (a *Addr) Elements() ([]Value, bool) { return nil, false }
+func (a Addr) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/bool.go
+++ b/pkg/zeek/bool.go
@@ -62,35 +62,38 @@ func (t *TypeOfBool) New(value []byte) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Bool{Native: v}, nil
+	return NewBool(v), nil
 }
 
-type Bool struct {
-	Native bool
+type Bool bool
+
+func NewBool(b bool) *Bool {
+	p := Bool(b)
+	return &p
 }
 
-func (b *Bool) String() string {
-	return strconv.FormatBool(b.Native)
+func (b Bool) String() string {
+	return strconv.FormatBool(bool(b))
 }
 
-func (b *Bool) Encode(dst zval.Encoding) zval.Encoding {
+func (b Bool) Encode(dst zval.Encoding) zval.Encoding {
 	v := []byte(b.String())
 	return zval.AppendValue(dst, v)
 }
 
-func (b *Bool) Type() Type {
+func (b Bool) Type() Type {
 	return TypeBool
 }
 
 // Comparison returns a Predicate that compares typed byte slices that must
 // be a boolean or coercible to an integer.  In the later case, the integer
 // is converted to a boolean.
-func (b *Bool) Comparison(op string) (Predicate, error) {
+func (b Bool) Comparison(op string) (Predicate, error) {
 	compare, ok := compareBool[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown bool comparator: %s", op)
 	}
-	pattern := b.Native
+	pattern := bool(b)
 	return func(e TypedEncoding) bool {
 		typeBool, ok := e.Type.(*TypeOfBool)
 		if !ok {
@@ -105,7 +108,7 @@ func (b *Bool) Comparison(op string) (Predicate, error) {
 	return nil, fmt.Errorf("bad comparator for boolean type: %s", op)
 }
 
-func (b *Bool) Coerce(typ Type) Value {
+func (b Bool) Coerce(typ Type) Value {
 	_, ok := typ.(*TypeOfBool)
 	if ok {
 		return b
@@ -114,7 +117,7 @@ func (b *Bool) Coerce(typ Type) Value {
 }
 
 func (b *Bool) MarshalJSON() ([]byte, error) {
-	return json.Marshal(b.Native)
+	return json.Marshal((*bool)(b))
 }
 
-func (b *Bool) Elements() ([]Value, bool) { return nil, false }
+func (b Bool) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/count.go
+++ b/pkg/zeek/count.go
@@ -33,23 +33,26 @@ func (t *TypeOfCount) New(value []byte) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Count{Native: v}, nil
+	return NewCount(v), nil
 }
 
-type Count struct {
-	Native uint64
+type Count uint64
+
+func NewCount(c uint64) *Count {
+	p := Count(c)
+	return &p
 }
 
-func (c *Count) String() string {
-	return strconv.FormatUint(c.Native, 10)
+func (c Count) String() string {
+	return strconv.FormatUint(uint64(c), 10)
 }
 
-func (c *Count) Encode(dst zval.Encoding) zval.Encoding {
+func (c Count) Encode(dst zval.Encoding) zval.Encoding {
 	v := []byte(c.String())
 	return zval.AppendValue(dst, v)
 }
 
-func (c *Count) Type() Type {
+func (c Count) Type() Type {
 	return TypeCount
 }
 
@@ -69,7 +72,7 @@ func (c *Count) Coerce(typ Type) Value {
 }
 
 func (c *Count) MarshalJSON() ([]byte, error) {
-	return json.Marshal(c.Native)
+	return json.Marshal((*uint64)(c))
 }
 
 func (c *Count) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/enum.go
+++ b/pkg/zeek/enum.go
@@ -28,35 +28,38 @@ func (t *TypeOfEnum) New(value []byte) (Value, error) {
 	if value == nil {
 		return &Unset{}, nil
 	}
-	return &Enum{Native: string(value)}, nil
+	return NewEnum(string(value)), nil
 }
 
-type Enum struct {
-	Native string
+type Enum string
+
+func NewEnum(s string) *Enum {
+	p := Enum(s)
+	return &p
 }
 
-func (e *Enum) String() string {
-	return e.Native
+func (e Enum) String() string {
+	return string(e)
 }
 
-func (e *Enum) Encode(dst zval.Encoding) zval.Encoding {
+func (e Enum) Encode(dst zval.Encoding) zval.Encoding {
 	v := []byte(e.String())
 	return zval.AppendValue(dst, v)
 }
 
-func (e *Enum) Type() Type {
+func (e Enum) Type() Type {
 	return TypeEnum
 }
 
 // Comparison returns a Predicate that compares typed byte slices that must
 // be a string or enum with the value's string value using a comparison
 // based on op.
-func (e *Enum) Comparison(op string) (Predicate, error) {
+func (e Enum) Comparison(op string) (Predicate, error) {
 	compare, ok := compareString[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown enum comparator: %s", op)
 	}
-	pattern := e.Native
+	pattern := string(e)
 	return func(e TypedEncoding) bool {
 		switch e.Type.(type) {
 		case *TypeOfString, *TypeOfEnum:
@@ -69,7 +72,7 @@ func (e *Enum) Comparison(op string) (Predicate, error) {
 func (e *Enum) Coerce(typ Type) Value {
 	switch typ.(type) {
 	case *TypeOfString:
-		return &String{e.Native}
+		return NewString(string(*e))
 	case *TypeOfEnum:
 		return e
 	}
@@ -77,7 +80,7 @@ func (e *Enum) Coerce(typ Type) Value {
 }
 
 func (e *Enum) MarshalJSON() ([]byte, error) {
-	return json.Marshal(e.Native)
+	return json.Marshal((*string)(e))
 }
 
 func (e *Enum) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/none.go
+++ b/pkg/zeek/none.go
@@ -30,11 +30,11 @@ func (n *None) String() string {
 	return "none"
 }
 
-func (n *None) Encode(dst zval.Encoding) zval.Encoding {
+func (n None) Encode(dst zval.Encoding) zval.Encoding {
 	return zval.AppendValue(dst, []byte("none"))
 }
 
-func (n *None) Type() Type {
+func (n None) Type() Type {
 	return TypeNone
 }
 
@@ -50,4 +50,4 @@ func (n *None) MarshalJSON() ([]byte, error) {
 	return json.Marshal(nil)
 }
 
-func (n *None) Elements() ([]Value, bool) { return nil, false }
+func (n None) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/pattern.go
+++ b/pkg/zeek/pattern.go
@@ -34,18 +34,21 @@ func (t *TypeOfPattern) New(value []byte) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Pattern{Native: re}, nil
+	return NewPattern(re), nil
 }
 
 //XXX need to check if zeek regexp and go regexp are the same, though it
 // doesn't really matter because I don't think they appear in log files but
 // are rather used in zeek scripts
-type Pattern struct {
-	Native *regexp.Regexp
+type Pattern regexp.Regexp
+
+func NewPattern(r *regexp.Regexp) *Pattern {
+	p := Pattern(*r)
+	return &p
 }
 
 func (p *Pattern) String() string {
-	return p.Native.String()
+	return p.String()
 }
 
 func (p *Pattern) Encode(dst zval.Encoding) zval.Encoding {
@@ -65,7 +68,7 @@ func (p *Pattern) Comparison(op string) (Predicate, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown pattern comparator: %s", op)
 	}
-	re := p.Native
+	re := (*regexp.Regexp)(p)
 	return func(e TypedEncoding) bool {
 		switch e.Type.(type) {
 		case *TypeOfString, *TypeOfEnum:

--- a/pkg/zeek/port.go
+++ b/pkg/zeek/port.go
@@ -33,22 +33,25 @@ func (t *TypeOfPort) New(value []byte) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Port{Native: uint32(v)}, nil
+	return NewPort(uint32(v)), nil
 }
 
-type Port struct {
-	Native uint32
+type Port uint32
+
+func NewPort(p uint32) *Port {
+	v := Port(p)
+	return &v
 }
 
-func (p *Port) String() string {
-	return strconv.FormatUint(uint64(p.Native), 10)
+func (p Port) String() string {
+	return strconv.FormatUint(uint64(p), 10)
 }
 
-func (p *Port) Type() Type {
+func (p Port) Type() Type {
 	return TypePort
 }
 
-func (p *Port) Encode(dst zval.Encoding) zval.Encoding {
+func (p Port) Encode(dst zval.Encoding) zval.Encoding {
 	v := []byte(p.String())
 	return zval.AppendValue(dst, v)
 }
@@ -57,7 +60,7 @@ func (p *Port) Encode(dst zval.Encoding) zval.Encoding {
 // be a port with the value's port value using a comparison based on op.
 // Integer fields are not coerced (nor are any other types) so they never
 // match the port literal here.
-func (p *Port) Comparison(op string) (Predicate, error) {
+func (p Port) Comparison(op string) (Predicate, error) {
 	compare, ok := compareInt[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown port comparator: %s", op)
@@ -65,7 +68,7 @@ func (p *Port) Comparison(op string) (Predicate, error) {
 	// only a zeek port can be compared with a port type.  If the user went
 	// to the trouble of specifying a port match (e.g., ":80" vs "80") then
 	// we use strict typing here on the port comparison.
-	pattern := int64(p.Native)
+	pattern := int64(p)
 	return func(e TypedEncoding) bool {
 		typePort, ok := e.Type.(*TypeOfPort)
 		if !ok {
@@ -89,7 +92,7 @@ func (p *Port) Coerce(typ Type) Value {
 }
 
 func (p *Port) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.Native)
+	return json.Marshal(p)
 }
 
-func (p *Port) Elements() ([]Value, bool) { return nil, false }
+func (p Port) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/string.go
+++ b/pkg/zeek/string.go
@@ -36,35 +36,38 @@ func (t *TypeOfString) New(value []byte) (Value, error) {
 	if value == nil {
 		return &Unset{}, nil
 	}
-	return &String{Native: string(value)}, nil
+	return NewString(string(value)), nil
 }
 
-type String struct {
-	Native string
+type String string
+
+func NewString(s string) *String {
+	v := String(s)
+	return &v
 }
 
-func (s *String) String() string {
-	return s.Native
+func (s String) String() string {
+	return string(s)
 }
 
-func (s *String) Encode(dst zval.Encoding) zval.Encoding {
-	v := []byte(s.Native)
+func (s String) Encode(dst zval.Encoding) zval.Encoding {
+	v := []byte(s)
 	return zval.AppendValue(dst, v)
 }
 
-func (s *String) Type() Type {
+func (s String) Type() Type {
 	return TypeString
 }
 
 // Comparison returns a Predicate that compares typed byte slices that must
 // be a string or enum with the value's string value using a comparison
 // based on op.
-func (s *String) Comparison(op string) (Predicate, error) {
+func (s String) Comparison(op string) (Predicate, error) {
 	compare, ok := compareString[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown string comparator: %s", op)
 	}
-	pattern := s.Native
+	pattern := string(s)
 	return func(e TypedEncoding) bool {
 		switch e.Type.(type) {
 		case *TypeOfString, *TypeOfEnum:
@@ -79,13 +82,13 @@ func (s *String) Coerce(typ Type) Value {
 	case *TypeOfString:
 		return s
 	case *TypeOfEnum:
-		return &Enum{s.Native}
+		return NewEnum(string(*s))
 	}
 	return nil
 }
 
 func (s *String) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.Native)
+	return json.Marshal((*string)(s))
 }
 
 func (s *String) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/subnet.go
+++ b/pkg/zeek/subnet.go
@@ -71,15 +71,18 @@ func (t *TypeOfSubnet) New(value []byte) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Subnet{Native: subnet}, nil
+	return NewSubnet(subnet), nil
 }
 
-type Subnet struct {
-	Native *net.IPNet
+type Subnet net.IPNet
+
+func NewSubnet(s *net.IPNet) *Subnet {
+	v := Subnet(*s)
+	return &v
 }
 
 func (s *Subnet) String() string {
-	return s.Native.String()
+	return s.String()
 }
 
 func (s *Subnet) Encode(dst zval.Encoding) zval.Encoding {
@@ -103,7 +106,7 @@ func (s *Subnet) Comparison(op string) (Predicate, error) {
 	if !ok1 || !ok2 {
 		return nil, fmt.Errorf("unknown subnet comparator: %s", op)
 	}
-	pattern := s.Native
+	pattern := (*net.IPNet)(s)
 	return func(e TypedEncoding) bool {
 		val := e.Body
 		switch e.Type.(type) {
@@ -131,7 +134,7 @@ func (s *Subnet) Coerce(typ Type) Value {
 }
 
 func (s *Subnet) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.Native)
+	return json.Marshal((*net.IPNet)(s))
 }
 
 func (s *Subnet) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zeek/type_test.go
+++ b/pkg/zeek/type_test.go
@@ -46,13 +46,13 @@ func TestZeek(t *testing.T) {
 		{zeek.TypePort, "80"},
 		{zeek.TypePort, "8080"},
 	}
-	err := run(vals, "lt", &zeek.Int{101}, []bool{true, false, true, true, true, false, false, true, false})
+	err := run(vals, "lt", zeek.NewInt(101), []bool{true, false, true, true, true, false, false, true, false})
 	require.NoError(t, err)
-	err = run(vals, "lte", &zeek.Int{101}, []bool{true, true, true, true, true, false, false, true, false})
+	err = run(vals, "lte", zeek.NewInt(101), []bool{true, true, true, true, true, false, false, true, false})
 	require.NoError(t, err)
-	err = run(vals, "lte", &zeek.Double{100.2}, []bool{true, false, true, true, false, false, false, true, false})
+	err = run(vals, "lte", zeek.NewDouble(100.2), []bool{true, false, true, true, false, false, false, true, false})
 	require.NoError(t, err)
-	err = run(vals, "gt", &zeek.Port{100}, []bool{false, false, false, false, false, false, false, false, true})
+	err = run(vals, "gt", zeek.NewPort(100), []bool{false, false, false, false, false, false, false, false, true})
 	require.NoError(t, err)
 	addr1, _ := zeek.TypeAddr.New([]byte("128.32.1.1"))
 	addr2, _ := zeek.TypeAddr.New([]byte("128.32.2.2"))

--- a/pkg/zeek/unset.go
+++ b/pkg/zeek/unset.go
@@ -35,19 +35,19 @@ func (t *TypeOfUnset) New(value []byte) (Value, error) {
 
 type Unset struct{}
 
-func (u *Unset) String() string {
+func (u Unset) String() string {
 	return "-"
 }
 
-func (u *Unset) Encode(dst zval.Encoding) zval.Encoding {
+func (u Unset) Encode(dst zval.Encoding) zval.Encoding {
 	return zval.AppendValue(dst, nil)
 }
 
-func (u *Unset) Type() Type {
+func (u Unset) Type() Type {
 	return TypeUnset
 }
 
-func (u *Unset) Comparison(op string) (Predicate, error) {
+func (u Unset) Comparison(op string) (Predicate, error) {
 	compare, ok := compareUnset[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown unset comparator: %s", op)
@@ -69,4 +69,4 @@ func (u *Unset) MarshalJSON() ([]byte, error) {
 	return json.Marshal(nil)
 }
 
-func (u *Unset) Elements() ([]Value, bool) { return nil, false }
+func (u Unset) Elements() ([]Value, bool) { return nil, false }

--- a/pkg/zsio/text/writer.go
+++ b/pkg/zsio/text/writer.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mccanne/zq/pkg/nano"
 	"github.com/mccanne/zq/pkg/zeek"
 	zk "github.com/mccanne/zq/pkg/zsio/zeek"
 	"github.com/mccanne/zq/pkg/zson"
@@ -44,8 +45,8 @@ func (t *Text) Write(rec *zson.Record) error {
 		for k, col := range rec.Descriptor.Type.Columns {
 			var s, v string
 			if !t.EpochDates && col.Name == "ts" && col.Type == zeek.TypeTime {
-				ts := rec.ValueByColumn(k).(*zeek.Time).Native
-				v = ts.Time().UTC().Format(time.RFC3339Nano)
+				ts := *rec.ValueByColumn(k).(*zeek.Time)
+				v = nano.Ts(ts).Time().UTC().Format(time.RFC3339Nano)
 			} else {
 				body := rec.Slice(k)
 				typ := col.Type

--- a/pkg/zsio/zeek/flatten.go
+++ b/pkg/zsio/zeek/flatten.go
@@ -59,7 +59,7 @@ func (f *Flattener) Flatten(r *zson.Record) (*zson.Record, error) {
 		r.Descriptor = d
 		return r, nil
 	}
-	zv, err := recode(nil, r.Descriptor.Type, r.Raw)
+        zv, err := recode(nil, r.Descriptor.Type, r.Raw)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zsio/zeek/flatten.go
+++ b/pkg/zsio/zeek/flatten.go
@@ -59,7 +59,7 @@ func (f *Flattener) Flatten(r *zson.Record) (*zson.Record, error) {
 		r.Descriptor = d
 		return r, nil
 	}
-        zv, err := recode(nil, r.Descriptor.Type, r.Raw)
+	zv, err := recode(nil, r.Descriptor.Type, r.Raw)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zsio/zeek/parser_test.go
+++ b/pkg/zsio/zeek/parser_test.go
@@ -112,8 +112,9 @@ func TestLegacyZeekValid(t *testing.T) {
 
 func assertInt(t *testing.T, i int64, val zeek.Value, what string) {
 	iv, ok := val.(*zeek.Int)
+	actual := int64(*iv)
 	assert.Truef(t, ok, "%s is type int", what)
-	assert.Equalf(t, i, iv.Native, "%s has value %d", what, i)
+	assert.Equalf(t, i, actual, "%s has value %d", what, i)
 }
 
 func TestNestedRecords(t *testing.T) {

--- a/pkg/zson/resolver/table_test.go
+++ b/pkg/zson/resolver/table_test.go
@@ -15,7 +15,7 @@ func TestTableAddColumns(t *testing.T) {
 	r, err := zson.NewRecordZeekStrings(d, "S1")
 	require.NoError(t, err)
 	cols := []zeek.Column{{"ts", zeek.TypeTime}, {"s2", zeek.TypeString}}
-	r, err = tab.AddColumns(r, cols, []zeek.Value{&zeek.String{"123.456"}, &zeek.String{"S2"}})
+	r, err = tab.AddColumns(r, cols, []zeek.Value{zeek.NewString("123.456"), zeek.NewString("S2")})
 	require.NoError(t, err)
 	assert.EqualValues(t, 123456000000, r.Ts)
 	assert.EqualValues(t, "S1", r.Slice(0))

--- a/proc/uniq.go
+++ b/proc/uniq.go
@@ -23,7 +23,7 @@ func NewUniq(c *Context, parent Proc, cflag bool) *Uniq {
 func (u *Uniq) wrap(t *zson.Record) *zson.Record {
 	if u.cflag {
 		cols := []zeek.Column{{Name: "_uniq", Type: zeek.TypeCount}}
-		vals := []zeek.Value{&zeek.Count{u.count}}
+		vals := []zeek.Value{zeek.NewCount(u.count)}
 		newR, err := u.Resolver.AddColumns(t, cols, vals)
 		if err != nil {
 			u.Logger.Error("AddColumns failed", zap.Error(err))

--- a/reducer/avg.go
+++ b/reducer/avg.go
@@ -48,5 +48,5 @@ func (a *Avg) Result() zeek.Value {
 	if a.count > 0 {
 		v = a.sum / float64(a.count)
 	}
-	return &zeek.Double{v}
+	return zeek.NewDouble(v)
 }

--- a/reducer/count.go
+++ b/reducer/count.go
@@ -38,5 +38,5 @@ func (c *Count) Consume(r *zson.Record) {
 }
 
 func (c *Count) Result() zeek.Value {
-	return &zeek.Count{c.count}
+	return zeek.NewCount(c.count)
 }

--- a/reducer/countdistinct.go
+++ b/reducer/countdistinct.go
@@ -44,7 +44,7 @@ func (c *CountDistinct) Consume(r *zson.Record) {
 }
 
 func (c *CountDistinct) Result() zeek.Value {
-	return &zeek.Count{Native: c.sketch.Estimate()}
+	return zeek.NewCount(c.sketch.Estimate())
 }
 
 // Sketch returns the native structure used to compute the distinct count

--- a/reducer/error.go
+++ b/reducer/error.go
@@ -27,5 +27,5 @@ func NewError(def ast.Reducer, rec *zson.Record) *Error {
 func (e *Error) Consume(t *zson.Record) {}
 
 func (e *Error) Result() zeek.Value {
-	return &zeek.String{e.msg}
+	return zeek.NewString(e.msg)
 }

--- a/reducer/field/count.go
+++ b/reducer/field/count.go
@@ -16,15 +16,16 @@ func NewCountStreamfn(op string) Streamfn {
 	}
 }
 
-func (i *Count) Result() zeek.Value {
-	return &zeek.Count{i.fn.State}
+func (c *Count) Result() zeek.Value {
+	return zeek.NewCount(c.fn.State)
 }
 
-func (i *Count) Consume(v zeek.Value) error {
-	cv := zeek.CoerceToInt(v) //XXX need CoerceToCount?
-	if cv == nil {
+func (c *Count) Consume(v zeek.Value) error {
+	var i zeek.Int
+	//XXX need CoerceToCount?
+	if !zeek.CoerceToInt(v, &i) {
 		return zson.ErrTypeMismatch
 	}
-	i.fn.Update(uint64(cv.Native))
+	c.fn.Update(uint64(i))
 	return nil
 }

--- a/reducer/field/double.go
+++ b/reducer/field/double.go
@@ -17,14 +17,15 @@ func NewDoubleStreamfn(op string) Streamfn {
 }
 
 func (i *Double) Result() zeek.Value {
-	return &zeek.Double{i.fn.State}
+	return zeek.NewDouble(i.fn.State)
 }
 
 func (i *Double) Consume(v zeek.Value) error {
+	//XXX change this to use *zeek.Double
 	cv := zeek.CoerceToDouble(v)
 	if cv == nil {
 		return zson.ErrTypeMismatch
 	}
-	i.fn.Update(cv.Native)
+	i.fn.Update(float64(*cv))
 	return nil
 }

--- a/reducer/field/int.go
+++ b/reducer/field/int.go
@@ -17,14 +17,14 @@ func NewIntStreamfn(op string) Streamfn {
 }
 
 func (i *Int) Result() zeek.Value {
-	return &zeek.Int{i.fn.State}
+	return zeek.NewInt(i.fn.State)
 }
 
 func (i *Int) Consume(v zeek.Value) error {
-	cv := zeek.CoerceToInt(v)
-	if cv == nil {
+	var k zeek.Int
+	if !zeek.CoerceToInt(v, &k) {
 		return zson.ErrTypeMismatch
 	}
-	i.fn.Update(cv.Native)
+	i.fn.Update(int64(k))
 	return nil
 }

--- a/reducer/field/interval.go
+++ b/reducer/field/interval.go
@@ -17,14 +17,14 @@ func NewIntervalStreamfn(op string) Streamfn {
 }
 
 func (i *Interval) Result() zeek.Value {
-	return &zeek.Interval{i.fn.State}
+	return zeek.NewInterval(i.fn.State)
 }
 
 func (i *Interval) Consume(v zeek.Value) error {
-	cv := zeek.CoerceToInterval(v)
-	if cv == nil {
+	var interval zeek.Interval
+	if !zeek.CoerceToInterval(v, &interval) {
 		return zson.ErrTypeMismatch
 	}
-	i.fn.Update(cv.Native)
+	i.fn.Update(int64(interval))
 	return nil
 }

--- a/reducer/field/time.go
+++ b/reducer/field/time.go
@@ -1,6 +1,7 @@
 package field
 
 import (
+	"github.com/mccanne/zq/pkg/nano"
 	"github.com/mccanne/zq/pkg/zeek"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/streamfn"
@@ -17,14 +18,14 @@ func NewTimeStreamfn(op string) Streamfn {
 }
 
 func (t *Time) Result() zeek.Value {
-	return &zeek.Time{t.fn.State}
+	return zeek.NewTime(t.fn.State)
 }
 
 func (t *Time) Consume(v zeek.Value) error {
-	cv := zeek.CoerceToTime(v)
-	if cv == nil {
+	var cv zeek.Time
+	if !zeek.CoerceToTime(v, &cv) {
 		return zson.ErrTypeMismatch
 	}
-	t.fn.Update(cv.Native)
+	t.fn.Update(nano.Ts(cv))
 	return nil
 }


### PR DESCRIPTION
These changes simplify the zeek type system so scalar
values are representing directly as their native Go type
instead of having a struct that contained the Go value.

We also modified the CoerceTo functions so that they
can set a value by reference instead of creating a new one,
allowing the caller to allocate the value on the stack
thus avoiding sending temporary values through GC.

This is step 1 toward finishing the bzson transition to 
machine types to replace strings in byte slices.