### PR TITLE
Handle nested records in cut

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -161,7 +161,7 @@ type (
 	// sending each such modified record to its output in the order received.
 	CutProc struct {
 		Node
-		Fields []string `json:"fields"`
+		Fields []FieldExpr `json:"fields"`
 	}
 	// A HeadProc node represents a proc that forwards the indicated number
 	// of records then terminates.

--- a/ast/copy.go
+++ b/ast/copy.go
@@ -20,8 +20,10 @@ func (p *ParallelProc) Copy() Proc {
 }
 
 func (p *CutProc) Copy() Proc {
-	fields := make([]string, len(p.Fields))
-	copy(fields, p.Fields)
+	fields := make([]FieldExpr, len(p.Fields))
+	for i, f := range p.Fields {
+		fields[i] = f.Copy()
+	}
 	return &CutProc{
 		Node:   Node{p.Op},
 		Fields: fields,

--- a/ast/copy_test.go
+++ b/ast/copy_test.go
@@ -70,8 +70,14 @@ var testCopyJSON = []byte(`
     },
     {
       "fields": [
-        "d",
-        "e"
+        {
+          "op": "FieldRead",
+          "field": "d"
+        },
+        {
+          "op": "FieldRead",
+          "field": "e"
+        }
       ],
       "op": "CutProc"
     },
@@ -184,8 +190,14 @@ var testCopyJSONExpected = []byte(`
     },
     {
       "fields": [
-        "z",
-        "e"
+        {
+          "op": "FieldRead",
+          "field": "z"
+        },
+        {
+          "op": "FieldRead",
+          "field": "e"
+        }
       ],
       "op": "CutProc"
     },
@@ -244,7 +256,7 @@ func TestCopyAST(t *testing.T) {
 	copy := initialProc.Copy()
 	copy.(*ast.SequentialProc).Procs[0].(*ast.FilterProc).Filter.(*ast.LogicalAnd).Right.(*ast.LogicalOr).Right.(*ast.CompareField).Field.(*ast.FieldRead).Field = "d"
 	copy.(*ast.SequentialProc).Procs[0].(*ast.FilterProc).Filter.(*ast.LogicalAnd).Right.(*ast.LogicalOr).Right.(*ast.CompareField).Value.Value = "4"
-	copy.(*ast.SequentialProc).Procs[1].(*ast.CutProc).Fields[0] = "z"
+	copy.(*ast.SequentialProc).Procs[1].(*ast.CutProc).Fields[0].(*ast.FieldRead).Field = "z"
 	copy.(*ast.SequentialProc).Procs[2].(*ast.GroupByProc).Duration.Seconds = 3600
 	copy.(*ast.SequentialProc).Procs[2].(*ast.GroupByProc).Reducers[0].Field = "k"
 	copy.(*ast.SequentialProc).Procs[2].(*ast.GroupByProc).Keys[1].(*ast.FieldRead).Field = "p"

--- a/ast/unpack.go
+++ b/ast/unpack.go
@@ -67,7 +67,11 @@ func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
 		}
 		return &SortProc{Fields: fields}, nil
 	case "CutProc":
-		return &CutProc{}, nil
+		fields, err := unpackFieldExprArray(node.Get("fields"))
+		if err != nil {
+			return nil, err
+		}
+		return &CutProc{Fields: fields}, nil
 	case "HeadProc":
 		return &HeadProc{}, nil
 	case "TailProc":

--- a/expr/fieldexpr.go
+++ b/expr/fieldexpr.go
@@ -138,3 +138,18 @@ outer:
 		return e
 	}, nil
 }
+
+func CompileFieldExprArray(nodes []ast.FieldExpr) ([]FieldExprResolver, error) {
+	var resolvers []FieldExprResolver
+	if nodes != nil {
+		resolvers = make([]FieldExprResolver, 0, len(nodes))
+		for _, exp := range nodes {
+			res, err := CompileFieldExpr(exp)
+			if err != nil {
+				return nil, err
+			}
+			resolvers = append(resolvers, res)
+		}
+	}
+	return resolvers, nil
+}

--- a/proc/cut.go
+++ b/proc/cut.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mccanne/zq/ast"
+	"github.com/mccanne/zq/expr"
 	"github.com/mccanne/zq/pkg/zeek"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zval"
@@ -12,67 +14,259 @@ import (
 
 var ErrNoField = errors.New("cut field not found")
 
+// fieldInfo encodes the structure of a particular "cut" invocation in a
+// format that enables the runtime processing to happen as efficiently
+// as possible.  When handling an input record, we build an output record
+// using a zval.Builder but when handling fields within nested records,
+// calls to BeginContainer() and EndContainer() on the builder need to
+// happen at the right times to yield the proper output structure.
+// This is probably best illustrated with an example, consider the proc
+// "cut a, b.c, b.d, x.y.z".
+//
+// At runtime, this needs to turn into the following actions:
+// 1.  builder.Append([value of a from the input record])
+// 2.  builder.BeginContainer()  // for "b"
+// 3.  builder.Append([value of b.c from the input record])
+// 4.  builder.Append([value of b.d from the input record])
+// 5.  builder.EndContainer()    // for "b"
+// 6.  builder.BeginContainer()  // for "x"
+// 7.  builder.BeginContainer()  // for "x.y"
+// 8.  builder.Append([value of x.y.z. from the input record])
+// 9.  builder.EndContainer()    // for "x.y"
+// 10. builder.EndContainer()    // for "y"
+//
+// This is encoded into the following fieldInfo objects:
+//  {name: "a", containerBegins: [], containerEnds: 0}         // step 1
+//  {name: "c", containerBegins: ["b"], containerEnds: 0}      // steps 2-3
+//  {name: "d", containerBegins: [], containerEnds: 1     }    // steps 4-5
+//  {name: "z", containerBegins: ["x", "y"], containerEnds: 2} // steps 6-10
+type fieldInfo struct {
+	resolver        expr.FieldExprResolver
+	name            string
+	fullname        string
+	containerBegins []string
+	containerEnds   int
+}
+
 type Cut struct {
 	Base
-	fields   []string
+	fields   []fieldInfo
 	cutmap   map[int]*zson.Descriptor
 	nblocked int
+	builder  *zval.Builder
 }
 
-func NewCut(c *Context, parent Proc, fields []string) *Cut {
-	return &Cut{
-		Base:   Base{Context: c, Parent: parent},
-		fields: fields,
-		cutmap: make(map[int]*zson.Descriptor),
-	}
-}
-
-func (c *Cut) lookup(in *zson.Descriptor) *zson.Descriptor {
-	d, ok := c.cutmap[in.ID]
-	if ok {
-		return d
-	}
-	var columns []zeek.Column
-	for _, field := range c.fields {
-		colno, ok := in.ColumnOfField(field)
-		if !ok {
-			// a field is missing... block this descriptor
-			c.cutmap[in.ID] = nil
-			c.nblocked++
-			return nil
+// Build the structures we need to construct output records efficiently.
+// See the comment above for a description of the desired output.
+// Note that we require any nested fields from the same parent record
+// to be adjacent.  Alternatively we could re-order provided fields
+// so the output record can be constructed efficiently, though we don't
+// do this now since it might confuse users who expect to see output
+// fields in the order they specified.
+func CompileCutProc(c *Context, parent Proc, node *ast.CutProc) (*Cut, error) {
+	seenRecords := make(map[string]bool)
+	fieldInfos := make([]fieldInfo, 0, len(node.Fields))
+	var currentRecord []string
+	for i, field := range node.Fields {
+		resolver, err := expr.CompileFieldExpr(field)
+		if err != nil {
+			return nil, err
 		}
-		columns = append(columns, in.Type.Columns[colno])
+
+		names, err := split(field)
+		if err != nil {
+			return nil, err
+		}
+
+		// Grab everything except the leaf field name and see if
+		// it has changed from the previous field.  If it hasn't,
+		// things are simple but if it has, we need to carefully
+		// figure out which records we are stepping in and out of.
+		record := names[:len(names)-1]
+		var containerBegins []string
+		if !sameRecord(record, currentRecord) {
+			// currentRecord is what nested record the zval.Builder
+			// is currently working on, record is the nested
+			// record for the current field.  First figure out
+			// what (if any) common parents are shared.
+			l := len(currentRecord)
+			if len(record) < l {
+				l = len(record)
+			}
+			pos := 0
+			for pos < l {
+				if record[pos] != currentRecord[pos] {
+					break
+				}
+				pos += 1
+			}
+
+			// Note any previously encoded records that are
+			// now finished.
+			if i > 0 {
+				fieldInfos[i-1].containerEnds = len(currentRecord) - pos
+			}
+
+			// Validate any new records that we're starting
+			// (i.e., ensure that we didn't handle fields from
+			// the same record previously), then record the names
+			// of all these records.
+			for pos2 := pos; pos2 < len(record); pos2++ {
+				recname := strings.Join(record[:pos2+1], ".")
+				_, seen := seenRecords[recname]
+				if seen {
+					return nil, fmt.Errorf("All cut fields in record %s must be adjacent", recname)
+				}
+				seenRecords[recname] = true
+				containerBegins = append(containerBegins, record[pos2])
+			}
+			currentRecord = record
+		}
+		fullname := strings.Join(names, ".")
+		fname := names[len(names)-1]
+		fieldInfos = append(fieldInfos, fieldInfo{resolver, fname, fullname, containerBegins, 0})
 	}
-	out := c.Resolver.GetByColumns(columns)
-	c.cutmap[in.ID] = out
-	return out
+	fieldInfos[len(fieldInfos)-1].containerEnds = len(currentRecord)
+
+	return &Cut{
+		Base:    Base{Context: c, Parent: parent},
+		fields:  fieldInfos,
+		cutmap:  make(map[int]*zson.Descriptor),
+		builder: zval.NewBuilder(),
+	}, nil
+}
+
+// Split an ast.FieldExpr representing a chain of record field references
+// into a list of strings representing the names.
+// E.g., "x.y.z" -> ["x", "y", "z"]
+func split(node ast.FieldExpr) ([]string, error) {
+	switch n := node.(type) {
+	case *ast.FieldRead:
+		return []string{n.Field}, nil
+	case *ast.FieldCall:
+		if n.Fn != "RecordFieldRead" {
+			return nil, fmt.Errorf("unexpected field op %s", n.Fn)
+		}
+		names, err := split(n.Field)
+		if err != nil {
+			return nil, err
+		}
+		return append(names, n.Param), nil
+	default:
+		return nil, fmt.Errorf("unexpected node type %T", node)
+	}
+}
+
+func sameRecord(names1, names2 []string) bool {
+	if len(names1) != len(names2) {
+		return false
+	}
+	for i := range names1 {
+		if names1[i] != names2[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // CreateCut returns a new record value derived by keeping only the fields
 // specified by name in the fields slice.
-func (c *Cut) cut(d *zson.Descriptor, in *zson.Record) (*zson.Record, error) {
-	var zv zval.Encoding
-	for _, column := range d.Type.Columns {
-		// colno must exist for each field since the descriptor map
-		// entry is only created when all the fields exist.
-		colno, _ := in.ColumnOfField(column.Name)
-		zv = zval.Append(zv, in.Slice(colno), zeek.IsContainerType(column.Type))
+func (c *Cut) cut(in *zson.Record) (*zson.Record, error) {
+	// Check if we already have an output descriptor for this
+	// input type
+	d, ok := c.cutmap[in.ID]
+	if ok && d == nil {
+		// One or more cut fields isn't present in this type of
+		// input record, drop it now.
+		return nil, nil
 	}
-	return zson.NewRecordNoTs(d, zv), nil
+
+	c.builder.Reset()
+	var types []zeek.Type
+	if d == nil {
+		types = make([]zeek.Type, 0, len(c.fields))
+	}
+	// Build the output record.  If we've already seen this input
+	// record type, we don't care about the types, but if we haven't
+	// gather the types as well so we can construct the output
+	// descriptor.
+	for _, field := range c.fields {
+		val := field.resolver(in)
+		if d == nil {
+			if val.Type == nil {
+				// a field is missing... block this descriptor
+				c.cutmap[in.ID] = nil
+				c.nblocked++
+				return nil, nil
+			}
+			types = append(types, val.Type)
+		}
+		for range field.containerBegins {
+			c.builder.BeginContainer()
+		}
+		c.builder.Append(val.Body)
+		for i := 0; i < field.containerEnds; i++ {
+			c.builder.EndContainer()
+		}
+	}
+	if d == nil {
+		d = c.getOutputDescriptor(types)
+		c.cutmap[in.ID] = d
+	}
+
+	return zson.NewRecordNoTs(d, c.builder.Encode()), nil
+}
+
+// Using similar logic to the main loop inside cut(), allocate a
+// descriptor for an output record in which the cut fields have the types
+// indicated in the passed-in array of types.
+func (c *Cut) getOutputDescriptor(types []zeek.Type) *zson.Descriptor {
+	type rec struct {
+		name string
+		cols []zeek.Column
+	}
+	current := &rec{"", nil}
+	stack := make([]*rec, 1)
+	stack[0] = current
+
+	for i, field := range c.fields {
+		for _, name := range field.containerBegins {
+			current = &rec{name, nil}
+			stack = append(stack, current)
+		}
+
+		current.cols = append(current.cols, zeek.Column{Name: field.name, Type: types[i]})
+
+		for j := 0; j < field.containerEnds; j++ {
+			recType := zeek.LookupTypeRecord(current.cols)
+			slen := len(stack)
+			stack = stack[:slen-1]
+			cur := stack[slen-2]
+			cur.cols = append(cur.cols, zeek.Column{Name: current.name, Type: recType})
+			current = cur
+		}
+	}
+	if len(stack) != 1 {
+		panic("Mismatched container begin/end")
+	}
+	return c.Resolver.GetByColumns(stack[0].cols)
 }
 
 func (c *Cut) warn() {
 	if len(c.cutmap) > c.nblocked {
 		return
 	}
-	flds := strings.Join(c.fields, ",")
-	plural := ""
-	msg := "not present in input"
-	if len(c.fields) > 1 {
-		plural = "s"
-		msg = "not present together in input"
+	var msg string
+	if len(c.fields) == 1 {
+		msg = fmt.Sprintf("Cut field %s not present in input", c.fields[0].fullname)
+	} else {
+		names := make([]string, 0, len(c.fields))
+		for _, f := range c.fields {
+			names = append(names, f.fullname)
+		}
+		msg = fmt.Sprintf("Cut fields %s not present together in input", strings.Join(names, ","))
 	}
-	c.Warnings <- fmt.Sprintf("Cut field%s %s %s", plural, flds, msg)
+	c.Warnings <- msg
 }
 
 func (c *Cut) Pull() (zson.Batch, error) {
@@ -90,15 +284,13 @@ func (c *Cut) Pull() (zson.Batch, error) {
 	recs := make([]*zson.Record, 0, batch.Length())
 	for k := 0; k < batch.Length(); k++ {
 		in := batch.Index(k)
-		d := c.lookup(in.Descriptor)
-		if d == nil {
-			continue
-		}
-		out, err := c.cut(d, in)
+		out, err := c.cut(in)
 		if err != nil {
 			return nil, err
 		}
-		recs = append(recs, out)
+		if out != nil {
+			recs = append(recs, out)
+		}
 	}
 	if len(recs) == 0 {
 		c.warn()

--- a/proc/cut_test.go
+++ b/proc/cut_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mccanne/zq/proc"
+	"github.com/stretchr/testify/require"
 )
 
 // Data sets for tests
@@ -47,4 +48,51 @@ func TestCut(t *testing.T) {
 
 	// test cut on multiple fields.
 	proc.TestOneProc(t, fooAndBar, fooAndBar, "cut foo,bar")
+}
+
+// Test that illegal cut operations fail at compile time with a
+// reasonable error message.
+func testNonAdjacentFields(t *testing.T, zql string) {
+	_, err := proc.CompileTestProc(zql, nil, nil)
+	require.Error(t, err, "cut with non-adjacent records failed")
+	require.Regexp(t, "All cut fields in record \\S+ must be adjacent", err.Error(), "error message for cutting non-adjacent fields is correct")
+}
+
+func TestNotAdjacentErrors(t *testing.T) {
+	testNonAdjacentFields(t, "cut rec.sub1,other,rec.sub2")
+	testNonAdjacentFields(t, "cut rec1.rec2.sub1,other,rec1.sub2")
+	testNonAdjacentFields(t, "cut rec1.rec2.sub1,other,rec1.rec2.sub2")
+	testNonAdjacentFields(t, "cut t.rec.sub1,t.other,t.rec.sub2")
+}
+
+// More data sets
+const nestedIn1 = `
+#0:record[rec:record[foo:string,bar:string]]
+0:[[foo1;bar1;]]
+0:[[foo2;bar2;]]
+`
+
+const nestedOut1 = `
+#1:record[rec:record[foo:string]]
+1:[[foo1;]]
+1:[[foo2;]]
+`
+
+const nestedIn2 = `
+#0:record[foo:string,rec1:record[sub1:record[foo:string,bar:string],sub2:record[foo:string,bar:string]],rec2:record[foo:string]]
+0:[outer1;[[foo1.1;bar1.1;][foo2.1;bar2.1;]][foo3.1;]]
+0:[outer2;[[foo1.2;bar1.2;][foo2.2;bar2.2;]][foo3.2;]]
+`
+
+const nestedOut2 = `
+#0:record[rec1:record[sub1:record[foo:string],sub2:record[bar:string]],rec2:record[foo:string],foo:string]
+0:[[[foo1.1;][bar2.1;]][foo3.1;]outer1;]
+0:[[[foo1.2;][bar2.2;]][foo3.2;]outer2;]
+`
+
+// Test cutting fields inside nested records.
+func TestCutNested(t *testing.T) {
+	proc.TestOneProc(t, nestedIn1, nestedOut1, "cut rec.foo")
+	proc.TestOneProc(t, nestedIn1, nestedIn1, "cut rec.foo,rec.bar")
+	proc.TestOneProc(t, nestedIn2, nestedOut2, "cut rec1.sub1.foo,rec1.sub2.bar,rec2.foo,foo")
 }

--- a/proc/cut_test.go
+++ b/proc/cut_test.go
@@ -55,7 +55,8 @@ func TestCut(t *testing.T) {
 func testNonAdjacentFields(t *testing.T, zql string) {
 	_, err := proc.CompileTestProc(zql, nil, nil)
 	require.Error(t, err, "cut with non-adjacent records failed")
-	require.Regexp(t, "All cut fields in record \\S+ must be adjacent", err.Error(), "error message for cutting non-adjacent fields is correct")
+	_, ok := err.(proc.ErrNonAdjacent)
+	require.True(t, ok, "cut with non-adjacent records failed with the proper error")
 }
 
 func TestNotAdjacentErrors(t *testing.T) {

--- a/proc/cut_test.go
+++ b/proc/cut_test.go
@@ -3,76 +3,48 @@ package proc_test
 import (
 	"testing"
 
-	"github.com/mccanne/zq/pkg/nano"
-	"github.com/mccanne/zq/pkg/zeek"
-	"github.com/mccanne/zq/pkg/zson"
-	"github.com/mccanne/zq/pkg/zson/resolver"
 	"github.com/mccanne/zq/proc"
-	"github.com/stretchr/testify/require"
 )
 
+// Data sets for tests
+
+const fooOnly = `
+#0:record[foo:string]
+0:[foo1;]
+0:[foo2;]
+0:[foo3;]
+`
+
+const barOnly = `
+#1:record[bar:string]
+1:[bar1;]
+1:[bar2;]
+1:[bar3;]
+`
+
+const fooAndBar = `
+#0:record[foo:string,bar:string]
+0:[foo1;bar1;]
+0:[foo2;bar2;]
+0:[foo3;bar3;]
+`
+
 func TestCut(t *testing.T) {
-	resolver := resolver.NewTable()
-
-	// Set up a few batches to use in tests.
-	// XXX when we have ZSON parsing, this can get neater: we can
-	// just write the test inputs in zson and not have to create
-	// descriptors and records programatically...
-	fooDesc := resolver.GetByColumns([]zeek.Column{{"foo", zeek.TypeString}})
-	r1, err := zson.NewRecordZeekStrings(fooDesc, "foo1")
-	r2, err := zson.NewRecordZeekStrings(fooDesc, "foo2")
-	r3, err := zson.NewRecordZeekStrings(fooDesc, "foo3")
-	fooBatch := zson.NewArray([]*zson.Record{r1, r2, r3}, nano.MaxSpan)
-
-	barDesc := resolver.GetByColumns([]zeek.Column{{"bar", zeek.TypeString}})
-	r1, err = zson.NewRecordZeekStrings(barDesc, "bar1")
-	r2, err = zson.NewRecordZeekStrings(barDesc, "bar2")
-	r3, err = zson.NewRecordZeekStrings(barDesc, "bar3")
-	barBatch := zson.NewArray([]*zson.Record{r1, r2, r3}, nano.MaxSpan)
-
-	fooBarDesc := resolver.GetByColumns([]zeek.Column{
-		{"foo", zeek.TypeString},
-		{"bar", zeek.TypeString},
-	})
-	r1, err = zson.NewRecordZeekStrings(fooBarDesc, "foo1", "bar1")
-	r2, err = zson.NewRecordZeekStrings(fooBarDesc, "foo2", "bar2")
-	r3, err = zson.NewRecordZeekStrings(fooBarDesc, "foo3", "bar3")
-	fooBarBatch := zson.NewArray([]*zson.Record{r1, r2, r3}, nano.MaxSpan)
-
 	// test "cut foo" on records that only have field foo
-	pt, err := proc.NewProcTestFromSource("cut foo", resolver, []zson.Batch{fooBatch})
-	require.NoError(t, err)
-	require.NoError(t, pt.Expect(fooBatch))
-	require.NoError(t, pt.ExpectEOS())
-	require.NoError(t, pt.Finish())
+	proc.TestOneProc(t, fooOnly, fooOnly, "cut foo")
 
 	// test "cut foo" on records that have fields foo and bar
-	pt, err = proc.NewProcTestFromSource("cut foo", resolver, []zson.Batch{fooBarBatch})
-	require.NoError(t, err)
-	require.NoError(t, pt.Expect(fooBatch))
-	require.NoError(t, pt.ExpectEOS())
-	require.NoError(t, pt.Finish())
+	proc.TestOneProc(t, fooAndBar, fooOnly, "cut foo")
 
 	// test "cut foo" on records that don't have field foo
-	pt, err = proc.NewProcTestFromSource("cut foo", resolver, []zson.Batch{barBatch})
-	require.NoError(t, err)
-	require.NoError(t, pt.ExpectEOS())
-	require.NoError(t, pt.ExpectWarning("Cut field foo not present in input"))
-	require.NoError(t, pt.Finish())
+	warning := "Cut field foo not present in input"
+	proc.TestOneProcWithWarnings(t, barOnly, "", []string{warning}, "cut foo")
 
 	// test "cut foo" on some fields with foo, some without
 	// Note there is no warning in this case since some of the input
 	// records have field "foo".
-	pt, err = proc.NewProcTestFromSource("cut foo", resolver, []zson.Batch{fooBatch, barBatch})
-	require.NoError(t, err)
-	require.NoError(t, pt.Expect(fooBatch))
-	require.NoError(t, pt.ExpectEOS())
-	require.NoError(t, pt.Finish())
+	proc.TestOneProc(t, fooOnly+barOnly, fooOnly, "cut foo")
 
 	// test cut on multiple fields.
-	pt, err = proc.NewProcTestFromSource("cut foo,bar", resolver, []zson.Batch{fooBarBatch})
-	require.NoError(t, err)
-	require.NoError(t, pt.Expect(fooBarBatch))
-	require.NoError(t, pt.ExpectEOS())
-	require.NoError(t, pt.Finish())
+	proc.TestOneProc(t, fooAndBar, fooAndBar, "cut foo,bar")
 }

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -145,19 +145,16 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 		return []Proc{NewGroupBy(c, parent, *params)}, nil
 
 	case *ast.CutProc:
-		return []Proc{NewCut(c, parent, v.Fields)}, nil
+		cut, err := CompileCutProc(c, parent, v)
+		if err != nil {
+			return nil, err
+		}
+		return []Proc{cut}, nil
 
 	case *ast.SortProc:
-		var fields []expr.FieldExprResolver
-		if v.Fields != nil {
-			fields = make([]expr.FieldExprResolver, 0, len(v.Fields))
-			for _, exp := range v.Fields {
-				res, err := expr.CompileFieldExpr(exp)
-				if err != nil {
-					return nil, err
-				}
-				fields = append(fields, res)
-			}
+		fields, err := expr.CompileFieldExprArray(v.Fields)
+		if err != nil {
+			return nil, err
 		}
 		return []Proc{NewSort(c, parent, v.Limit, fields, v.SortDir)}, nil
 
@@ -189,16 +186,9 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 		return []Proc{NewFilter(c, parent, f)}, nil
 
 	case *ast.TopProc:
-		var fields []expr.FieldExprResolver
-		if v.Fields != nil {
-			fields = make([]expr.FieldExprResolver, 0, len(v.Fields))
-			for _, exp := range v.Fields {
-				res, err := expr.CompileFieldExpr(exp)
-				if err != nil {
-					return nil, err
-				}
-				fields = append(fields, res)
-			}
+		fields, err := expr.CompileFieldExprArray(v.Fields)
+		if err != nil {
+			return nil, err
 		}
 		return []Proc{NewTop(c, parent, v.Limit, fields, v.Flush)}, nil
 

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func compileProc(code string, ctx *Context, parent Proc) (Proc, error) {
+func CompileTestProc(code string, ctx *Context, parent Proc) (Proc, error) {
 	// XXX If we use a newer version of pigeon, we can just compile
 	// with "proc" as the terminal symbol.
 	// But for now, we have to compile a complete flowgraph.
@@ -108,7 +108,7 @@ func NewTestContext(res *resolver.Table) *Context {
 func NewProcTestFromSource(code string, resolver *resolver.Table, inRecords []zson.Batch) (*ProcTest, error) {
 	ctx := NewTestContext(resolver)
 	src := TestSource{inRecords, 0}
-	compiledProc, err := compileProc(code, ctx, &src)
+	compiledProc, err := CompileTestProc(code, ctx, &src)
 	if err != nil {
 		return nil, err
 	}

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -186,7 +186,7 @@ func makeTopProc(fieldsIn, limitIn, flushIn interface{}) *ast.TopProc {
 }
 
 func makeCutProc(fieldsIn interface{}) *ast.CutProc {
-	fields := stringArray(fieldsIn)
+	fields := fieldExprArray(fieldsIn)
 	return &ast.CutProc{ast.Node{"CutProc"}, fields}
 }
 

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1669,51 +1669,165 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "fieldNameList",
+			name: "fieldRefDotOnly",
 			pos:  position{line: 229, col: 1, offset: 5544},
 			expr: &actionExpr{
-				pos: position{line: 230, col: 5, offset: 5562},
-				run: (*parser).callonfieldNameList1,
+				pos: position{line: 230, col: 5, offset: 5564},
+				run: (*parser).callonfieldRefDotOnly1,
 				expr: &seqExpr{
-					pos: position{line: 230, col: 5, offset: 5562},
+					pos: position{line: 230, col: 5, offset: 5564},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 230, col: 5, offset: 5562},
-							label: "first",
+							pos:   position{line: 230, col: 5, offset: 5564},
+							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 230, col: 11, offset: 5568},
+								pos:  position{line: 230, col: 10, offset: 5569},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 230, col: 21, offset: 5578},
+							pos:   position{line: 230, col: 20, offset: 5579},
+							label: "refs",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 230, col: 25, offset: 5584},
+								expr: &actionExpr{
+									pos: position{line: 230, col: 26, offset: 5585},
+									run: (*parser).callonfieldRefDotOnly7,
+									expr: &seqExpr{
+										pos: position{line: 230, col: 26, offset: 5585},
+										exprs: []interface{}{
+											&litMatcher{
+												pos:        position{line: 230, col: 26, offset: 5585},
+												val:        ".",
+												ignoreCase: false,
+											},
+											&labeledExpr{
+												pos:   position{line: 230, col: 30, offset: 5589},
+												label: "field",
+												expr: &ruleRefExpr{
+													pos:  position{line: 230, col: 36, offset: 5595},
+													name: "fieldName",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fieldRefDotOnlyList",
+			pos:  position{line: 234, col: 1, offset: 5720},
+			expr: &actionExpr{
+				pos: position{line: 235, col: 5, offset: 5744},
+				run: (*parser).callonfieldRefDotOnlyList1,
+				expr: &seqExpr{
+					pos: position{line: 235, col: 5, offset: 5744},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 235, col: 5, offset: 5744},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 235, col: 11, offset: 5750},
+								name: "fieldRefDotOnly",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 235, col: 27, offset: 5766},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 230, col: 26, offset: 5583},
+								pos: position{line: 235, col: 32, offset: 5771},
+								expr: &actionExpr{
+									pos: position{line: 235, col: 33, offset: 5772},
+									run: (*parser).callonfieldRefDotOnlyList7,
+									expr: &seqExpr{
+										pos: position{line: 235, col: 33, offset: 5772},
+										exprs: []interface{}{
+											&zeroOrOneExpr{
+												pos: position{line: 235, col: 33, offset: 5772},
+												expr: &ruleRefExpr{
+													pos:  position{line: 235, col: 33, offset: 5772},
+													name: "_",
+												},
+											},
+											&litMatcher{
+												pos:        position{line: 235, col: 36, offset: 5775},
+												val:        ",",
+												ignoreCase: false,
+											},
+											&zeroOrOneExpr{
+												pos: position{line: 235, col: 40, offset: 5779},
+												expr: &ruleRefExpr{
+													pos:  position{line: 235, col: 40, offset: 5779},
+													name: "_",
+												},
+											},
+											&labeledExpr{
+												pos:   position{line: 235, col: 43, offset: 5782},
+												label: "ref",
+												expr: &ruleRefExpr{
+													pos:  position{line: 235, col: 47, offset: 5786},
+													name: "fieldRefDotOnly",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fieldNameList",
+			pos:  position{line: 243, col: 1, offset: 5966},
+			expr: &actionExpr{
+				pos: position{line: 244, col: 5, offset: 5984},
+				run: (*parser).callonfieldNameList1,
+				expr: &seqExpr{
+					pos: position{line: 244, col: 5, offset: 5984},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 244, col: 5, offset: 5984},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 244, col: 11, offset: 5990},
+								name: "fieldName",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 244, col: 21, offset: 6000},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 244, col: 26, offset: 6005},
 								expr: &seqExpr{
-									pos: position{line: 230, col: 27, offset: 5584},
+									pos: position{line: 244, col: 27, offset: 6006},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 230, col: 27, offset: 5584},
+											pos: position{line: 244, col: 27, offset: 6006},
 											expr: &ruleRefExpr{
-												pos:  position{line: 230, col: 27, offset: 5584},
+												pos:  position{line: 244, col: 27, offset: 6006},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 230, col: 30, offset: 5587},
+											pos:        position{line: 244, col: 30, offset: 6009},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 230, col: 34, offset: 5591},
+											pos: position{line: 244, col: 34, offset: 6013},
 											expr: &ruleRefExpr{
-												pos:  position{line: 230, col: 34, offset: 5591},
+												pos:  position{line: 244, col: 34, offset: 6013},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 230, col: 37, offset: 5594},
+											pos:  position{line: 244, col: 37, offset: 6016},
 											name: "fieldName",
 										},
 									},
@@ -1726,12 +1840,12 @@ var g = &grammar{
 		},
 		{
 			name: "countOp",
-			pos:  position{line: 238, col: 1, offset: 5787},
+			pos:  position{line: 252, col: 1, offset: 6209},
 			expr: &actionExpr{
-				pos: position{line: 239, col: 5, offset: 5799},
+				pos: position{line: 253, col: 5, offset: 6221},
 				run: (*parser).calloncountOp1,
 				expr: &litMatcher{
-					pos:        position{line: 239, col: 5, offset: 5799},
+					pos:        position{line: 253, col: 5, offset: 6221},
 					val:        "count",
 					ignoreCase: true,
 				},
@@ -1739,105 +1853,105 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducerOp",
-			pos:  position{line: 241, col: 1, offset: 5833},
+			pos:  position{line: 255, col: 1, offset: 6255},
 			expr: &choiceExpr{
-				pos: position{line: 242, col: 5, offset: 5852},
+				pos: position{line: 256, col: 5, offset: 6274},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 242, col: 5, offset: 5852},
+						pos: position{line: 256, col: 5, offset: 6274},
 						run: (*parser).callonfieldReducerOp2,
 						expr: &litMatcher{
-							pos:        position{line: 242, col: 5, offset: 5852},
+							pos:        position{line: 256, col: 5, offset: 6274},
 							val:        "sum",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 243, col: 5, offset: 5886},
+						pos: position{line: 257, col: 5, offset: 6308},
 						run: (*parser).callonfieldReducerOp4,
 						expr: &litMatcher{
-							pos:        position{line: 243, col: 5, offset: 5886},
+							pos:        position{line: 257, col: 5, offset: 6308},
 							val:        "avg",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 244, col: 5, offset: 5920},
+						pos: position{line: 258, col: 5, offset: 6342},
 						run: (*parser).callonfieldReducerOp6,
 						expr: &litMatcher{
-							pos:        position{line: 244, col: 5, offset: 5920},
+							pos:        position{line: 258, col: 5, offset: 6342},
 							val:        "stdev",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 245, col: 5, offset: 5957},
+						pos: position{line: 259, col: 5, offset: 6379},
 						run: (*parser).callonfieldReducerOp8,
 						expr: &litMatcher{
-							pos:        position{line: 245, col: 5, offset: 5957},
+							pos:        position{line: 259, col: 5, offset: 6379},
 							val:        "sd",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 246, col: 5, offset: 5993},
+						pos: position{line: 260, col: 5, offset: 6415},
 						run: (*parser).callonfieldReducerOp10,
 						expr: &litMatcher{
-							pos:        position{line: 246, col: 5, offset: 5993},
+							pos:        position{line: 260, col: 5, offset: 6415},
 							val:        "var",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 247, col: 5, offset: 6027},
+						pos: position{line: 261, col: 5, offset: 6449},
 						run: (*parser).callonfieldReducerOp12,
 						expr: &litMatcher{
-							pos:        position{line: 247, col: 5, offset: 6027},
+							pos:        position{line: 261, col: 5, offset: 6449},
 							val:        "entropy",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 248, col: 5, offset: 6068},
+						pos: position{line: 262, col: 5, offset: 6490},
 						run: (*parser).callonfieldReducerOp14,
 						expr: &litMatcher{
-							pos:        position{line: 248, col: 5, offset: 6068},
+							pos:        position{line: 262, col: 5, offset: 6490},
 							val:        "min",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 249, col: 5, offset: 6102},
+						pos: position{line: 263, col: 5, offset: 6524},
 						run: (*parser).callonfieldReducerOp16,
 						expr: &litMatcher{
-							pos:        position{line: 249, col: 5, offset: 6102},
+							pos:        position{line: 263, col: 5, offset: 6524},
 							val:        "max",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 250, col: 5, offset: 6136},
+						pos: position{line: 264, col: 5, offset: 6558},
 						run: (*parser).callonfieldReducerOp18,
 						expr: &litMatcher{
-							pos:        position{line: 250, col: 5, offset: 6136},
+							pos:        position{line: 264, col: 5, offset: 6558},
 							val:        "first",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 251, col: 5, offset: 6174},
+						pos: position{line: 265, col: 5, offset: 6596},
 						run: (*parser).callonfieldReducerOp20,
 						expr: &litMatcher{
-							pos:        position{line: 251, col: 5, offset: 6174},
+							pos:        position{line: 265, col: 5, offset: 6596},
 							val:        "last",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 252, col: 5, offset: 6210},
+						pos: position{line: 266, col: 5, offset: 6632},
 						run: (*parser).callonfieldReducerOp22,
 						expr: &litMatcher{
-							pos:        position{line: 252, col: 5, offset: 6210},
+							pos:        position{line: 266, col: 5, offset: 6632},
 							val:        "countdistinct",
 							ignoreCase: true,
 						},
@@ -1847,32 +1961,32 @@ var g = &grammar{
 		},
 		{
 			name: "paddedFieldName",
-			pos:  position{line: 254, col: 1, offset: 6260},
+			pos:  position{line: 268, col: 1, offset: 6682},
 			expr: &actionExpr{
-				pos: position{line: 254, col: 19, offset: 6278},
+				pos: position{line: 268, col: 19, offset: 6700},
 				run: (*parser).callonpaddedFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 254, col: 19, offset: 6278},
+					pos: position{line: 268, col: 19, offset: 6700},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 254, col: 19, offset: 6278},
+							pos: position{line: 268, col: 19, offset: 6700},
 							expr: &ruleRefExpr{
-								pos:  position{line: 254, col: 19, offset: 6278},
+								pos:  position{line: 268, col: 19, offset: 6700},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 254, col: 22, offset: 6281},
+							pos:   position{line: 268, col: 22, offset: 6703},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 254, col: 28, offset: 6287},
+								pos:  position{line: 268, col: 28, offset: 6709},
 								name: "fieldName",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 254, col: 38, offset: 6297},
+							pos: position{line: 268, col: 38, offset: 6719},
 							expr: &ruleRefExpr{
-								pos:  position{line: 254, col: 38, offset: 6297},
+								pos:  position{line: 268, col: 38, offset: 6719},
 								name: "_",
 							},
 						},
@@ -1882,53 +1996,53 @@ var g = &grammar{
 		},
 		{
 			name: "countReducer",
-			pos:  position{line: 256, col: 1, offset: 6323},
+			pos:  position{line: 270, col: 1, offset: 6745},
 			expr: &actionExpr{
-				pos: position{line: 257, col: 5, offset: 6340},
+				pos: position{line: 271, col: 5, offset: 6762},
 				run: (*parser).calloncountReducer1,
 				expr: &seqExpr{
-					pos: position{line: 257, col: 5, offset: 6340},
+					pos: position{line: 271, col: 5, offset: 6762},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 257, col: 5, offset: 6340},
+							pos:   position{line: 271, col: 5, offset: 6762},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 257, col: 8, offset: 6343},
+								pos:  position{line: 271, col: 8, offset: 6765},
 								name: "countOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 257, col: 16, offset: 6351},
+							pos: position{line: 271, col: 16, offset: 6773},
 							expr: &ruleRefExpr{
-								pos:  position{line: 257, col: 16, offset: 6351},
+								pos:  position{line: 271, col: 16, offset: 6773},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 257, col: 19, offset: 6354},
+							pos:        position{line: 271, col: 19, offset: 6776},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 257, col: 23, offset: 6358},
+							pos:   position{line: 271, col: 23, offset: 6780},
 							label: "field",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 257, col: 29, offset: 6364},
+								pos: position{line: 271, col: 29, offset: 6786},
 								expr: &ruleRefExpr{
-									pos:  position{line: 257, col: 29, offset: 6364},
+									pos:  position{line: 271, col: 29, offset: 6786},
 									name: "paddedFieldName",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 257, col: 47, offset: 6382},
+							pos: position{line: 271, col: 47, offset: 6804},
 							expr: &ruleRefExpr{
-								pos:  position{line: 257, col: 47, offset: 6382},
+								pos:  position{line: 271, col: 47, offset: 6804},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 257, col: 50, offset: 6385},
+							pos:        position{line: 271, col: 50, offset: 6807},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1938,57 +2052,57 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducer",
-			pos:  position{line: 261, col: 1, offset: 6444},
+			pos:  position{line: 275, col: 1, offset: 6866},
 			expr: &actionExpr{
-				pos: position{line: 262, col: 5, offset: 6461},
+				pos: position{line: 276, col: 5, offset: 6883},
 				run: (*parser).callonfieldReducer1,
 				expr: &seqExpr{
-					pos: position{line: 262, col: 5, offset: 6461},
+					pos: position{line: 276, col: 5, offset: 6883},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 262, col: 5, offset: 6461},
+							pos:   position{line: 276, col: 5, offset: 6883},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 262, col: 8, offset: 6464},
+								pos:  position{line: 276, col: 8, offset: 6886},
 								name: "fieldReducerOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 262, col: 23, offset: 6479},
+							pos: position{line: 276, col: 23, offset: 6901},
 							expr: &ruleRefExpr{
-								pos:  position{line: 262, col: 23, offset: 6479},
+								pos:  position{line: 276, col: 23, offset: 6901},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 262, col: 26, offset: 6482},
+							pos:        position{line: 276, col: 26, offset: 6904},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 262, col: 30, offset: 6486},
+							pos: position{line: 276, col: 30, offset: 6908},
 							expr: &ruleRefExpr{
-								pos:  position{line: 262, col: 30, offset: 6486},
+								pos:  position{line: 276, col: 30, offset: 6908},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 262, col: 33, offset: 6489},
+							pos:   position{line: 276, col: 33, offset: 6911},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 262, col: 39, offset: 6495},
+								pos:  position{line: 276, col: 39, offset: 6917},
 								name: "fieldName",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 262, col: 50, offset: 6506},
+							pos: position{line: 276, col: 50, offset: 6928},
 							expr: &ruleRefExpr{
-								pos:  position{line: 262, col: 50, offset: 6506},
+								pos:  position{line: 276, col: 50, offset: 6928},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 262, col: 53, offset: 6509},
+							pos:        position{line: 276, col: 53, offset: 6931},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1998,27 +2112,27 @@ var g = &grammar{
 		},
 		{
 			name: "reducerProc",
-			pos:  position{line: 266, col: 1, offset: 6576},
+			pos:  position{line: 280, col: 1, offset: 6998},
 			expr: &actionExpr{
-				pos: position{line: 267, col: 5, offset: 6592},
+				pos: position{line: 281, col: 5, offset: 7014},
 				run: (*parser).callonreducerProc1,
 				expr: &seqExpr{
-					pos: position{line: 267, col: 5, offset: 6592},
+					pos: position{line: 281, col: 5, offset: 7014},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 267, col: 5, offset: 6592},
+							pos:   position{line: 281, col: 5, offset: 7014},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 267, col: 11, offset: 6598},
+								pos: position{line: 281, col: 11, offset: 7020},
 								expr: &seqExpr{
-									pos: position{line: 267, col: 12, offset: 6599},
+									pos: position{line: 281, col: 12, offset: 7021},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 267, col: 12, offset: 6599},
+											pos:  position{line: 281, col: 12, offset: 7021},
 											name: "everyDur",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 267, col: 21, offset: 6608},
+											pos:  position{line: 281, col: 21, offset: 7030},
 											name: "_",
 										},
 									},
@@ -2026,27 +2140,27 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 267, col: 25, offset: 6612},
+							pos:   position{line: 281, col: 25, offset: 7034},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 267, col: 34, offset: 6621},
+								pos:  position{line: 281, col: 34, offset: 7043},
 								name: "reducerList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 267, col: 46, offset: 6633},
+							pos:   position{line: 281, col: 46, offset: 7055},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 267, col: 51, offset: 6638},
+								pos: position{line: 281, col: 51, offset: 7060},
 								expr: &seqExpr{
-									pos: position{line: 267, col: 52, offset: 6639},
+									pos: position{line: 281, col: 52, offset: 7061},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 267, col: 52, offset: 6639},
+											pos:  position{line: 281, col: 52, offset: 7061},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 267, col: 54, offset: 6641},
+											pos:  position{line: 281, col: 54, offset: 7063},
 											name: "groupBy",
 										},
 									},
@@ -2054,12 +2168,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 267, col: 64, offset: 6651},
+							pos:   position{line: 281, col: 64, offset: 7073},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 267, col: 70, offset: 6657},
+								pos: position{line: 281, col: 70, offset: 7079},
 								expr: &ruleRefExpr{
-									pos:  position{line: 267, col: 70, offset: 6657},
+									pos:  position{line: 281, col: 70, offset: 7079},
 									name: "procLimitArg",
 								},
 							},
@@ -2070,27 +2184,27 @@ var g = &grammar{
 		},
 		{
 			name: "asClause",
-			pos:  position{line: 285, col: 1, offset: 7014},
+			pos:  position{line: 299, col: 1, offset: 7436},
 			expr: &actionExpr{
-				pos: position{line: 286, col: 5, offset: 7027},
+				pos: position{line: 300, col: 5, offset: 7449},
 				run: (*parser).callonasClause1,
 				expr: &seqExpr{
-					pos: position{line: 286, col: 5, offset: 7027},
+					pos: position{line: 300, col: 5, offset: 7449},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 286, col: 5, offset: 7027},
+							pos:        position{line: 300, col: 5, offset: 7449},
 							val:        "as",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 286, col: 11, offset: 7033},
+							pos:  position{line: 300, col: 11, offset: 7455},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 286, col: 13, offset: 7035},
+							pos:   position{line: 300, col: 13, offset: 7457},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 286, col: 15, offset: 7037},
+								pos:  position{line: 300, col: 15, offset: 7459},
 								name: "fieldName",
 							},
 						},
@@ -2100,48 +2214,48 @@ var g = &grammar{
 		},
 		{
 			name: "reducerExpr",
-			pos:  position{line: 288, col: 1, offset: 7066},
+			pos:  position{line: 302, col: 1, offset: 7488},
 			expr: &choiceExpr{
-				pos: position{line: 289, col: 5, offset: 7082},
+				pos: position{line: 303, col: 5, offset: 7504},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 289, col: 5, offset: 7082},
+						pos: position{line: 303, col: 5, offset: 7504},
 						run: (*parser).callonreducerExpr2,
 						expr: &seqExpr{
-							pos: position{line: 289, col: 5, offset: 7082},
+							pos: position{line: 303, col: 5, offset: 7504},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 289, col: 5, offset: 7082},
+									pos:   position{line: 303, col: 5, offset: 7504},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 289, col: 11, offset: 7088},
+										pos:  position{line: 303, col: 11, offset: 7510},
 										name: "fieldName",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 289, col: 21, offset: 7098},
+									pos: position{line: 303, col: 21, offset: 7520},
 									expr: &ruleRefExpr{
-										pos:  position{line: 289, col: 21, offset: 7098},
+										pos:  position{line: 303, col: 21, offset: 7520},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 289, col: 24, offset: 7101},
+									pos:        position{line: 303, col: 24, offset: 7523},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 289, col: 28, offset: 7105},
+									pos: position{line: 303, col: 28, offset: 7527},
 									expr: &ruleRefExpr{
-										pos:  position{line: 289, col: 28, offset: 7105},
+										pos:  position{line: 303, col: 28, offset: 7527},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 289, col: 31, offset: 7108},
+									pos:   position{line: 303, col: 31, offset: 7530},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 289, col: 33, offset: 7110},
+										pos:  position{line: 303, col: 33, offset: 7532},
 										name: "reducer",
 									},
 								},
@@ -2149,28 +2263,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 292, col: 5, offset: 7173},
+						pos: position{line: 306, col: 5, offset: 7595},
 						run: (*parser).callonreducerExpr13,
 						expr: &seqExpr{
-							pos: position{line: 292, col: 5, offset: 7173},
+							pos: position{line: 306, col: 5, offset: 7595},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 292, col: 5, offset: 7173},
+									pos:   position{line: 306, col: 5, offset: 7595},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 292, col: 7, offset: 7175},
+										pos:  position{line: 306, col: 7, offset: 7597},
 										name: "reducer",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 292, col: 15, offset: 7183},
+									pos:  position{line: 306, col: 15, offset: 7605},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 292, col: 17, offset: 7185},
+									pos:   position{line: 306, col: 17, offset: 7607},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 292, col: 23, offset: 7191},
+										pos:  position{line: 306, col: 23, offset: 7613},
 										name: "asClause",
 									},
 								},
@@ -2178,7 +2292,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 295, col: 5, offset: 7255},
+						pos:  position{line: 309, col: 5, offset: 7677},
 						name: "reducer",
 					},
 				},
@@ -2186,16 +2300,16 @@ var g = &grammar{
 		},
 		{
 			name: "reducer",
-			pos:  position{line: 297, col: 1, offset: 7264},
+			pos:  position{line: 311, col: 1, offset: 7686},
 			expr: &choiceExpr{
-				pos: position{line: 298, col: 5, offset: 7276},
+				pos: position{line: 312, col: 5, offset: 7698},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 298, col: 5, offset: 7276},
+						pos:  position{line: 312, col: 5, offset: 7698},
 						name: "countReducer",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 299, col: 5, offset: 7293},
+						pos:  position{line: 313, col: 5, offset: 7715},
 						name: "fieldReducer",
 					},
 				},
@@ -2203,50 +2317,50 @@ var g = &grammar{
 		},
 		{
 			name: "reducerList",
-			pos:  position{line: 301, col: 1, offset: 7307},
+			pos:  position{line: 315, col: 1, offset: 7729},
 			expr: &actionExpr{
-				pos: position{line: 302, col: 5, offset: 7323},
+				pos: position{line: 316, col: 5, offset: 7745},
 				run: (*parser).callonreducerList1,
 				expr: &seqExpr{
-					pos: position{line: 302, col: 5, offset: 7323},
+					pos: position{line: 316, col: 5, offset: 7745},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 302, col: 5, offset: 7323},
+							pos:   position{line: 316, col: 5, offset: 7745},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 11, offset: 7329},
+								pos:  position{line: 316, col: 11, offset: 7751},
 								name: "reducerExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 23, offset: 7341},
+							pos:   position{line: 316, col: 23, offset: 7763},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 302, col: 28, offset: 7346},
+								pos: position{line: 316, col: 28, offset: 7768},
 								expr: &seqExpr{
-									pos: position{line: 302, col: 29, offset: 7347},
+									pos: position{line: 316, col: 29, offset: 7769},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 302, col: 29, offset: 7347},
+											pos: position{line: 316, col: 29, offset: 7769},
 											expr: &ruleRefExpr{
-												pos:  position{line: 302, col: 29, offset: 7347},
+												pos:  position{line: 316, col: 29, offset: 7769},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 302, col: 32, offset: 7350},
+											pos:        position{line: 316, col: 32, offset: 7772},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 302, col: 36, offset: 7354},
+											pos: position{line: 316, col: 36, offset: 7776},
 											expr: &ruleRefExpr{
-												pos:  position{line: 302, col: 36, offset: 7354},
+												pos:  position{line: 316, col: 36, offset: 7776},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 302, col: 39, offset: 7357},
+											pos:  position{line: 316, col: 39, offset: 7779},
 											name: "reducerExpr",
 										},
 									},
@@ -2259,36 +2373,36 @@ var g = &grammar{
 		},
 		{
 			name: "simpleProc",
-			pos:  position{line: 310, col: 1, offset: 7554},
+			pos:  position{line: 324, col: 1, offset: 7976},
 			expr: &choiceExpr{
-				pos: position{line: 311, col: 5, offset: 7569},
+				pos: position{line: 325, col: 5, offset: 7991},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 311, col: 5, offset: 7569},
+						pos:  position{line: 325, col: 5, offset: 7991},
 						name: "sort",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 5, offset: 7578},
+						pos:  position{line: 326, col: 5, offset: 8000},
 						name: "top",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 313, col: 5, offset: 7586},
+						pos:  position{line: 327, col: 5, offset: 8008},
 						name: "cut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 314, col: 5, offset: 7594},
+						pos:  position{line: 328, col: 5, offset: 8016},
 						name: "head",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 315, col: 5, offset: 7603},
+						pos:  position{line: 329, col: 5, offset: 8025},
 						name: "tail",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 316, col: 5, offset: 7612},
+						pos:  position{line: 330, col: 5, offset: 8034},
 						name: "filter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 7623},
+						pos:  position{line: 331, col: 5, offset: 8045},
 						name: "uniq",
 					},
 				},
@@ -2296,35 +2410,35 @@ var g = &grammar{
 		},
 		{
 			name: "sort",
-			pos:  position{line: 319, col: 1, offset: 7629},
+			pos:  position{line: 333, col: 1, offset: 8051},
 			expr: &choiceExpr{
-				pos: position{line: 320, col: 5, offset: 7638},
+				pos: position{line: 334, col: 5, offset: 8060},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 320, col: 5, offset: 7638},
+						pos: position{line: 334, col: 5, offset: 8060},
 						run: (*parser).callonsort2,
 						expr: &seqExpr{
-							pos: position{line: 320, col: 5, offset: 7638},
+							pos: position{line: 334, col: 5, offset: 8060},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 320, col: 5, offset: 7638},
+									pos:        position{line: 334, col: 5, offset: 8060},
 									val:        "sort",
 									ignoreCase: true,
 								},
 								&labeledExpr{
-									pos:   position{line: 320, col: 13, offset: 7646},
+									pos:   position{line: 334, col: 13, offset: 8068},
 									label: "rev",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 320, col: 17, offset: 7650},
+										pos: position{line: 334, col: 17, offset: 8072},
 										expr: &seqExpr{
-											pos: position{line: 320, col: 18, offset: 7651},
+											pos: position{line: 334, col: 18, offset: 8073},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 320, col: 18, offset: 7651},
+													pos:  position{line: 334, col: 18, offset: 8073},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 320, col: 20, offset: 7653},
+													pos:        position{line: 334, col: 20, offset: 8075},
 													val:        "-r",
 													ignoreCase: false,
 												},
@@ -2333,38 +2447,38 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 320, col: 27, offset: 7660},
+									pos:   position{line: 334, col: 27, offset: 8082},
 									label: "limit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 320, col: 33, offset: 7666},
+										pos: position{line: 334, col: 33, offset: 8088},
 										expr: &ruleRefExpr{
-											pos:  position{line: 320, col: 33, offset: 7666},
+											pos:  position{line: 334, col: 33, offset: 8088},
 											name: "procLimitArg",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 320, col: 48, offset: 7681},
+									pos: position{line: 334, col: 48, offset: 8103},
 									expr: &ruleRefExpr{
-										pos:  position{line: 320, col: 48, offset: 7681},
+										pos:  position{line: 334, col: 48, offset: 8103},
 										name: "_",
 									},
 								},
 								&notExpr{
-									pos: position{line: 320, col: 51, offset: 7684},
+									pos: position{line: 334, col: 51, offset: 8106},
 									expr: &litMatcher{
-										pos:        position{line: 320, col: 52, offset: 7685},
+										pos:        position{line: 334, col: 52, offset: 8107},
 										val:        "-r",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 320, col: 57, offset: 7690},
+									pos:   position{line: 334, col: 57, offset: 8112},
 									label: "list",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 320, col: 62, offset: 7695},
+										pos: position{line: 334, col: 62, offset: 8117},
 										expr: &ruleRefExpr{
-											pos:  position{line: 320, col: 63, offset: 7696},
+											pos:  position{line: 334, col: 63, offset: 8118},
 											name: "fieldExprList",
 										},
 									},
@@ -2373,41 +2487,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 325, col: 5, offset: 7826},
+						pos: position{line: 339, col: 5, offset: 8248},
 						run: (*parser).callonsort20,
 						expr: &seqExpr{
-							pos: position{line: 325, col: 5, offset: 7826},
+							pos: position{line: 339, col: 5, offset: 8248},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 325, col: 5, offset: 7826},
+									pos:        position{line: 339, col: 5, offset: 8248},
 									val:        "sort",
 									ignoreCase: true,
 								},
 								&labeledExpr{
-									pos:   position{line: 325, col: 13, offset: 7834},
+									pos:   position{line: 339, col: 13, offset: 8256},
 									label: "limit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 325, col: 19, offset: 7840},
+										pos: position{line: 339, col: 19, offset: 8262},
 										expr: &ruleRefExpr{
-											pos:  position{line: 325, col: 19, offset: 7840},
+											pos:  position{line: 339, col: 19, offset: 8262},
 											name: "procLimitArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 325, col: 33, offset: 7854},
+									pos:   position{line: 339, col: 33, offset: 8276},
 									label: "rev",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 325, col: 37, offset: 7858},
+										pos: position{line: 339, col: 37, offset: 8280},
 										expr: &seqExpr{
-											pos: position{line: 325, col: 38, offset: 7859},
+											pos: position{line: 339, col: 38, offset: 8281},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 325, col: 38, offset: 7859},
+													pos:  position{line: 339, col: 38, offset: 8281},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 325, col: 40, offset: 7861},
+													pos:        position{line: 339, col: 40, offset: 8283},
 													val:        "-r",
 													ignoreCase: false,
 												},
@@ -2416,19 +2530,19 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 325, col: 47, offset: 7868},
+									pos: position{line: 339, col: 47, offset: 8290},
 									expr: &ruleRefExpr{
-										pos:  position{line: 325, col: 47, offset: 7868},
+										pos:  position{line: 339, col: 47, offset: 8290},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 325, col: 50, offset: 7871},
+									pos:   position{line: 339, col: 50, offset: 8293},
 									label: "list",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 325, col: 55, offset: 7876},
+										pos: position{line: 339, col: 55, offset: 8298},
 										expr: &ruleRefExpr{
-											pos:  position{line: 325, col: 56, offset: 7877},
+											pos:  position{line: 339, col: 56, offset: 8299},
 											name: "fieldExprList",
 										},
 									},
@@ -2441,43 +2555,43 @@ var g = &grammar{
 		},
 		{
 			name: "top",
-			pos:  position{line: 331, col: 1, offset: 8004},
+			pos:  position{line: 345, col: 1, offset: 8426},
 			expr: &actionExpr{
-				pos: position{line: 332, col: 5, offset: 8012},
+				pos: position{line: 346, col: 5, offset: 8434},
 				run: (*parser).callontop1,
 				expr: &seqExpr{
-					pos: position{line: 332, col: 5, offset: 8012},
+					pos: position{line: 346, col: 5, offset: 8434},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 332, col: 5, offset: 8012},
+							pos:        position{line: 346, col: 5, offset: 8434},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 12, offset: 8019},
+							pos:   position{line: 346, col: 12, offset: 8441},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 332, col: 18, offset: 8025},
+								pos: position{line: 346, col: 18, offset: 8447},
 								expr: &ruleRefExpr{
-									pos:  position{line: 332, col: 18, offset: 8025},
+									pos:  position{line: 346, col: 18, offset: 8447},
 									name: "procLimitArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 32, offset: 8039},
+							pos:   position{line: 346, col: 32, offset: 8461},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 332, col: 38, offset: 8045},
+								pos: position{line: 346, col: 38, offset: 8467},
 								expr: &seqExpr{
-									pos: position{line: 332, col: 39, offset: 8046},
+									pos: position{line: 346, col: 39, offset: 8468},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 332, col: 39, offset: 8046},
+											pos:  position{line: 346, col: 39, offset: 8468},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 332, col: 41, offset: 8048},
+											pos:        position{line: 346, col: 41, offset: 8470},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2486,19 +2600,19 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 332, col: 52, offset: 8059},
+							pos: position{line: 346, col: 52, offset: 8481},
 							expr: &ruleRefExpr{
-								pos:  position{line: 332, col: 52, offset: 8059},
+								pos:  position{line: 346, col: 52, offset: 8481},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 55, offset: 8062},
+							pos:   position{line: 346, col: 55, offset: 8484},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 332, col: 60, offset: 8067},
+								pos: position{line: 346, col: 60, offset: 8489},
 								expr: &ruleRefExpr{
-									pos:  position{line: 332, col: 61, offset: 8068},
+									pos:  position{line: 346, col: 61, offset: 8490},
 									name: "fieldExprList",
 								},
 							},
@@ -2509,31 +2623,31 @@ var g = &grammar{
 		},
 		{
 			name: "procLimitArg",
-			pos:  position{line: 336, col: 1, offset: 8139},
+			pos:  position{line: 350, col: 1, offset: 8561},
 			expr: &actionExpr{
-				pos: position{line: 337, col: 5, offset: 8156},
+				pos: position{line: 351, col: 5, offset: 8578},
 				run: (*parser).callonprocLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 337, col: 5, offset: 8156},
+					pos: position{line: 351, col: 5, offset: 8578},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 337, col: 5, offset: 8156},
+							pos:  position{line: 351, col: 5, offset: 8578},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 337, col: 7, offset: 8158},
+							pos:        position{line: 351, col: 7, offset: 8580},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 337, col: 16, offset: 8167},
+							pos:  position{line: 351, col: 16, offset: 8589},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 337, col: 18, offset: 8169},
+							pos:   position{line: 351, col: 18, offset: 8591},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 337, col: 24, offset: 8175},
+								pos:  position{line: 351, col: 24, offset: 8597},
 								name: "integer",
 							},
 						},
@@ -2543,28 +2657,28 @@ var g = &grammar{
 		},
 		{
 			name: "cut",
-			pos:  position{line: 339, col: 1, offset: 8206},
+			pos:  position{line: 353, col: 1, offset: 8628},
 			expr: &actionExpr{
-				pos: position{line: 340, col: 5, offset: 8214},
+				pos: position{line: 354, col: 5, offset: 8636},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 340, col: 5, offset: 8214},
+					pos: position{line: 354, col: 5, offset: 8636},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 340, col: 5, offset: 8214},
+							pos:        position{line: 354, col: 5, offset: 8636},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 340, col: 12, offset: 8221},
+							pos:  position{line: 354, col: 12, offset: 8643},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 340, col: 14, offset: 8223},
+							pos:   position{line: 354, col: 14, offset: 8645},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 340, col: 19, offset: 8228},
-								name: "fieldNameList",
+								pos:  position{line: 354, col: 19, offset: 8650},
+								name: "fieldRefDotOnlyList",
 							},
 						},
 					},
@@ -2573,30 +2687,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 341, col: 1, offset: 8276},
+			pos:  position{line: 355, col: 1, offset: 8704},
 			expr: &choiceExpr{
-				pos: position{line: 342, col: 5, offset: 8285},
+				pos: position{line: 356, col: 5, offset: 8713},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 342, col: 5, offset: 8285},
+						pos: position{line: 356, col: 5, offset: 8713},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 342, col: 5, offset: 8285},
+							pos: position{line: 356, col: 5, offset: 8713},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 342, col: 5, offset: 8285},
+									pos:        position{line: 356, col: 5, offset: 8713},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 342, col: 13, offset: 8293},
+									pos:  position{line: 356, col: 13, offset: 8721},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 342, col: 15, offset: 8295},
+									pos:   position{line: 356, col: 15, offset: 8723},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 342, col: 21, offset: 8301},
+										pos:  position{line: 356, col: 21, offset: 8729},
 										name: "integer",
 									},
 								},
@@ -2604,10 +2718,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 343, col: 5, offset: 8349},
+						pos: position{line: 357, col: 5, offset: 8777},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 343, col: 5, offset: 8349},
+							pos:        position{line: 357, col: 5, offset: 8777},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2617,30 +2731,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 344, col: 1, offset: 8389},
+			pos:  position{line: 358, col: 1, offset: 8817},
 			expr: &choiceExpr{
-				pos: position{line: 345, col: 5, offset: 8398},
+				pos: position{line: 359, col: 5, offset: 8826},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 345, col: 5, offset: 8398},
+						pos: position{line: 359, col: 5, offset: 8826},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 345, col: 5, offset: 8398},
+							pos: position{line: 359, col: 5, offset: 8826},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 345, col: 5, offset: 8398},
+									pos:        position{line: 359, col: 5, offset: 8826},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 345, col: 13, offset: 8406},
+									pos:  position{line: 359, col: 13, offset: 8834},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 345, col: 15, offset: 8408},
+									pos:   position{line: 359, col: 15, offset: 8836},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 345, col: 21, offset: 8414},
+										pos:  position{line: 359, col: 21, offset: 8842},
 										name: "integer",
 									},
 								},
@@ -2648,10 +2762,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 346, col: 5, offset: 8462},
+						pos: position{line: 360, col: 5, offset: 8890},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 346, col: 5, offset: 8462},
+							pos:        position{line: 360, col: 5, offset: 8890},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2661,27 +2775,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 348, col: 1, offset: 8503},
+			pos:  position{line: 362, col: 1, offset: 8931},
 			expr: &actionExpr{
-				pos: position{line: 349, col: 5, offset: 8514},
+				pos: position{line: 363, col: 5, offset: 8942},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 349, col: 5, offset: 8514},
+					pos: position{line: 363, col: 5, offset: 8942},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 349, col: 5, offset: 8514},
+							pos:        position{line: 363, col: 5, offset: 8942},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 349, col: 15, offset: 8524},
+							pos:  position{line: 363, col: 15, offset: 8952},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 349, col: 17, offset: 8526},
+							pos:   position{line: 363, col: 17, offset: 8954},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 349, col: 22, offset: 8531},
+								pos:  position{line: 363, col: 22, offset: 8959},
 								name: "searchExpr",
 							},
 						},
@@ -2691,27 +2805,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 352, col: 1, offset: 8589},
+			pos:  position{line: 366, col: 1, offset: 9017},
 			expr: &choiceExpr{
-				pos: position{line: 353, col: 5, offset: 8598},
+				pos: position{line: 367, col: 5, offset: 9026},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 353, col: 5, offset: 8598},
+						pos: position{line: 367, col: 5, offset: 9026},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 353, col: 5, offset: 8598},
+							pos: position{line: 367, col: 5, offset: 9026},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 353, col: 5, offset: 8598},
+									pos:        position{line: 367, col: 5, offset: 9026},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 353, col: 13, offset: 8606},
+									pos:  position{line: 367, col: 13, offset: 9034},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 353, col: 15, offset: 8608},
+									pos:        position{line: 367, col: 15, offset: 9036},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2719,10 +2833,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 356, col: 5, offset: 8662},
+						pos: position{line: 370, col: 5, offset: 9090},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 356, col: 5, offset: 8662},
+							pos:        position{line: 370, col: 5, offset: 9090},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2732,54 +2846,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 360, col: 1, offset: 8717},
+			pos:  position{line: 374, col: 1, offset: 9145},
 			expr: &choiceExpr{
-				pos: position{line: 361, col: 5, offset: 8730},
+				pos: position{line: 375, col: 5, offset: 9158},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 361, col: 5, offset: 8730},
+						pos:  position{line: 375, col: 5, offset: 9158},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 362, col: 5, offset: 8742},
+						pos:  position{line: 376, col: 5, offset: 9170},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 363, col: 5, offset: 8754},
+						pos:  position{line: 377, col: 5, offset: 9182},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 364, col: 5, offset: 8764},
+						pos: position{line: 378, col: 5, offset: 9192},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 364, col: 5, offset: 8764},
+								pos:  position{line: 378, col: 5, offset: 9192},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 364, col: 11, offset: 8770},
+								pos:  position{line: 378, col: 11, offset: 9198},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 364, col: 13, offset: 8772},
+								pos:        position{line: 378, col: 13, offset: 9200},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 364, col: 19, offset: 8778},
+								pos:  position{line: 378, col: 19, offset: 9206},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 364, col: 21, offset: 8780},
+								pos:  position{line: 378, col: 21, offset: 9208},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 365, col: 5, offset: 8792},
+						pos:  position{line: 379, col: 5, offset: 9220},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 366, col: 5, offset: 8801},
+						pos:  position{line: 380, col: 5, offset: 9229},
 						name: "weeks",
 					},
 				},
@@ -2787,32 +2901,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 368, col: 1, offset: 8808},
+			pos:  position{line: 382, col: 1, offset: 9236},
 			expr: &choiceExpr{
-				pos: position{line: 369, col: 5, offset: 8823},
+				pos: position{line: 383, col: 5, offset: 9251},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 369, col: 5, offset: 8823},
+						pos:        position{line: 383, col: 5, offset: 9251},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 370, col: 5, offset: 8837},
+						pos:        position{line: 384, col: 5, offset: 9265},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 371, col: 5, offset: 8850},
+						pos:        position{line: 385, col: 5, offset: 9278},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 372, col: 5, offset: 8861},
+						pos:        position{line: 386, col: 5, offset: 9289},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 373, col: 5, offset: 8871},
+						pos:        position{line: 387, col: 5, offset: 9299},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -2821,32 +2935,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 375, col: 1, offset: 8876},
+			pos:  position{line: 389, col: 1, offset: 9304},
 			expr: &choiceExpr{
-				pos: position{line: 376, col: 5, offset: 8891},
+				pos: position{line: 390, col: 5, offset: 9319},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 376, col: 5, offset: 8891},
+						pos:        position{line: 390, col: 5, offset: 9319},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 377, col: 5, offset: 8905},
+						pos:        position{line: 391, col: 5, offset: 9333},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 378, col: 5, offset: 8918},
+						pos:        position{line: 392, col: 5, offset: 9346},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 379, col: 5, offset: 8929},
+						pos:        position{line: 393, col: 5, offset: 9357},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 380, col: 5, offset: 8939},
+						pos:        position{line: 394, col: 5, offset: 9367},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -2855,32 +2969,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 382, col: 1, offset: 8944},
+			pos:  position{line: 396, col: 1, offset: 9372},
 			expr: &choiceExpr{
-				pos: position{line: 383, col: 5, offset: 8960},
+				pos: position{line: 397, col: 5, offset: 9388},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 383, col: 5, offset: 8960},
+						pos:        position{line: 397, col: 5, offset: 9388},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 384, col: 5, offset: 8972},
+						pos:        position{line: 398, col: 5, offset: 9400},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 385, col: 5, offset: 8982},
+						pos:        position{line: 399, col: 5, offset: 9410},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 386, col: 5, offset: 8991},
+						pos:        position{line: 400, col: 5, offset: 9419},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 387, col: 5, offset: 8999},
+						pos:        position{line: 401, col: 5, offset: 9427},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -2889,22 +3003,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 389, col: 1, offset: 9007},
+			pos:  position{line: 403, col: 1, offset: 9435},
 			expr: &choiceExpr{
-				pos: position{line: 389, col: 14, offset: 9020},
+				pos: position{line: 403, col: 14, offset: 9448},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 389, col: 14, offset: 9020},
+						pos:        position{line: 403, col: 14, offset: 9448},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 389, col: 21, offset: 9027},
+						pos:        position{line: 403, col: 21, offset: 9455},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 389, col: 27, offset: 9033},
+						pos:        position{line: 403, col: 27, offset: 9461},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -2913,32 +3027,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 390, col: 1, offset: 9037},
+			pos:  position{line: 404, col: 1, offset: 9465},
 			expr: &choiceExpr{
-				pos: position{line: 390, col: 15, offset: 9051},
+				pos: position{line: 404, col: 15, offset: 9479},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 390, col: 15, offset: 9051},
+						pos:        position{line: 404, col: 15, offset: 9479},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 390, col: 23, offset: 9059},
+						pos:        position{line: 404, col: 23, offset: 9487},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 390, col: 30, offset: 9066},
+						pos:        position{line: 404, col: 30, offset: 9494},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 390, col: 36, offset: 9072},
+						pos:        position{line: 404, col: 36, offset: 9500},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 390, col: 41, offset: 9077},
+						pos:        position{line: 404, col: 41, offset: 9505},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -2947,42 +3061,42 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 392, col: 1, offset: 9082},
+			pos:  position{line: 406, col: 1, offset: 9510},
 			expr: &choiceExpr{
-				pos: position{line: 393, col: 5, offset: 9094},
+				pos: position{line: 407, col: 5, offset: 9522},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 393, col: 5, offset: 9094},
+						pos: position{line: 407, col: 5, offset: 9522},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 393, col: 5, offset: 9094},
+							pos:        position{line: 407, col: 5, offset: 9522},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 394, col: 5, offset: 9139},
+						pos: position{line: 408, col: 5, offset: 9567},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 394, col: 5, offset: 9139},
+							pos: position{line: 408, col: 5, offset: 9567},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 394, col: 5, offset: 9139},
+									pos:   position{line: 408, col: 5, offset: 9567},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 394, col: 9, offset: 9143},
+										pos:  position{line: 408, col: 9, offset: 9571},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 394, col: 16, offset: 9150},
+									pos: position{line: 408, col: 16, offset: 9578},
 									expr: &ruleRefExpr{
-										pos:  position{line: 394, col: 16, offset: 9150},
+										pos:  position{line: 408, col: 16, offset: 9578},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 394, col: 19, offset: 9153},
+									pos:  position{line: 408, col: 19, offset: 9581},
 									name: "sec_abbrev",
 								},
 							},
@@ -2993,42 +3107,42 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 396, col: 1, offset: 9199},
+			pos:  position{line: 410, col: 1, offset: 9627},
 			expr: &choiceExpr{
-				pos: position{line: 397, col: 5, offset: 9211},
+				pos: position{line: 411, col: 5, offset: 9639},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 397, col: 5, offset: 9211},
+						pos: position{line: 411, col: 5, offset: 9639},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 397, col: 5, offset: 9211},
+							pos:        position{line: 411, col: 5, offset: 9639},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 398, col: 5, offset: 9257},
+						pos: position{line: 412, col: 5, offset: 9685},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 398, col: 5, offset: 9257},
+							pos: position{line: 412, col: 5, offset: 9685},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 398, col: 5, offset: 9257},
+									pos:   position{line: 412, col: 5, offset: 9685},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 398, col: 9, offset: 9261},
+										pos:  position{line: 412, col: 9, offset: 9689},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 398, col: 16, offset: 9268},
+									pos: position{line: 412, col: 16, offset: 9696},
 									expr: &ruleRefExpr{
-										pos:  position{line: 398, col: 16, offset: 9268},
+										pos:  position{line: 412, col: 16, offset: 9696},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 398, col: 19, offset: 9271},
+									pos:  position{line: 412, col: 19, offset: 9699},
 									name: "min_abbrev",
 								},
 							},
@@ -3039,42 +3153,42 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 400, col: 1, offset: 9326},
+			pos:  position{line: 414, col: 1, offset: 9754},
 			expr: &choiceExpr{
-				pos: position{line: 401, col: 5, offset: 9336},
+				pos: position{line: 415, col: 5, offset: 9764},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 401, col: 5, offset: 9336},
+						pos: position{line: 415, col: 5, offset: 9764},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 401, col: 5, offset: 9336},
+							pos:        position{line: 415, col: 5, offset: 9764},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 402, col: 5, offset: 9382},
+						pos: position{line: 416, col: 5, offset: 9810},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 402, col: 5, offset: 9382},
+							pos: position{line: 416, col: 5, offset: 9810},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 402, col: 5, offset: 9382},
+									pos:   position{line: 416, col: 5, offset: 9810},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 402, col: 9, offset: 9386},
+										pos:  position{line: 416, col: 9, offset: 9814},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 402, col: 16, offset: 9393},
+									pos: position{line: 416, col: 16, offset: 9821},
 									expr: &ruleRefExpr{
-										pos:  position{line: 402, col: 16, offset: 9393},
+										pos:  position{line: 416, col: 16, offset: 9821},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 402, col: 19, offset: 9396},
+									pos:  position{line: 416, col: 19, offset: 9824},
 									name: "hour_abbrev",
 								},
 							},
@@ -3085,42 +3199,42 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 404, col: 1, offset: 9454},
+			pos:  position{line: 418, col: 1, offset: 9882},
 			expr: &choiceExpr{
-				pos: position{line: 405, col: 5, offset: 9463},
+				pos: position{line: 419, col: 5, offset: 9891},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 405, col: 5, offset: 9463},
+						pos: position{line: 419, col: 5, offset: 9891},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 405, col: 5, offset: 9463},
+							pos:        position{line: 419, col: 5, offset: 9891},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 406, col: 5, offset: 9511},
+						pos: position{line: 420, col: 5, offset: 9939},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 406, col: 5, offset: 9511},
+							pos: position{line: 420, col: 5, offset: 9939},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 406, col: 5, offset: 9511},
+									pos:   position{line: 420, col: 5, offset: 9939},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 406, col: 9, offset: 9515},
+										pos:  position{line: 420, col: 9, offset: 9943},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 406, col: 16, offset: 9522},
+									pos: position{line: 420, col: 16, offset: 9950},
 									expr: &ruleRefExpr{
-										pos:  position{line: 406, col: 16, offset: 9522},
+										pos:  position{line: 420, col: 16, offset: 9950},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 406, col: 19, offset: 9525},
+									pos:  position{line: 420, col: 19, offset: 9953},
 									name: "day_abbrev",
 								},
 							},
@@ -3131,30 +3245,30 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 408, col: 1, offset: 9585},
+			pos:  position{line: 422, col: 1, offset: 10013},
 			expr: &actionExpr{
-				pos: position{line: 409, col: 5, offset: 9595},
+				pos: position{line: 423, col: 5, offset: 10023},
 				run: (*parser).callonweeks1,
 				expr: &seqExpr{
-					pos: position{line: 409, col: 5, offset: 9595},
+					pos: position{line: 423, col: 5, offset: 10023},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 409, col: 5, offset: 9595},
+							pos:   position{line: 423, col: 5, offset: 10023},
 							label: "num",
 							expr: &ruleRefExpr{
-								pos:  position{line: 409, col: 9, offset: 9599},
+								pos:  position{line: 423, col: 9, offset: 10027},
 								name: "number",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 409, col: 16, offset: 9606},
+							pos: position{line: 423, col: 16, offset: 10034},
 							expr: &ruleRefExpr{
-								pos:  position{line: 409, col: 16, offset: 9606},
+								pos:  position{line: 423, col: 16, offset: 10034},
 								name: "_",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 409, col: 19, offset: 9609},
+							pos:  position{line: 423, col: 19, offset: 10037},
 							name: "week_abbrev",
 						},
 					},
@@ -3163,53 +3277,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 411, col: 1, offset: 9672},
+			pos:  position{line: 425, col: 1, offset: 10100},
 			expr: &ruleRefExpr{
-				pos:  position{line: 411, col: 10, offset: 9681},
+				pos:  position{line: 425, col: 10, offset: 10109},
 				name: "integer",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 415, col: 1, offset: 9719},
+			pos:  position{line: 429, col: 1, offset: 10147},
 			expr: &actionExpr{
-				pos: position{line: 416, col: 5, offset: 9728},
+				pos: position{line: 430, col: 5, offset: 10156},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 416, col: 5, offset: 9728},
+					pos:   position{line: 430, col: 5, offset: 10156},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 416, col: 8, offset: 9731},
+						pos: position{line: 430, col: 8, offset: 10159},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 416, col: 8, offset: 9731},
+								pos:  position{line: 430, col: 8, offset: 10159},
 								name: "integer",
 							},
 							&litMatcher{
-								pos:        position{line: 416, col: 16, offset: 9739},
+								pos:        position{line: 430, col: 16, offset: 10167},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 416, col: 20, offset: 9743},
+								pos:  position{line: 430, col: 20, offset: 10171},
 								name: "integer",
 							},
 							&litMatcher{
-								pos:        position{line: 416, col: 28, offset: 9751},
+								pos:        position{line: 430, col: 28, offset: 10179},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 416, col: 32, offset: 9755},
+								pos:  position{line: 430, col: 32, offset: 10183},
 								name: "integer",
 							},
 							&litMatcher{
-								pos:        position{line: 416, col: 40, offset: 9763},
+								pos:        position{line: 430, col: 40, offset: 10191},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 416, col: 44, offset: 9767},
+								pos:  position{line: 430, col: 44, offset: 10195},
 								name: "integer",
 							},
 						},
@@ -3219,23 +3333,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 418, col: 1, offset: 9808},
+			pos:  position{line: 432, col: 1, offset: 10236},
 			expr: &actionExpr{
-				pos: position{line: 419, col: 5, offset: 9817},
+				pos: position{line: 433, col: 5, offset: 10245},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 419, col: 5, offset: 9817},
+					pos: position{line: 433, col: 5, offset: 10245},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 419, col: 5, offset: 9817},
+							pos:        position{line: 433, col: 5, offset: 10245},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 419, col: 9, offset: 9821},
+							pos:   position{line: 433, col: 9, offset: 10249},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 419, col: 11, offset: 9823},
+								pos:  position{line: 433, col: 11, offset: 10251},
 								name: "sinteger",
 							},
 						},
@@ -3245,32 +3359,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 423, col: 1, offset: 9982},
+			pos:  position{line: 437, col: 1, offset: 10410},
 			expr: &choiceExpr{
-				pos: position{line: 424, col: 5, offset: 9994},
+				pos: position{line: 438, col: 5, offset: 10422},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 424, col: 5, offset: 9994},
+						pos: position{line: 438, col: 5, offset: 10422},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 424, col: 5, offset: 9994},
+							pos: position{line: 438, col: 5, offset: 10422},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 424, col: 5, offset: 9994},
+									pos:   position{line: 438, col: 5, offset: 10422},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 424, col: 7, offset: 9996},
+										pos: position{line: 438, col: 7, offset: 10424},
 										expr: &ruleRefExpr{
-											pos:  position{line: 424, col: 8, offset: 9997},
+											pos:  position{line: 438, col: 8, offset: 10425},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 424, col: 20, offset: 10009},
+									pos:   position{line: 438, col: 20, offset: 10437},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 424, col: 22, offset: 10011},
+										pos:  position{line: 438, col: 22, offset: 10439},
 										name: "ip6tail",
 									},
 								},
@@ -3278,51 +3392,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 427, col: 5, offset: 10075},
+						pos: position{line: 441, col: 5, offset: 10503},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 427, col: 5, offset: 10075},
+							pos: position{line: 441, col: 5, offset: 10503},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 427, col: 5, offset: 10075},
+									pos:   position{line: 441, col: 5, offset: 10503},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 427, col: 7, offset: 10077},
+										pos:  position{line: 441, col: 7, offset: 10505},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 427, col: 11, offset: 10081},
+									pos:   position{line: 441, col: 11, offset: 10509},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 427, col: 13, offset: 10083},
+										pos: position{line: 441, col: 13, offset: 10511},
 										expr: &ruleRefExpr{
-											pos:  position{line: 427, col: 14, offset: 10084},
+											pos:  position{line: 441, col: 14, offset: 10512},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 427, col: 25, offset: 10095},
+									pos:        position{line: 441, col: 25, offset: 10523},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 427, col: 30, offset: 10100},
+									pos:   position{line: 441, col: 30, offset: 10528},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 427, col: 32, offset: 10102},
+										pos: position{line: 441, col: 32, offset: 10530},
 										expr: &ruleRefExpr{
-											pos:  position{line: 427, col: 33, offset: 10103},
+											pos:  position{line: 441, col: 33, offset: 10531},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 427, col: 45, offset: 10115},
+									pos:   position{line: 441, col: 45, offset: 10543},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 427, col: 47, offset: 10117},
+										pos:  position{line: 441, col: 47, offset: 10545},
 										name: "ip6tail",
 									},
 								},
@@ -3330,32 +3444,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 430, col: 5, offset: 10216},
+						pos: position{line: 444, col: 5, offset: 10644},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 430, col: 5, offset: 10216},
+							pos: position{line: 444, col: 5, offset: 10644},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 430, col: 5, offset: 10216},
+									pos:        position{line: 444, col: 5, offset: 10644},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 430, col: 10, offset: 10221},
+									pos:   position{line: 444, col: 10, offset: 10649},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 430, col: 12, offset: 10223},
+										pos: position{line: 444, col: 12, offset: 10651},
 										expr: &ruleRefExpr{
-											pos:  position{line: 430, col: 13, offset: 10224},
+											pos:  position{line: 444, col: 13, offset: 10652},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 430, col: 25, offset: 10236},
+									pos:   position{line: 444, col: 25, offset: 10664},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 430, col: 27, offset: 10238},
+										pos:  position{line: 444, col: 27, offset: 10666},
 										name: "ip6tail",
 									},
 								},
@@ -3363,32 +3477,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 433, col: 5, offset: 10309},
+						pos: position{line: 447, col: 5, offset: 10737},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 433, col: 5, offset: 10309},
+							pos: position{line: 447, col: 5, offset: 10737},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 433, col: 5, offset: 10309},
+									pos:   position{line: 447, col: 5, offset: 10737},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 433, col: 7, offset: 10311},
+										pos:  position{line: 447, col: 7, offset: 10739},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 433, col: 11, offset: 10315},
+									pos:   position{line: 447, col: 11, offset: 10743},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 433, col: 13, offset: 10317},
+										pos: position{line: 447, col: 13, offset: 10745},
 										expr: &ruleRefExpr{
-											pos:  position{line: 433, col: 14, offset: 10318},
+											pos:  position{line: 447, col: 14, offset: 10746},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 433, col: 25, offset: 10329},
+									pos:        position{line: 447, col: 25, offset: 10757},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -3396,10 +3510,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 436, col: 5, offset: 10397},
+						pos: position{line: 450, col: 5, offset: 10825},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 436, col: 5, offset: 10397},
+							pos:        position{line: 450, col: 5, offset: 10825},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -3409,16 +3523,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 440, col: 1, offset: 10434},
+			pos:  position{line: 454, col: 1, offset: 10862},
 			expr: &choiceExpr{
-				pos: position{line: 441, col: 5, offset: 10446},
+				pos: position{line: 455, col: 5, offset: 10874},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 441, col: 5, offset: 10446},
+						pos:  position{line: 455, col: 5, offset: 10874},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 442, col: 5, offset: 10455},
+						pos:  position{line: 456, col: 5, offset: 10883},
 						name: "h16",
 					},
 				},
@@ -3426,23 +3540,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 444, col: 1, offset: 10460},
+			pos:  position{line: 458, col: 1, offset: 10888},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 12, offset: 10471},
+				pos: position{line: 458, col: 12, offset: 10899},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 444, col: 12, offset: 10471},
+					pos: position{line: 458, col: 12, offset: 10899},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 444, col: 12, offset: 10471},
+							pos:        position{line: 458, col: 12, offset: 10899},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 444, col: 16, offset: 10475},
+							pos:   position{line: 458, col: 16, offset: 10903},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 444, col: 18, offset: 10477},
+								pos:  position{line: 458, col: 18, offset: 10905},
 								name: "h16",
 							},
 						},
@@ -3452,23 +3566,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 445, col: 1, offset: 10514},
+			pos:  position{line: 459, col: 1, offset: 10942},
 			expr: &actionExpr{
-				pos: position{line: 445, col: 13, offset: 10526},
+				pos: position{line: 459, col: 13, offset: 10954},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 445, col: 13, offset: 10526},
+					pos: position{line: 459, col: 13, offset: 10954},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 445, col: 13, offset: 10526},
+							pos:   position{line: 459, col: 13, offset: 10954},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 445, col: 15, offset: 10528},
+								pos:  position{line: 459, col: 15, offset: 10956},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 445, col: 19, offset: 10532},
+							pos:        position{line: 459, col: 19, offset: 10960},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -3478,43 +3592,43 @@ var g = &grammar{
 		},
 		{
 			name: "sub_addr",
-			pos:  position{line: 447, col: 1, offset: 10570},
+			pos:  position{line: 461, col: 1, offset: 10998},
 			expr: &choiceExpr{
-				pos: position{line: 448, col: 5, offset: 10583},
+				pos: position{line: 462, col: 5, offset: 11011},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 448, col: 5, offset: 10583},
+						pos:  position{line: 462, col: 5, offset: 11011},
 						name: "addr",
 					},
 					&actionExpr{
-						pos: position{line: 449, col: 5, offset: 10592},
+						pos: position{line: 463, col: 5, offset: 11020},
 						run: (*parser).callonsub_addr3,
 						expr: &labeledExpr{
-							pos:   position{line: 449, col: 5, offset: 10592},
+							pos:   position{line: 463, col: 5, offset: 11020},
 							label: "a",
 							expr: &seqExpr{
-								pos: position{line: 449, col: 8, offset: 10595},
+								pos: position{line: 463, col: 8, offset: 11023},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 449, col: 8, offset: 10595},
+										pos:  position{line: 463, col: 8, offset: 11023},
 										name: "integer",
 									},
 									&litMatcher{
-										pos:        position{line: 449, col: 16, offset: 10603},
+										pos:        position{line: 463, col: 16, offset: 11031},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 449, col: 20, offset: 10607},
+										pos:  position{line: 463, col: 20, offset: 11035},
 										name: "integer",
 									},
 									&litMatcher{
-										pos:        position{line: 449, col: 28, offset: 10615},
+										pos:        position{line: 463, col: 28, offset: 11043},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 449, col: 32, offset: 10619},
+										pos:  position{line: 463, col: 32, offset: 11047},
 										name: "integer",
 									},
 								},
@@ -3522,25 +3636,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 450, col: 5, offset: 10671},
+						pos: position{line: 464, col: 5, offset: 11099},
 						run: (*parser).callonsub_addr11,
 						expr: &labeledExpr{
-							pos:   position{line: 450, col: 5, offset: 10671},
+							pos:   position{line: 464, col: 5, offset: 11099},
 							label: "a",
 							expr: &seqExpr{
-								pos: position{line: 450, col: 8, offset: 10674},
+								pos: position{line: 464, col: 8, offset: 11102},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 450, col: 8, offset: 10674},
+										pos:  position{line: 464, col: 8, offset: 11102},
 										name: "integer",
 									},
 									&litMatcher{
-										pos:        position{line: 450, col: 16, offset: 10682},
+										pos:        position{line: 464, col: 16, offset: 11110},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 450, col: 20, offset: 10686},
+										pos:  position{line: 464, col: 20, offset: 11114},
 										name: "integer",
 									},
 								},
@@ -3548,13 +3662,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 451, col: 5, offset: 10740},
+						pos: position{line: 465, col: 5, offset: 11168},
 						run: (*parser).callonsub_addr17,
 						expr: &labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 10740},
+							pos:   position{line: 465, col: 5, offset: 11168},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 7, offset: 10742},
+								pos:  position{line: 465, col: 7, offset: 11170},
 								name: "integer",
 							},
 						},
@@ -3564,31 +3678,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 453, col: 1, offset: 10793},
+			pos:  position{line: 467, col: 1, offset: 11221},
 			expr: &actionExpr{
-				pos: position{line: 454, col: 5, offset: 10804},
+				pos: position{line: 468, col: 5, offset: 11232},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 454, col: 5, offset: 10804},
+					pos: position{line: 468, col: 5, offset: 11232},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 454, col: 5, offset: 10804},
+							pos:   position{line: 468, col: 5, offset: 11232},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 454, col: 7, offset: 10806},
+								pos:  position{line: 468, col: 7, offset: 11234},
 								name: "sub_addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 454, col: 16, offset: 10815},
+							pos:        position{line: 468, col: 16, offset: 11243},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 454, col: 20, offset: 10819},
+							pos:   position{line: 468, col: 20, offset: 11247},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 454, col: 22, offset: 10821},
+								pos:  position{line: 468, col: 22, offset: 11249},
 								name: "integer",
 							},
 						},
@@ -3598,31 +3712,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 458, col: 1, offset: 10897},
+			pos:  position{line: 472, col: 1, offset: 11325},
 			expr: &actionExpr{
-				pos: position{line: 459, col: 5, offset: 10911},
+				pos: position{line: 473, col: 5, offset: 11339},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 459, col: 5, offset: 10911},
+					pos: position{line: 473, col: 5, offset: 11339},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 459, col: 5, offset: 10911},
+							pos:   position{line: 473, col: 5, offset: 11339},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 7, offset: 10913},
+								pos:  position{line: 473, col: 7, offset: 11341},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 459, col: 15, offset: 10921},
+							pos:        position{line: 473, col: 15, offset: 11349},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 459, col: 19, offset: 10925},
+							pos:   position{line: 473, col: 19, offset: 11353},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 21, offset: 10927},
+								pos:  position{line: 473, col: 21, offset: 11355},
 								name: "integer",
 							},
 						},
@@ -3632,15 +3746,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 463, col: 1, offset: 10993},
+			pos:  position{line: 477, col: 1, offset: 11421},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 5, offset: 11005},
+				pos: position{line: 478, col: 5, offset: 11433},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 464, col: 5, offset: 11005},
+					pos:   position{line: 478, col: 5, offset: 11433},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 464, col: 7, offset: 11007},
+						pos:  position{line: 478, col: 7, offset: 11435},
 						name: "sinteger",
 					},
 				},
@@ -3648,17 +3762,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 468, col: 1, offset: 11051},
+			pos:  position{line: 482, col: 1, offset: 11479},
 			expr: &actionExpr{
-				pos: position{line: 469, col: 5, offset: 11064},
+				pos: position{line: 483, col: 5, offset: 11492},
 				run: (*parser).callonsinteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 469, col: 5, offset: 11064},
+					pos:   position{line: 483, col: 5, offset: 11492},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 469, col: 11, offset: 11070},
+						pos: position{line: 483, col: 11, offset: 11498},
 						expr: &charClassMatcher{
-							pos:        position{line: 469, col: 11, offset: 11070},
+							pos:        position{line: 483, col: 11, offset: 11498},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -3670,15 +3784,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 473, col: 1, offset: 11115},
+			pos:  position{line: 487, col: 1, offset: 11543},
 			expr: &actionExpr{
-				pos: position{line: 474, col: 5, offset: 11126},
+				pos: position{line: 488, col: 5, offset: 11554},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 474, col: 5, offset: 11126},
+					pos:   position{line: 488, col: 5, offset: 11554},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 474, col: 7, offset: 11128},
+						pos:  position{line: 488, col: 7, offset: 11556},
 						name: "sdouble",
 					},
 				},
@@ -3686,39 +3800,39 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 478, col: 1, offset: 11175},
+			pos:  position{line: 492, col: 1, offset: 11603},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 5, offset: 11187},
+				pos: position{line: 493, col: 5, offset: 11615},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 479, col: 5, offset: 11187},
+						pos: position{line: 493, col: 5, offset: 11615},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 479, col: 5, offset: 11187},
+							pos: position{line: 493, col: 5, offset: 11615},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 479, col: 5, offset: 11187},
+									pos: position{line: 493, col: 5, offset: 11615},
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 5, offset: 11187},
+										pos:  position{line: 493, col: 5, offset: 11615},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 479, col: 20, offset: 11202},
+									pos:        position{line: 493, col: 20, offset: 11630},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 479, col: 24, offset: 11206},
+									pos: position{line: 493, col: 24, offset: 11634},
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 24, offset: 11206},
+										pos:  position{line: 493, col: 24, offset: 11634},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 479, col: 37, offset: 11219},
+									pos: position{line: 493, col: 37, offset: 11647},
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 37, offset: 11219},
+										pos:  position{line: 493, col: 37, offset: 11647},
 										name: "exponentPart",
 									},
 								},
@@ -3726,27 +3840,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 11278},
+						pos: position{line: 496, col: 5, offset: 11706},
 						run: (*parser).callonsdouble11,
 						expr: &seqExpr{
-							pos: position{line: 482, col: 5, offset: 11278},
+							pos: position{line: 496, col: 5, offset: 11706},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 482, col: 5, offset: 11278},
+									pos:        position{line: 496, col: 5, offset: 11706},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 482, col: 9, offset: 11282},
+									pos: position{line: 496, col: 9, offset: 11710},
 									expr: &ruleRefExpr{
-										pos:  position{line: 482, col: 9, offset: 11282},
+										pos:  position{line: 496, col: 9, offset: 11710},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 482, col: 22, offset: 11295},
+									pos: position{line: 496, col: 22, offset: 11723},
 									expr: &ruleRefExpr{
-										pos:  position{line: 482, col: 22, offset: 11295},
+										pos:  position{line: 496, col: 22, offset: 11723},
 										name: "exponentPart",
 									},
 								},
@@ -3758,29 +3872,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 486, col: 1, offset: 11351},
+			pos:  position{line: 500, col: 1, offset: 11779},
 			expr: &choiceExpr{
-				pos: position{line: 487, col: 5, offset: 11369},
+				pos: position{line: 501, col: 5, offset: 11797},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 487, col: 5, offset: 11369},
+						pos:        position{line: 501, col: 5, offset: 11797},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 488, col: 5, offset: 11377},
+						pos: position{line: 502, col: 5, offset: 11805},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 488, col: 5, offset: 11377},
+								pos:        position{line: 502, col: 5, offset: 11805},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 488, col: 11, offset: 11383},
+								pos: position{line: 502, col: 11, offset: 11811},
 								expr: &charClassMatcher{
-									pos:        position{line: 488, col: 11, offset: 11383},
+									pos:        position{line: 502, col: 11, offset: 11811},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -3794,9 +3908,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 490, col: 1, offset: 11391},
+			pos:  position{line: 504, col: 1, offset: 11819},
 			expr: &charClassMatcher{
-				pos:        position{line: 490, col: 15, offset: 11405},
+				pos:        position{line: 504, col: 15, offset: 11833},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -3805,14 +3919,14 @@ var g = &grammar{
 		},
 		{
 			name: "signedInteger",
-			pos:  position{line: 492, col: 1, offset: 11412},
+			pos:  position{line: 506, col: 1, offset: 11840},
 			expr: &seqExpr{
-				pos: position{line: 492, col: 17, offset: 11428},
+				pos: position{line: 506, col: 17, offset: 11856},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 492, col: 17, offset: 11428},
+						pos: position{line: 506, col: 17, offset: 11856},
 						expr: &charClassMatcher{
-							pos:        position{line: 492, col: 17, offset: 11428},
+							pos:        position{line: 506, col: 17, offset: 11856},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -3820,9 +3934,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 492, col: 23, offset: 11434},
+						pos: position{line: 506, col: 23, offset: 11862},
 						expr: &ruleRefExpr{
-							pos:  position{line: 492, col: 23, offset: 11434},
+							pos:  position{line: 506, col: 23, offset: 11862},
 							name: "doubleDigit",
 						},
 					},
@@ -3831,17 +3945,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 494, col: 1, offset: 11448},
+			pos:  position{line: 508, col: 1, offset: 11876},
 			expr: &seqExpr{
-				pos: position{line: 494, col: 16, offset: 11463},
+				pos: position{line: 508, col: 16, offset: 11891},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 494, col: 16, offset: 11463},
+						pos:        position{line: 508, col: 16, offset: 11891},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 494, col: 21, offset: 11468},
+						pos:  position{line: 508, col: 21, offset: 11896},
 						name: "signedInteger",
 					},
 				},
@@ -3849,17 +3963,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 496, col: 1, offset: 11483},
+			pos:  position{line: 510, col: 1, offset: 11911},
 			expr: &actionExpr{
-				pos: position{line: 496, col: 7, offset: 11489},
+				pos: position{line: 510, col: 7, offset: 11917},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 496, col: 7, offset: 11489},
+					pos:   position{line: 510, col: 7, offset: 11917},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 496, col: 13, offset: 11495},
+						pos: position{line: 510, col: 13, offset: 11923},
 						expr: &ruleRefExpr{
-							pos:  position{line: 496, col: 13, offset: 11495},
+							pos:  position{line: 510, col: 13, offset: 11923},
 							name: "hexdigit",
 						},
 					},
@@ -3868,9 +3982,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 498, col: 1, offset: 11537},
+			pos:  position{line: 512, col: 1, offset: 11965},
 			expr: &charClassMatcher{
-				pos:        position{line: 498, col: 12, offset: 11548},
+				pos:        position{line: 512, col: 12, offset: 11976},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -3880,17 +3994,17 @@ var g = &grammar{
 		{
 			name:        "boomWord",
 			displayName: "\"boomWord\"",
-			pos:         position{line: 500, col: 1, offset: 11561},
+			pos:         position{line: 514, col: 1, offset: 11989},
 			expr: &actionExpr{
-				pos: position{line: 500, col: 23, offset: 11583},
+				pos: position{line: 514, col: 23, offset: 12011},
 				run: (*parser).callonboomWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 500, col: 23, offset: 11583},
+					pos:   position{line: 514, col: 23, offset: 12011},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 500, col: 29, offset: 11589},
+						pos: position{line: 514, col: 29, offset: 12017},
 						expr: &ruleRefExpr{
-							pos:  position{line: 500, col: 29, offset: 11589},
+							pos:  position{line: 514, col: 29, offset: 12017},
 							name: "boomWordPart",
 						},
 					},
@@ -3899,26 +4013,26 @@ var g = &grammar{
 		},
 		{
 			name: "boomWordPart",
-			pos:  position{line: 502, col: 1, offset: 11637},
+			pos:  position{line: 516, col: 1, offset: 12065},
 			expr: &choiceExpr{
-				pos: position{line: 503, col: 5, offset: 11654},
+				pos: position{line: 517, col: 5, offset: 12082},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 503, col: 5, offset: 11654},
+						pos: position{line: 517, col: 5, offset: 12082},
 						run: (*parser).callonboomWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 503, col: 5, offset: 11654},
+							pos: position{line: 517, col: 5, offset: 12082},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 503, col: 5, offset: 11654},
+									pos:        position{line: 517, col: 5, offset: 12082},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 503, col: 10, offset: 11659},
+									pos:   position{line: 517, col: 10, offset: 12087},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 503, col: 12, offset: 11661},
+										pos:  position{line: 517, col: 12, offset: 12089},
 										name: "escapeSequence",
 									},
 								},
@@ -3926,18 +4040,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 504, col: 5, offset: 11699},
+						pos: position{line: 518, col: 5, offset: 12127},
 						run: (*parser).callonboomWordPart7,
 						expr: &seqExpr{
-							pos: position{line: 504, col: 5, offset: 11699},
+							pos: position{line: 518, col: 5, offset: 12127},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 504, col: 5, offset: 11699},
+									pos: position{line: 518, col: 5, offset: 12127},
 									expr: &choiceExpr{
-										pos: position{line: 504, col: 7, offset: 11701},
+										pos: position{line: 518, col: 7, offset: 12129},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 504, col: 7, offset: 11701},
+												pos:        position{line: 518, col: 7, offset: 12129},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -3945,14 +4059,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 504, col: 42, offset: 11736},
+												pos:  position{line: 518, col: 42, offset: 12164},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 504, col: 46, offset: 11740,
+									line: 518, col: 46, offset: 12168,
 								},
 							},
 						},
@@ -3962,34 +4076,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 506, col: 1, offset: 11774},
+			pos:  position{line: 520, col: 1, offset: 12202},
 			expr: &choiceExpr{
-				pos: position{line: 507, col: 5, offset: 11791},
+				pos: position{line: 521, col: 5, offset: 12219},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 507, col: 5, offset: 11791},
+						pos: position{line: 521, col: 5, offset: 12219},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 507, col: 5, offset: 11791},
+							pos: position{line: 521, col: 5, offset: 12219},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 507, col: 5, offset: 11791},
+									pos:        position{line: 521, col: 5, offset: 12219},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 507, col: 9, offset: 11795},
+									pos:   position{line: 521, col: 9, offset: 12223},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 507, col: 11, offset: 11797},
+										pos: position{line: 521, col: 11, offset: 12225},
 										expr: &ruleRefExpr{
-											pos:  position{line: 507, col: 11, offset: 11797},
+											pos:  position{line: 521, col: 11, offset: 12225},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 507, col: 29, offset: 11815},
+									pos:        position{line: 521, col: 29, offset: 12243},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -3997,29 +4111,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 508, col: 5, offset: 11852},
+						pos: position{line: 522, col: 5, offset: 12280},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 508, col: 5, offset: 11852},
+							pos: position{line: 522, col: 5, offset: 12280},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 508, col: 5, offset: 11852},
+									pos:        position{line: 522, col: 5, offset: 12280},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 508, col: 9, offset: 11856},
+									pos:   position{line: 522, col: 9, offset: 12284},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 508, col: 11, offset: 11858},
+										pos: position{line: 522, col: 11, offset: 12286},
 										expr: &ruleRefExpr{
-											pos:  position{line: 508, col: 11, offset: 11858},
+											pos:  position{line: 522, col: 11, offset: 12286},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 508, col: 29, offset: 11876},
+									pos:        position{line: 522, col: 29, offset: 12304},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -4031,55 +4145,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 510, col: 1, offset: 11910},
+			pos:  position{line: 524, col: 1, offset: 12338},
 			expr: &choiceExpr{
-				pos: position{line: 511, col: 5, offset: 11931},
+				pos: position{line: 525, col: 5, offset: 12359},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 511, col: 5, offset: 11931},
+						pos: position{line: 525, col: 5, offset: 12359},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 511, col: 5, offset: 11931},
+							pos: position{line: 525, col: 5, offset: 12359},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 511, col: 5, offset: 11931},
+									pos: position{line: 525, col: 5, offset: 12359},
 									expr: &choiceExpr{
-										pos: position{line: 511, col: 7, offset: 11933},
+										pos: position{line: 525, col: 7, offset: 12361},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 511, col: 7, offset: 11933},
+												pos:        position{line: 525, col: 7, offset: 12361},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 511, col: 13, offset: 11939},
+												pos:  position{line: 525, col: 13, offset: 12367},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 511, col: 26, offset: 11952,
+									line: 525, col: 26, offset: 12380,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 512, col: 5, offset: 11989},
+						pos: position{line: 526, col: 5, offset: 12417},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 512, col: 5, offset: 11989},
+							pos: position{line: 526, col: 5, offset: 12417},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 512, col: 5, offset: 11989},
+									pos:        position{line: 526, col: 5, offset: 12417},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 512, col: 10, offset: 11994},
+									pos:   position{line: 526, col: 10, offset: 12422},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 512, col: 12, offset: 11996},
+										pos:  position{line: 526, col: 12, offset: 12424},
 										name: "escapeSequence",
 									},
 								},
@@ -4091,55 +4205,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 514, col: 1, offset: 12030},
+			pos:  position{line: 528, col: 1, offset: 12458},
 			expr: &choiceExpr{
-				pos: position{line: 515, col: 5, offset: 12051},
+				pos: position{line: 529, col: 5, offset: 12479},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 515, col: 5, offset: 12051},
+						pos: position{line: 529, col: 5, offset: 12479},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 515, col: 5, offset: 12051},
+							pos: position{line: 529, col: 5, offset: 12479},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 515, col: 5, offset: 12051},
+									pos: position{line: 529, col: 5, offset: 12479},
 									expr: &choiceExpr{
-										pos: position{line: 515, col: 7, offset: 12053},
+										pos: position{line: 529, col: 7, offset: 12481},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 515, col: 7, offset: 12053},
+												pos:        position{line: 529, col: 7, offset: 12481},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 515, col: 13, offset: 12059},
+												pos:  position{line: 529, col: 13, offset: 12487},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 515, col: 26, offset: 12072,
+									line: 529, col: 26, offset: 12500,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 516, col: 5, offset: 12109},
+						pos: position{line: 530, col: 5, offset: 12537},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 516, col: 5, offset: 12109},
+							pos: position{line: 530, col: 5, offset: 12537},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 516, col: 5, offset: 12109},
+									pos:        position{line: 530, col: 5, offset: 12537},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 516, col: 10, offset: 12114},
+									pos:   position{line: 530, col: 10, offset: 12542},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 516, col: 12, offset: 12116},
+										pos:  position{line: 530, col: 12, offset: 12544},
 										name: "escapeSequence",
 									},
 								},
@@ -4151,38 +4265,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 518, col: 1, offset: 12150},
+			pos:  position{line: 532, col: 1, offset: 12578},
 			expr: &choiceExpr{
-				pos: position{line: 519, col: 5, offset: 12169},
+				pos: position{line: 533, col: 5, offset: 12597},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 519, col: 5, offset: 12169},
+						pos: position{line: 533, col: 5, offset: 12597},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 519, col: 5, offset: 12169},
+							pos: position{line: 533, col: 5, offset: 12597},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 519, col: 5, offset: 12169},
+									pos:        position{line: 533, col: 5, offset: 12597},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 519, col: 9, offset: 12173},
+									pos:  position{line: 533, col: 9, offset: 12601},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 519, col: 18, offset: 12182},
+									pos:  position{line: 533, col: 18, offset: 12610},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 520, col: 5, offset: 12233},
+						pos:  position{line: 534, col: 5, offset: 12661},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 521, col: 5, offset: 12254},
+						pos:  position{line: 535, col: 5, offset: 12682},
 						name: "unicodeEscape",
 					},
 				},
@@ -4190,75 +4304,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 523, col: 1, offset: 12269},
+			pos:  position{line: 537, col: 1, offset: 12697},
 			expr: &choiceExpr{
-				pos: position{line: 524, col: 5, offset: 12290},
+				pos: position{line: 538, col: 5, offset: 12718},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 524, col: 5, offset: 12290},
+						pos:        position{line: 538, col: 5, offset: 12718},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 525, col: 5, offset: 12298},
+						pos:        position{line: 539, col: 5, offset: 12726},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 526, col: 5, offset: 12306},
+						pos:        position{line: 540, col: 5, offset: 12734},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 527, col: 5, offset: 12315},
+						pos: position{line: 541, col: 5, offset: 12743},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 527, col: 5, offset: 12315},
+							pos:        position{line: 541, col: 5, offset: 12743},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 528, col: 5, offset: 12344},
+						pos: position{line: 542, col: 5, offset: 12772},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 528, col: 5, offset: 12344},
+							pos:        position{line: 542, col: 5, offset: 12772},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 529, col: 5, offset: 12373},
+						pos: position{line: 543, col: 5, offset: 12801},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 529, col: 5, offset: 12373},
+							pos:        position{line: 543, col: 5, offset: 12801},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 530, col: 5, offset: 12402},
+						pos: position{line: 544, col: 5, offset: 12830},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 530, col: 5, offset: 12402},
+							pos:        position{line: 544, col: 5, offset: 12830},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 531, col: 5, offset: 12431},
+						pos: position{line: 545, col: 5, offset: 12859},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 531, col: 5, offset: 12431},
+							pos:        position{line: 545, col: 5, offset: 12859},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 532, col: 5, offset: 12460},
+						pos: position{line: 546, col: 5, offset: 12888},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 532, col: 5, offset: 12460},
+							pos:        position{line: 546, col: 5, offset: 12888},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -4268,29 +4382,29 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 534, col: 1, offset: 12486},
+			pos:  position{line: 548, col: 1, offset: 12914},
 			expr: &seqExpr{
-				pos: position{line: 535, col: 5, offset: 12504},
+				pos: position{line: 549, col: 5, offset: 12932},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 535, col: 5, offset: 12504},
+						pos:        position{line: 549, col: 5, offset: 12932},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 535, col: 9, offset: 12508},
+						pos:  position{line: 549, col: 9, offset: 12936},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 535, col: 18, offset: 12517},
+						pos:  position{line: 549, col: 18, offset: 12945},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 535, col: 27, offset: 12526},
+						pos:  position{line: 549, col: 27, offset: 12954},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 535, col: 36, offset: 12535},
+						pos:  position{line: 549, col: 36, offset: 12963},
 						name: "hexdigit",
 					},
 				},
@@ -4298,28 +4412,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 537, col: 1, offset: 12545},
+			pos:  position{line: 551, col: 1, offset: 12973},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 5, offset: 12558},
+				pos: position{line: 552, col: 5, offset: 12986},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 538, col: 5, offset: 12558},
+					pos: position{line: 552, col: 5, offset: 12986},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 538, col: 5, offset: 12558},
+							pos:        position{line: 552, col: 5, offset: 12986},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 538, col: 9, offset: 12562},
+							pos:   position{line: 552, col: 9, offset: 12990},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 538, col: 11, offset: 12564},
+								pos:  position{line: 552, col: 11, offset: 12992},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 538, col: 18, offset: 12571},
+							pos:        position{line: 552, col: 18, offset: 12999},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4329,24 +4443,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 540, col: 1, offset: 12594},
+			pos:  position{line: 554, col: 1, offset: 13022},
 			expr: &actionExpr{
-				pos: position{line: 541, col: 5, offset: 12605},
+				pos: position{line: 555, col: 5, offset: 13033},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 541, col: 5, offset: 12605},
+					pos: position{line: 555, col: 5, offset: 13033},
 					expr: &choiceExpr{
-						pos: position{line: 541, col: 6, offset: 12606},
+						pos: position{line: 555, col: 6, offset: 13034},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 541, col: 6, offset: 12606},
+								pos:        position{line: 555, col: 6, offset: 13034},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 541, col: 13, offset: 12613},
+								pos:        position{line: 555, col: 13, offset: 13041},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -4357,9 +4471,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 543, col: 1, offset: 12653},
+			pos:  position{line: 557, col: 1, offset: 13081},
 			expr: &charClassMatcher{
-				pos:        position{line: 544, col: 5, offset: 12669},
+				pos:        position{line: 558, col: 5, offset: 13097},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -4369,37 +4483,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 546, col: 1, offset: 12684},
+			pos:  position{line: 560, col: 1, offset: 13112},
 			expr: &choiceExpr{
-				pos: position{line: 547, col: 5, offset: 12691},
+				pos: position{line: 561, col: 5, offset: 13119},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 547, col: 5, offset: 12691},
+						pos:        position{line: 561, col: 5, offset: 13119},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 548, col: 5, offset: 12700},
+						pos:        position{line: 562, col: 5, offset: 13128},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 549, col: 5, offset: 12709},
+						pos:        position{line: 563, col: 5, offset: 13137},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 5, offset: 12718},
+						pos:        position{line: 564, col: 5, offset: 13146},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 5, offset: 12726},
+						pos:        position{line: 565, col: 5, offset: 13154},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 552, col: 5, offset: 12739},
+						pos:        position{line: 566, col: 5, offset: 13167},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -4409,22 +4523,22 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 554, col: 1, offset: 12749},
+			pos:         position{line: 568, col: 1, offset: 13177},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 554, col: 18, offset: 12766},
+				pos: position{line: 568, col: 18, offset: 13194},
 				expr: &ruleRefExpr{
-					pos:  position{line: 554, col: 18, offset: 12766},
+					pos:  position{line: 568, col: 18, offset: 13194},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 556, col: 1, offset: 12771},
+			pos:  position{line: 570, col: 1, offset: 13199},
 			expr: &notExpr{
-				pos: position{line: 556, col: 7, offset: 12777},
+				pos: position{line: 570, col: 7, offset: 13205},
 				expr: &anyMatcher{
-					line: 556, col: 8, offset: 12778,
+					line: 570, col: 8, offset: 13206,
 				},
 			},
 		},
@@ -5028,6 +5142,52 @@ func (p *parser) callonfieldExprList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onfieldExprList1(stack["first"], stack["rest"])
+}
+
+func (c *current) onfieldRefDotOnly7(field interface{}) (interface{}, error) {
+	return makeFieldCall("RecordFieldRead", nil, field), nil
+}
+
+func (p *parser) callonfieldRefDotOnly7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onfieldRefDotOnly7(stack["field"])
+}
+
+func (c *current) onfieldRefDotOnly1(base, refs interface{}) (interface{}, error) {
+	return chainFieldCalls(base, refs), nil
+
+}
+
+func (p *parser) callonfieldRefDotOnly1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onfieldRefDotOnly1(stack["base"], stack["refs"])
+}
+
+func (c *current) onfieldRefDotOnlyList7(ref interface{}) (interface{}, error) {
+	return ref, nil
+}
+
+func (p *parser) callonfieldRefDotOnlyList7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onfieldRefDotOnlyList7(stack["ref"])
+}
+
+func (c *current) onfieldRefDotOnlyList1(first, rest interface{}) (interface{}, error) {
+	result := []interface{}{first}
+	for _, r := range rest.([]interface{}) {
+		result = append(result, r)
+	}
+	return result, nil
+
+}
+
+func (p *parser) callonfieldRefDotOnlyList1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onfieldRefDotOnlyList1(stack["first"], stack["rest"])
 }
 
 func (c *current) onfieldNameList1(first, rest interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -359,55 +359,66 @@ function peg$parse(input, options) {
 
             return result
         },
-      peg$c133 = function(first, rest) {
+      peg$c133 = function(base, refs) {
+          return chainFieldCalls(base, refs)
+        },
+      peg$c134 = function(first, ref) { return ref },
+      peg$c135 = function(first, rest) {
+        let result =  [first]
+        for(let  r of rest) {
+          result.push( r)
+        }
+        return result
+        },
+      peg$c136 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
         },
-      peg$c134 = peg$literalExpectation("count", true),
-      peg$c135 = function() { return "Count" },
-      peg$c136 = "sum",
-      peg$c137 = peg$literalExpectation("sum", true),
-      peg$c138 = function() { return "Sum" },
-      peg$c139 = "avg",
-      peg$c140 = peg$literalExpectation("avg", true),
-      peg$c141 = function() { return "Avg" },
-      peg$c142 = "stdev",
-      peg$c143 = peg$literalExpectation("stdev", true),
-      peg$c144 = function() { return "Stdev" },
-      peg$c145 = "sd",
-      peg$c146 = peg$literalExpectation("sd", true),
-      peg$c147 = "var",
-      peg$c148 = peg$literalExpectation("var", true),
-      peg$c149 = function() { return "Var" },
-      peg$c150 = "entropy",
-      peg$c151 = peg$literalExpectation("entropy", true),
-      peg$c152 = function() { return "Entropy" },
-      peg$c153 = "min",
-      peg$c154 = peg$literalExpectation("min", true),
-      peg$c155 = function() { return "Min" },
-      peg$c156 = "max",
-      peg$c157 = peg$literalExpectation("max", true),
-      peg$c158 = function() { return "Max" },
-      peg$c159 = "first",
-      peg$c160 = peg$literalExpectation("first", true),
-      peg$c161 = function() { return "First" },
-      peg$c162 = "last",
-      peg$c163 = peg$literalExpectation("last", true),
-      peg$c164 = function() { return "Last" },
-      peg$c165 = "countdistinct",
-      peg$c166 = peg$literalExpectation("countdistinct", true),
-      peg$c167 = function() { return "CountDistinct" },
-      peg$c168 = function(field) { return field },
-      peg$c169 = function(op, field) {
+      peg$c137 = peg$literalExpectation("count", true),
+      peg$c138 = function() { return "Count" },
+      peg$c139 = "sum",
+      peg$c140 = peg$literalExpectation("sum", true),
+      peg$c141 = function() { return "Sum" },
+      peg$c142 = "avg",
+      peg$c143 = peg$literalExpectation("avg", true),
+      peg$c144 = function() { return "Avg" },
+      peg$c145 = "stdev",
+      peg$c146 = peg$literalExpectation("stdev", true),
+      peg$c147 = function() { return "Stdev" },
+      peg$c148 = "sd",
+      peg$c149 = peg$literalExpectation("sd", true),
+      peg$c150 = "var",
+      peg$c151 = peg$literalExpectation("var", true),
+      peg$c152 = function() { return "Var" },
+      peg$c153 = "entropy",
+      peg$c154 = peg$literalExpectation("entropy", true),
+      peg$c155 = function() { return "Entropy" },
+      peg$c156 = "min",
+      peg$c157 = peg$literalExpectation("min", true),
+      peg$c158 = function() { return "Min" },
+      peg$c159 = "max",
+      peg$c160 = peg$literalExpectation("max", true),
+      peg$c161 = function() { return "Max" },
+      peg$c162 = "first",
+      peg$c163 = peg$literalExpectation("first", true),
+      peg$c164 = function() { return "First" },
+      peg$c165 = "last",
+      peg$c166 = peg$literalExpectation("last", true),
+      peg$c167 = function() { return "Last" },
+      peg$c168 = "countdistinct",
+      peg$c169 = peg$literalExpectation("countdistinct", true),
+      peg$c170 = function() { return "CountDistinct" },
+      peg$c171 = function(field) { return field },
+      peg$c172 = function(op, field) {
           return makeReducer(op, "count", field)
         },
-      peg$c170 = function(op, field) {
+      peg$c173 = function(op, field) {
           return makeReducer(op, toLowerCase(op), field)
         },
-      peg$c171 = function(every, reducers, keys, limit) {
+      peg$c174 = function(every, reducers, keys, limit) {
           if (OR(keys, every)) {
             if (keys) {
               keys = keys[1]
@@ -424,232 +435,232 @@ function peg$parse(input, options) {
 
           return makeReducerProc(reducers)
         },
-      peg$c172 = "as",
-      peg$c173 = peg$literalExpectation("as", true),
-      peg$c174 = function(field, f) {
+      peg$c175 = "as",
+      peg$c176 = peg$literalExpectation("as", true),
+      peg$c177 = function(field, f) {
           return overrideReducerVar(f, field)
         },
-      peg$c175 = function(f, field) {
+      peg$c178 = function(f, field) {
           return overrideReducerVar(f, field)
         },
-      peg$c176 = function(first, rest) {
+      peg$c179 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c177 = "sort",
-      peg$c178 = peg$literalExpectation("sort", true),
-      peg$c179 = "-r",
-      peg$c180 = peg$literalExpectation("-r", false),
-      peg$c181 = function(rev, limit, list) {
+      peg$c180 = "sort",
+      peg$c181 = peg$literalExpectation("sort", true),
+      peg$c182 = "-r",
+      peg$c183 = peg$literalExpectation("-r", false),
+      peg$c184 = function(rev, limit, list) {
           let sortdir =  1
           if ((rev)) { sortdir = -1 }
           return makeSortProc(list, sortdir, limit)
         },
-      peg$c182 = function(limit, rev, list) {
+      peg$c185 = function(limit, rev, list) {
           let sortdir =  1
           if ((rev)) { sortdir = -1 }
           return makeSortProc(list, sortdir, limit)
         },
-      peg$c183 = "top",
-      peg$c184 = peg$literalExpectation("top", true),
-      peg$c185 = "-flush",
-      peg$c186 = peg$literalExpectation("-flush", false),
-      peg$c187 = function(limit, flush, list) {
+      peg$c186 = "top",
+      peg$c187 = peg$literalExpectation("top", true),
+      peg$c188 = "-flush",
+      peg$c189 = peg$literalExpectation("-flush", false),
+      peg$c190 = function(limit, flush, list) {
           return makeTopProc(list, limit, flush)
         },
-      peg$c188 = "-limit",
-      peg$c189 = peg$literalExpectation("-limit", false),
-      peg$c190 = function(limit) { return limit },
-      peg$c191 = "cut",
-      peg$c192 = peg$literalExpectation("cut", true),
-      peg$c193 = function(list) { return makeCutProc(list) },
-      peg$c194 = "head",
-      peg$c195 = peg$literalExpectation("head", true),
-      peg$c196 = function(count) { return makeHeadProc(count) },
-      peg$c197 = function() { return makeHeadProc(1) },
-      peg$c198 = "tail",
-      peg$c199 = peg$literalExpectation("tail", true),
-      peg$c200 = function(count) { return makeTailProc(count) },
-      peg$c201 = function() { return makeTailProc(1) },
-      peg$c202 = "filter",
-      peg$c203 = peg$literalExpectation("filter", true),
-      peg$c204 = "uniq",
-      peg$c205 = peg$literalExpectation("uniq", true),
-      peg$c206 = "-c",
-      peg$c207 = peg$literalExpectation("-c", false),
-      peg$c208 = function() {
+      peg$c191 = "-limit",
+      peg$c192 = peg$literalExpectation("-limit", false),
+      peg$c193 = function(limit) { return limit },
+      peg$c194 = "cut",
+      peg$c195 = peg$literalExpectation("cut", true),
+      peg$c196 = function(list) { return makeCutProc(list) },
+      peg$c197 = "head",
+      peg$c198 = peg$literalExpectation("head", true),
+      peg$c199 = function(count) { return makeHeadProc(count) },
+      peg$c200 = function() { return makeHeadProc(1) },
+      peg$c201 = "tail",
+      peg$c202 = peg$literalExpectation("tail", true),
+      peg$c203 = function(count) { return makeTailProc(count) },
+      peg$c204 = function() { return makeTailProc(1) },
+      peg$c205 = "filter",
+      peg$c206 = peg$literalExpectation("filter", true),
+      peg$c207 = "uniq",
+      peg$c208 = peg$literalExpectation("uniq", true),
+      peg$c209 = "-c",
+      peg$c210 = peg$literalExpectation("-c", false),
+      peg$c211 = function() {
             return makeUniqProc(true)
           },
-      peg$c209 = function() {
+      peg$c212 = function() {
             return makeUniqProc(false)
           },
-      peg$c210 = "seconds",
-      peg$c211 = peg$literalExpectation("seconds", false),
-      peg$c212 = "second",
-      peg$c213 = peg$literalExpectation("second", false),
-      peg$c214 = "secs",
-      peg$c215 = peg$literalExpectation("secs", false),
-      peg$c216 = "sec",
-      peg$c217 = peg$literalExpectation("sec", false),
-      peg$c218 = "s",
-      peg$c219 = peg$literalExpectation("s", false),
-      peg$c220 = "minutes",
-      peg$c221 = peg$literalExpectation("minutes", false),
-      peg$c222 = "minute",
-      peg$c223 = peg$literalExpectation("minute", false),
-      peg$c224 = "mins",
-      peg$c225 = peg$literalExpectation("mins", false),
-      peg$c226 = peg$literalExpectation("min", false),
-      peg$c227 = "m",
-      peg$c228 = peg$literalExpectation("m", false),
-      peg$c229 = "hours",
-      peg$c230 = peg$literalExpectation("hours", false),
-      peg$c231 = "hrs",
-      peg$c232 = peg$literalExpectation("hrs", false),
-      peg$c233 = "hr",
-      peg$c234 = peg$literalExpectation("hr", false),
-      peg$c235 = "h",
-      peg$c236 = peg$literalExpectation("h", false),
-      peg$c237 = "hour",
-      peg$c238 = peg$literalExpectation("hour", false),
-      peg$c239 = "days",
-      peg$c240 = peg$literalExpectation("days", false),
-      peg$c241 = "day",
-      peg$c242 = peg$literalExpectation("day", false),
-      peg$c243 = "d",
-      peg$c244 = peg$literalExpectation("d", false),
-      peg$c245 = "weeks",
-      peg$c246 = peg$literalExpectation("weeks", false),
-      peg$c247 = "week",
-      peg$c248 = peg$literalExpectation("week", false),
-      peg$c249 = "wks",
-      peg$c250 = peg$literalExpectation("wks", false),
-      peg$c251 = "wk",
-      peg$c252 = peg$literalExpectation("wk", false),
-      peg$c253 = "w",
-      peg$c254 = peg$literalExpectation("w", false),
-      peg$c255 = function() { return makeDuration(1) },
-      peg$c256 = function(num) { return makeDuration(num) },
-      peg$c257 = function() { return makeDuration(60) },
-      peg$c258 = function(num) { return makeDuration(num*60) },
-      peg$c259 = function() { return makeDuration(3600) },
-      peg$c260 = function(num) { return makeDuration(num*3600) },
-      peg$c261 = function() { return makeDuration(3600*24) },
-      peg$c262 = function(num) { return makeDuration(num*3600*24) },
-      peg$c263 = function(num) { return makeDuration(num*3600*24*7) },
-      peg$c264 = function(a) { return text() },
-      peg$c265 = ":",
-      peg$c266 = peg$literalExpectation(":", false),
-      peg$c267 = function(a, b) {
+      peg$c213 = "seconds",
+      peg$c214 = peg$literalExpectation("seconds", false),
+      peg$c215 = "second",
+      peg$c216 = peg$literalExpectation("second", false),
+      peg$c217 = "secs",
+      peg$c218 = peg$literalExpectation("secs", false),
+      peg$c219 = "sec",
+      peg$c220 = peg$literalExpectation("sec", false),
+      peg$c221 = "s",
+      peg$c222 = peg$literalExpectation("s", false),
+      peg$c223 = "minutes",
+      peg$c224 = peg$literalExpectation("minutes", false),
+      peg$c225 = "minute",
+      peg$c226 = peg$literalExpectation("minute", false),
+      peg$c227 = "mins",
+      peg$c228 = peg$literalExpectation("mins", false),
+      peg$c229 = peg$literalExpectation("min", false),
+      peg$c230 = "m",
+      peg$c231 = peg$literalExpectation("m", false),
+      peg$c232 = "hours",
+      peg$c233 = peg$literalExpectation("hours", false),
+      peg$c234 = "hrs",
+      peg$c235 = peg$literalExpectation("hrs", false),
+      peg$c236 = "hr",
+      peg$c237 = peg$literalExpectation("hr", false),
+      peg$c238 = "h",
+      peg$c239 = peg$literalExpectation("h", false),
+      peg$c240 = "hour",
+      peg$c241 = peg$literalExpectation("hour", false),
+      peg$c242 = "days",
+      peg$c243 = peg$literalExpectation("days", false),
+      peg$c244 = "day",
+      peg$c245 = peg$literalExpectation("day", false),
+      peg$c246 = "d",
+      peg$c247 = peg$literalExpectation("d", false),
+      peg$c248 = "weeks",
+      peg$c249 = peg$literalExpectation("weeks", false),
+      peg$c250 = "week",
+      peg$c251 = peg$literalExpectation("week", false),
+      peg$c252 = "wks",
+      peg$c253 = peg$literalExpectation("wks", false),
+      peg$c254 = "wk",
+      peg$c255 = peg$literalExpectation("wk", false),
+      peg$c256 = "w",
+      peg$c257 = peg$literalExpectation("w", false),
+      peg$c258 = function() { return makeDuration(1) },
+      peg$c259 = function(num) { return makeDuration(num) },
+      peg$c260 = function() { return makeDuration(60) },
+      peg$c261 = function(num) { return makeDuration(num*60) },
+      peg$c262 = function() { return makeDuration(3600) },
+      peg$c263 = function(num) { return makeDuration(num*3600) },
+      peg$c264 = function() { return makeDuration(3600*24) },
+      peg$c265 = function(num) { return makeDuration(num*3600*24) },
+      peg$c266 = function(num) { return makeDuration(num*3600*24*7) },
+      peg$c267 = function(a) { return text() },
+      peg$c268 = ":",
+      peg$c269 = peg$literalExpectation(":", false),
+      peg$c270 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c268 = "::",
-      peg$c269 = peg$literalExpectation("::", false),
-      peg$c270 = function(a, b, d, e) {
+      peg$c271 = "::",
+      peg$c272 = peg$literalExpectation("::", false),
+      peg$c273 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c271 = function(a, b) {
+      peg$c274 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c272 = function(a, b) {
+      peg$c275 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c273 = function() {
+      peg$c276 = function() {
             return "::"
           },
-      peg$c274 = function(v) { return ":" + v },
-      peg$c275 = function(v) { return v + ":" },
-      peg$c276 = function(a) { return text() + ".0" },
-      peg$c277 = function(a) { return text() + ".0.0" },
-      peg$c278 = function(a) { return text() + ".0.0.0" },
-      peg$c279 = "/",
-      peg$c280 = peg$literalExpectation("/", false),
-      peg$c281 = function(a, m) {
+      peg$c277 = function(v) { return ":" + v },
+      peg$c278 = function(v) { return v + ":" },
+      peg$c279 = function(a) { return text() + ".0" },
+      peg$c280 = function(a) { return text() + ".0.0" },
+      peg$c281 = function(a) { return text() + ".0.0.0" },
+      peg$c282 = "/",
+      peg$c283 = peg$literalExpectation("/", false),
+      peg$c284 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c282 = function(a, m) {
+      peg$c285 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c283 = function(s) {
+      peg$c286 = function(s) {
           return parseInt(s)
         },
-      peg$c284 = function(chars) {
+      peg$c287 = function(chars) {
           return text()
         },
-      peg$c285 = function(s) {
+      peg$c288 = function(s) {
             return parseFloat(s)
         },
-      peg$c286 = function() {
+      peg$c289 = function() {
             return text()
           },
-      peg$c287 = "0",
-      peg$c288 = peg$literalExpectation("0", false),
-      peg$c289 = /^[1-9]/,
-      peg$c290 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c291 = /^[+\-]/,
-      peg$c292 = peg$classExpectation(["+", "-"], false, false),
-      peg$c293 = "e",
-      peg$c294 = peg$literalExpectation("e", true),
-      peg$c295 = function(chars) { return text() },
-      peg$c296 = /^[0-9a-fA-F]/,
-      peg$c297 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c298 = peg$otherExpectation("boomWord"),
-      peg$c299 = function(chars) { return joinChars(chars) },
-      peg$c300 = "\\",
-      peg$c301 = peg$literalExpectation("\\", false),
-      peg$c302 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c303 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c304 = peg$anyExpectation(),
-      peg$c305 = "\"",
-      peg$c306 = peg$literalExpectation("\"", false),
-      peg$c307 = function(v) { return joinChars(v) },
-      peg$c308 = "'",
-      peg$c309 = peg$literalExpectation("'", false),
-      peg$c310 = "x",
-      peg$c311 = peg$literalExpectation("x", false),
-      peg$c312 = function() { return "\\" + text() },
-      peg$c313 = "b",
-      peg$c314 = peg$literalExpectation("b", false),
-      peg$c315 = function() { return "\b" },
-      peg$c316 = "f",
-      peg$c317 = peg$literalExpectation("f", false),
-      peg$c318 = function() { return "\f" },
-      peg$c319 = "n",
-      peg$c320 = peg$literalExpectation("n", false),
-      peg$c321 = function() { return "\n" },
-      peg$c322 = "r",
-      peg$c323 = peg$literalExpectation("r", false),
-      peg$c324 = function() { return "\r" },
-      peg$c325 = "t",
-      peg$c326 = peg$literalExpectation("t", false),
-      peg$c327 = function() { return "\t" },
-      peg$c328 = "v",
-      peg$c329 = peg$literalExpectation("v", false),
-      peg$c330 = function() { return "\v" },
-      peg$c331 = "u",
-      peg$c332 = peg$literalExpectation("u", false),
-      peg$c333 = /^[^\/\\]/,
-      peg$c334 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c335 = "\\/",
-      peg$c336 = peg$literalExpectation("\\/", false),
-      peg$c337 = /^[\0-\x1F\\]/,
-      peg$c338 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c339 = "\t",
-      peg$c340 = peg$literalExpectation("\t", false),
-      peg$c341 = "\x0B",
-      peg$c342 = peg$literalExpectation("\x0B", false),
-      peg$c343 = "\f",
-      peg$c344 = peg$literalExpectation("\f", false),
-      peg$c345 = " ",
-      peg$c346 = peg$literalExpectation(" ", false),
-      peg$c347 = "\xA0",
-      peg$c348 = peg$literalExpectation("\xA0", false),
-      peg$c349 = "\uFEFF",
-      peg$c350 = peg$literalExpectation("\uFEFF", false),
-      peg$c351 = peg$otherExpectation("whitespace"),
+      peg$c290 = "0",
+      peg$c291 = peg$literalExpectation("0", false),
+      peg$c292 = /^[1-9]/,
+      peg$c293 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c294 = /^[+\-]/,
+      peg$c295 = peg$classExpectation(["+", "-"], false, false),
+      peg$c296 = "e",
+      peg$c297 = peg$literalExpectation("e", true),
+      peg$c298 = function(chars) { return text() },
+      peg$c299 = /^[0-9a-fA-F]/,
+      peg$c300 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c301 = peg$otherExpectation("boomWord"),
+      peg$c302 = function(chars) { return joinChars(chars) },
+      peg$c303 = "\\",
+      peg$c304 = peg$literalExpectation("\\", false),
+      peg$c305 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c306 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c307 = peg$anyExpectation(),
+      peg$c308 = "\"",
+      peg$c309 = peg$literalExpectation("\"", false),
+      peg$c310 = function(v) { return joinChars(v) },
+      peg$c311 = "'",
+      peg$c312 = peg$literalExpectation("'", false),
+      peg$c313 = "x",
+      peg$c314 = peg$literalExpectation("x", false),
+      peg$c315 = function() { return "\\" + text() },
+      peg$c316 = "b",
+      peg$c317 = peg$literalExpectation("b", false),
+      peg$c318 = function() { return "\b" },
+      peg$c319 = "f",
+      peg$c320 = peg$literalExpectation("f", false),
+      peg$c321 = function() { return "\f" },
+      peg$c322 = "n",
+      peg$c323 = peg$literalExpectation("n", false),
+      peg$c324 = function() { return "\n" },
+      peg$c325 = "r",
+      peg$c326 = peg$literalExpectation("r", false),
+      peg$c327 = function() { return "\r" },
+      peg$c328 = "t",
+      peg$c329 = peg$literalExpectation("t", false),
+      peg$c330 = function() { return "\t" },
+      peg$c331 = "v",
+      peg$c332 = peg$literalExpectation("v", false),
+      peg$c333 = function() { return "\v" },
+      peg$c334 = "u",
+      peg$c335 = peg$literalExpectation("u", false),
+      peg$c336 = /^[^\/\\]/,
+      peg$c337 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c338 = "\\/",
+      peg$c339 = peg$literalExpectation("\\/", false),
+      peg$c340 = /^[\0-\x1F\\]/,
+      peg$c341 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c342 = "\t",
+      peg$c343 = peg$literalExpectation("\t", false),
+      peg$c344 = "\x0B",
+      peg$c345 = peg$literalExpectation("\x0B", false),
+      peg$c346 = "\f",
+      peg$c347 = peg$literalExpectation("\f", false),
+      peg$c348 = " ",
+      peg$c349 = peg$literalExpectation(" ", false),
+      peg$c350 = "\xA0",
+      peg$c351 = peg$literalExpectation("\xA0", false),
+      peg$c352 = "\uFEFF",
+      peg$c353 = peg$literalExpectation("\uFEFF", false),
+      peg$c354 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2716,6 +2727,182 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsefieldRefDotOnly() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parsefieldName();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s4 = peg$c117;
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+      }
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parsefieldName();
+        if (s5 !== peg$FAILED) {
+          peg$savedPos = s3;
+          s4 = peg$c119(s1, s5);
+          s3 = s4;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s4 = peg$c117;
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parsefieldName();
+          if (s5 !== peg$FAILED) {
+            peg$savedPos = s3;
+            s4 = peg$c119(s1, s5);
+            s3 = s4;
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c133(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parsefieldRefDotOnlyList() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parsefieldRefDotOnly();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse_();
+      if (s4 === peg$FAILED) {
+        s4 = null;
+      }
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c130;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c131); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 === peg$FAILED) {
+            s6 = null;
+          }
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parsefieldRefDotOnly();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c134(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse_();
+        if (s4 === peg$FAILED) {
+          s4 = null;
+        }
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c130;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c131); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 === peg$FAILED) {
+              s6 = null;
+            }
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parsefieldRefDotOnly();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c134(s1, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c135(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parsefieldNameList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
@@ -2806,7 +2993,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c133(s1, s2);
+        s1 = peg$c136(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2829,11 +3016,11 @@ function peg$parse(input, options) {
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c134); }
+      if (peg$silentFails === 0) { peg$fail(peg$c137); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c135();
+      s1 = peg$c138();
     }
     s0 = s1;
 
@@ -2844,156 +3031,156 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c136) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c139) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c138();
+      s1 = peg$c141();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c139) {
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c142) {
         s1 = input.substr(peg$currPos, 3);
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c141();
+        s1 = peg$c144();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c142) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c145) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c146); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c144();
+          s1 = peg$c147();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c145) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c148) {
             s1 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c146); }
+            if (peg$silentFails === 0) { peg$fail(peg$c149); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c144();
+            s1 = peg$c147();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c147) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c150) {
               s1 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c148); }
+              if (peg$silentFails === 0) { peg$fail(peg$c151); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c149();
+              s1 = peg$c152();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c150) {
+              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c153) {
                 s1 = input.substr(peg$currPos, 7);
                 peg$currPos += 7;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c151); }
+                if (peg$silentFails === 0) { peg$fail(peg$c154); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c152();
+                s1 = peg$c155();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c153) {
+                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
                   s1 = input.substr(peg$currPos, 3);
                   peg$currPos += 3;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c154); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c157); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c155();
+                  s1 = peg$c158();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
+                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c159) {
                     s1 = input.substr(peg$currPos, 3);
                     peg$currPos += 3;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c157); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c160); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c158();
+                    s1 = peg$c161();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c159) {
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c162) {
                       s1 = input.substr(peg$currPos, 5);
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c160); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c163); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c161();
+                      s1 = peg$c164();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c162) {
+                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c165) {
                         s1 = input.substr(peg$currPos, 4);
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c166); }
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c164();
+                        s1 = peg$c167();
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c165) {
+                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c168) {
                           s1 = input.substr(peg$currPos, 13);
                           peg$currPos += 13;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c166); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c169); }
                         }
                         if (s1 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c167();
+                          s1 = peg$c170();
                         }
                         s0 = s1;
                       }
@@ -3027,7 +3214,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c168(s2);
+          s1 = peg$c171(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3083,7 +3270,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c169(s1, s4);
+                s1 = peg$c172(s1, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3153,7 +3340,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c170(s1, s5);
+                  s1 = peg$c173(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3237,7 +3424,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c171(s1, s2, s3, s4);
+            s1 = peg$c174(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3263,12 +3450,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c172) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c175) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c176); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3321,7 +3508,7 @@ function peg$parse(input, options) {
             s5 = peg$parsereducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c174(s1, s5);
+              s1 = peg$c177(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3352,7 +3539,7 @@ function peg$parse(input, options) {
           s3 = peg$parseasClause();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1, s3);
+            s1 = peg$c178(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3475,7 +3662,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c176(s1, s2);
+        s1 = peg$c179(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3519,23 +3706,23 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c178); }
+      if (peg$silentFails === 0) { peg$fail(peg$c181); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c179) {
-          s4 = peg$c179;
+        if (input.substr(peg$currPos, 2) === peg$c182) {
+          s4 = peg$c182;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c180); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -3564,12 +3751,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$currPos;
             peg$silentFails++;
-            if (input.substr(peg$currPos, 2) === peg$c179) {
-              s6 = peg$c179;
+            if (input.substr(peg$currPos, 2) === peg$c182) {
+              s6 = peg$c182;
               peg$currPos += 2;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c180); }
+              if (peg$silentFails === 0) { peg$fail(peg$c183); }
             }
             peg$silentFails--;
             if (s6 === peg$FAILED) {
@@ -3585,7 +3772,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c181(s2, s3, s6);
+                s1 = peg$c184(s2, s3, s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3613,12 +3800,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c178); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseprocLimitArg();
@@ -3629,12 +3816,12 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c179) {
-              s5 = peg$c179;
+            if (input.substr(peg$currPos, 2) === peg$c182) {
+              s5 = peg$c182;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c180); }
+              if (peg$silentFails === 0) { peg$fail(peg$c183); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -3662,7 +3849,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c182(s2, s3, s5);
+                s1 = peg$c185(s2, s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3693,12 +3880,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c183) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c186) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c184); }
+      if (peg$silentFails === 0) { peg$fail(peg$c187); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseprocLimitArg();
@@ -3709,12 +3896,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c185) {
-            s5 = peg$c185;
+          if (input.substr(peg$currPos, 6) === peg$c188) {
+            s5 = peg$c188;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c186); }
+            if (peg$silentFails === 0) { peg$fail(peg$c189); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3742,7 +3929,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c187(s2, s3, s5);
+              s1 = peg$c190(s2, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3774,12 +3961,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c188) {
-        s2 = peg$c188;
+      if (input.substr(peg$currPos, 6) === peg$c191) {
+        s2 = peg$c191;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c189); }
+        if (peg$silentFails === 0) { peg$fail(peg$c192); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3787,7 +3974,7 @@ function peg$parse(input, options) {
           s4 = peg$parseinteger();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c190(s4);
+            s1 = peg$c193(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3813,20 +4000,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c191) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c194) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c195); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsefieldNameList();
+        s3 = peg$parsefieldRefDotOnlyList();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c193(s3);
+          s1 = peg$c196(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3848,12 +4035,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c194) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c197) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c198); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3861,7 +4048,7 @@ function peg$parse(input, options) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c196(s3);
+          s1 = peg$c199(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3877,16 +4064,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c194) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c197) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c198); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197();
+        s1 = peg$c200();
       }
       s0 = s1;
     }
@@ -3898,12 +4085,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c198) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c201) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
+      if (peg$silentFails === 0) { peg$fail(peg$c202); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3911,7 +4098,7 @@ function peg$parse(input, options) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c200(s3);
+          s1 = peg$c203(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3927,16 +4114,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c198) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c201) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c199); }
+        if (peg$silentFails === 0) { peg$fail(peg$c202); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c201();
+        s1 = peg$c204();
       }
       s0 = s1;
     }
@@ -3948,12 +4135,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c202) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c205) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c203); }
+      if (peg$silentFails === 0) { peg$fail(peg$c206); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3983,26 +4170,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c204) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c207) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c205); }
+      if (peg$silentFails === 0) { peg$fail(peg$c208); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c206) {
-          s3 = peg$c206;
+        if (input.substr(peg$currPos, 2) === peg$c209) {
+          s3 = peg$c209;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c207); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c208();
+          s1 = peg$c211();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4018,16 +4205,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c204) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c207) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c205); }
+        if (peg$silentFails === 0) { peg$fail(peg$c208); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c209();
+        s1 = peg$c212();
       }
       s0 = s1;
     }
@@ -4099,44 +4286,44 @@ function peg$parse(input, options) {
   function peg$parsesec_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c210) {
-      s0 = peg$c210;
+    if (input.substr(peg$currPos, 7) === peg$c213) {
+      s0 = peg$c213;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c211); }
+      if (peg$silentFails === 0) { peg$fail(peg$c214); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c212) {
-        s0 = peg$c212;
+      if (input.substr(peg$currPos, 6) === peg$c215) {
+        s0 = peg$c215;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c213); }
+        if (peg$silentFails === 0) { peg$fail(peg$c216); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c214) {
-          s0 = peg$c214;
+        if (input.substr(peg$currPos, 4) === peg$c217) {
+          s0 = peg$c217;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c215); }
+          if (peg$silentFails === 0) { peg$fail(peg$c218); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c216) {
-            s0 = peg$c216;
+          if (input.substr(peg$currPos, 3) === peg$c219) {
+            s0 = peg$c219;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c217); }
+            if (peg$silentFails === 0) { peg$fail(peg$c220); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c218;
+              s0 = peg$c221;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c219); }
+              if (peg$silentFails === 0) { peg$fail(peg$c222); }
             }
           }
         }
@@ -4149,44 +4336,44 @@ function peg$parse(input, options) {
   function peg$parsemin_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c220) {
-      s0 = peg$c220;
+    if (input.substr(peg$currPos, 7) === peg$c223) {
+      s0 = peg$c223;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c221); }
+      if (peg$silentFails === 0) { peg$fail(peg$c224); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c222) {
-        s0 = peg$c222;
+      if (input.substr(peg$currPos, 6) === peg$c225) {
+        s0 = peg$c225;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c223); }
+        if (peg$silentFails === 0) { peg$fail(peg$c226); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c224) {
-          s0 = peg$c224;
+        if (input.substr(peg$currPos, 4) === peg$c227) {
+          s0 = peg$c227;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c225); }
+          if (peg$silentFails === 0) { peg$fail(peg$c228); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c153) {
-            s0 = peg$c153;
+          if (input.substr(peg$currPos, 3) === peg$c156) {
+            s0 = peg$c156;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c226); }
+            if (peg$silentFails === 0) { peg$fail(peg$c229); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c227;
+              s0 = peg$c230;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c228); }
+              if (peg$silentFails === 0) { peg$fail(peg$c231); }
             }
           }
         }
@@ -4199,44 +4386,44 @@ function peg$parse(input, options) {
   function peg$parsehour_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c229) {
-      s0 = peg$c229;
+    if (input.substr(peg$currPos, 5) === peg$c232) {
+      s0 = peg$c232;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c230); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c231) {
-        s0 = peg$c231;
+      if (input.substr(peg$currPos, 3) === peg$c234) {
+        s0 = peg$c234;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c232); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c233) {
-          s0 = peg$c233;
+        if (input.substr(peg$currPos, 2) === peg$c236) {
+          s0 = peg$c236;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c234); }
+          if (peg$silentFails === 0) { peg$fail(peg$c237); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c235;
+            s0 = peg$c238;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c236); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c237) {
-              s0 = peg$c237;
+            if (input.substr(peg$currPos, 4) === peg$c240) {
+              s0 = peg$c240;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c238); }
+              if (peg$silentFails === 0) { peg$fail(peg$c241); }
             }
           }
         }
@@ -4249,28 +4436,28 @@ function peg$parse(input, options) {
   function peg$parseday_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c239) {
-      s0 = peg$c239;
+    if (input.substr(peg$currPos, 4) === peg$c242) {
+      s0 = peg$c242;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c243); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c241) {
-        s0 = peg$c241;
+      if (input.substr(peg$currPos, 3) === peg$c244) {
+        s0 = peg$c244;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c242); }
+        if (peg$silentFails === 0) { peg$fail(peg$c245); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c243;
+          s0 = peg$c246;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c244); }
+          if (peg$silentFails === 0) { peg$fail(peg$c247); }
         }
       }
     }
@@ -4281,44 +4468,44 @@ function peg$parse(input, options) {
   function peg$parseweek_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c245) {
-      s0 = peg$c245;
+    if (input.substr(peg$currPos, 5) === peg$c248) {
+      s0 = peg$c248;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c247) {
-        s0 = peg$c247;
+      if (input.substr(peg$currPos, 4) === peg$c250) {
+        s0 = peg$c250;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c248); }
+        if (peg$silentFails === 0) { peg$fail(peg$c251); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c249) {
-          s0 = peg$c249;
+        if (input.substr(peg$currPos, 3) === peg$c252) {
+          s0 = peg$c252;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c250); }
+          if (peg$silentFails === 0) { peg$fail(peg$c253); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c251) {
-            s0 = peg$c251;
+          if (input.substr(peg$currPos, 2) === peg$c254) {
+            s0 = peg$c254;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c252); }
+            if (peg$silentFails === 0) { peg$fail(peg$c255); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c253;
+              s0 = peg$c256;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c254); }
+              if (peg$silentFails === 0) { peg$fail(peg$c257); }
             }
           }
         }
@@ -4332,16 +4519,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c212) {
-      s1 = peg$c212;
+    if (input.substr(peg$currPos, 6) === peg$c215) {
+      s1 = peg$c215;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c213); }
+      if (peg$silentFails === 0) { peg$fail(peg$c216); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c255();
+      s1 = peg$c258();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4356,7 +4543,7 @@ function peg$parse(input, options) {
           s3 = peg$parsesec_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s1);
+            s1 = peg$c259(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4379,16 +4566,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c222) {
-      s1 = peg$c222;
+    if (input.substr(peg$currPos, 6) === peg$c225) {
+      s1 = peg$c225;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c223); }
+      if (peg$silentFails === 0) { peg$fail(peg$c226); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c257();
+      s1 = peg$c260();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4403,7 +4590,7 @@ function peg$parse(input, options) {
           s3 = peg$parsemin_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c258(s1);
+            s1 = peg$c261(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4426,16 +4613,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c237) {
-      s1 = peg$c237;
+    if (input.substr(peg$currPos, 4) === peg$c240) {
+      s1 = peg$c240;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c241); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c259();
+      s1 = peg$c262();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4450,7 +4637,7 @@ function peg$parse(input, options) {
           s3 = peg$parsehour_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c260(s1);
+            s1 = peg$c263(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4473,16 +4660,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c241) {
-      s1 = peg$c241;
+    if (input.substr(peg$currPos, 3) === peg$c244) {
+      s1 = peg$c244;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c242); }
+      if (peg$silentFails === 0) { peg$fail(peg$c245); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c261();
+      s1 = peg$c264();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4497,7 +4684,7 @@ function peg$parse(input, options) {
           s3 = peg$parseday_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c265(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4530,7 +4717,7 @@ function peg$parse(input, options) {
         s3 = peg$parseweek_abbrev();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c263(s1);
+          s1 = peg$c266(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4617,7 +4804,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c264(s1);
+      s1 = peg$c267(s1);
     }
     s0 = s1;
 
@@ -4629,11 +4816,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c265;
+      s1 = peg$c268;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c269); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
@@ -4671,7 +4858,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c267(s1, s2);
+        s1 = peg$c270(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4692,12 +4879,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c268) {
-            s3 = peg$c268;
+          if (input.substr(peg$currPos, 2) === peg$c271) {
+            s3 = peg$c271;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -4710,7 +4897,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c270(s1, s2, s4, s5);
+                s1 = peg$c273(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4734,12 +4921,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c268) {
-          s1 = peg$c268;
+        if (input.substr(peg$currPos, 2) === peg$c271) {
+          s1 = peg$c271;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c269); }
+          if (peg$silentFails === 0) { peg$fail(peg$c272); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -4752,7 +4939,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c271(s2, s3);
+              s1 = peg$c274(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4777,16 +4964,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c268) {
-                s3 = peg$c268;
+              if (input.substr(peg$currPos, 2) === peg$c271) {
+                s3 = peg$c271;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c269); }
+                if (peg$silentFails === 0) { peg$fail(peg$c272); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c272(s1, s2);
+                s1 = peg$c275(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4802,16 +4989,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c268) {
-              s1 = peg$c268;
+            if (input.substr(peg$currPos, 2) === peg$c271) {
+              s1 = peg$c271;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c269); }
+              if (peg$silentFails === 0) { peg$fail(peg$c272); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c273();
+              s1 = peg$c276();
             }
             s0 = s1;
           }
@@ -4838,17 +5025,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c265;
+      s1 = peg$c268;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c269); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c274(s2);
+        s1 = peg$c277(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4869,15 +5056,15 @@ function peg$parse(input, options) {
     s1 = peg$parseh16();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c265;
+        s2 = peg$c268;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c269); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c275(s1);
+        s1 = peg$c278(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4944,7 +5131,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c276(s1);
+        s1 = peg$c279(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -4978,7 +5165,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c277(s1);
+          s1 = peg$c280(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -4986,7 +5173,7 @@ function peg$parse(input, options) {
           s1 = peg$parseinteger();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c278(s1);
+            s1 = peg$c281(s1);
           }
           s0 = s1;
         }
@@ -5003,17 +5190,17 @@ function peg$parse(input, options) {
     s1 = peg$parsesub_addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c279;
+        s2 = peg$c282;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c283); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c281(s1, s3);
+          s1 = peg$c284(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5038,17 +5225,17 @@ function peg$parse(input, options) {
     s1 = peg$parseip6addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c279;
+        s2 = peg$c282;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c280); }
+        if (peg$silentFails === 0) { peg$fail(peg$c283); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c282(s1, s3);
+          s1 = peg$c285(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5073,7 +5260,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesinteger();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c283(s1);
+      s1 = peg$c286(s1);
     }
     s0 = s1;
 
@@ -5108,7 +5295,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c284(s1);
+      s1 = peg$c287(s1);
     }
     s0 = s1;
 
@@ -5122,7 +5309,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesdouble();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c285(s1);
+      s1 = peg$c288(s1);
     }
     s0 = s1;
 
@@ -5169,7 +5356,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c286();
+            s1 = peg$c289();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5214,7 +5401,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c286();
+            s1 = peg$c289();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5237,20 +5424,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c287;
+      s0 = peg$c290;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c288); }
+      if (peg$silentFails === 0) { peg$fail(peg$c291); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c289.test(input.charAt(peg$currPos))) {
+      if (peg$c292.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c290); }
+        if (peg$silentFails === 0) { peg$fail(peg$c293); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -5305,12 +5492,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$c291.test(input.charAt(peg$currPos))) {
+    if (peg$c294.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -5345,12 +5532,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c293) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c296) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesignedInteger();
@@ -5385,7 +5572,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c295(s1);
+      s1 = peg$c298(s1);
     }
     s0 = s1;
 
@@ -5395,12 +5582,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c296.test(input.charAt(peg$currPos))) {
+    if (peg$c299.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c297); }
+      if (peg$silentFails === 0) { peg$fail(peg$c300); }
     }
 
     return s0;
@@ -5423,13 +5610,13 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c299(s1);
+      s1 = peg$c302(s1);
     }
     s0 = s1;
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c298); }
+      if (peg$silentFails === 0) { peg$fail(peg$c301); }
     }
 
     return s0;
@@ -5440,11 +5627,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c300;
+      s1 = peg$c303;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
+      if (peg$silentFails === 0) { peg$fail(peg$c304); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -5464,12 +5651,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c302.test(input.charAt(peg$currPos))) {
+      if (peg$c305.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c303); }
+        if (peg$silentFails === 0) { peg$fail(peg$c306); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -5487,7 +5674,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c304); }
+          if (peg$silentFails === 0) { peg$fail(peg$c307); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -5511,11 +5698,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c305;
+      s1 = peg$c308;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c306); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -5526,15 +5713,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c305;
+          s3 = peg$c308;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c306); }
+          if (peg$silentFails === 0) { peg$fail(peg$c309); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c307(s2);
+          s1 = peg$c310(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5551,11 +5738,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c308;
+        s1 = peg$c311;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c309); }
+        if (peg$silentFails === 0) { peg$fail(peg$c312); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -5566,15 +5753,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c308;
+            s3 = peg$c311;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c309); }
+            if (peg$silentFails === 0) { peg$fail(peg$c312); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c307(s2);
+            s1 = peg$c310(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5600,11 +5787,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c305;
+      s2 = peg$c308;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c306); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -5622,7 +5809,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c304); }
+        if (peg$silentFails === 0) { peg$fail(peg$c307); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -5639,11 +5826,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c300;
+        s1 = peg$c303;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -5671,11 +5858,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c308;
+      s2 = peg$c311;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -5693,7 +5880,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c304); }
+        if (peg$silentFails === 0) { peg$fail(peg$c307); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -5710,11 +5897,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c300;
+        s1 = peg$c303;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -5740,11 +5927,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c310;
+      s1 = peg$c313;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c311); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -5752,7 +5939,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c312();
+          s1 = peg$c315();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5780,110 +5967,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c308;
+      s0 = peg$c311;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c305;
+        s0 = peg$c308;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c306); }
+        if (peg$silentFails === 0) { peg$fail(peg$c309); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c300;
+          s0 = peg$c303;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c304); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c313;
+            s1 = peg$c316;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c314); }
+            if (peg$silentFails === 0) { peg$fail(peg$c317); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c315();
+            s1 = peg$c318();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c316;
+              s1 = peg$c319;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c317); }
+              if (peg$silentFails === 0) { peg$fail(peg$c320); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318();
+              s1 = peg$c321();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c319;
+                s1 = peg$c322;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c320); }
+                if (peg$silentFails === 0) { peg$fail(peg$c323); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c321();
+                s1 = peg$c324();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c322;
+                  s1 = peg$c325;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c326); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c324();
+                  s1 = peg$c327();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c325;
+                    s1 = peg$c328;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c326); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c329); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c327();
+                    s1 = peg$c330();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c328;
+                      s1 = peg$c331;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c332); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c330();
+                      s1 = peg$c333();
                     }
                     s0 = s1;
                   }
@@ -5903,11 +6090,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c331;
+      s1 = peg$c334;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c332); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -5949,21 +6136,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c279;
+      s1 = peg$c282;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c283); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c279;
+          s3 = peg$c282;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c280); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -5990,39 +6177,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c333.test(input.charAt(peg$currPos))) {
+    if (peg$c336.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c334); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c335) {
-        s2 = peg$c335;
+      if (input.substr(peg$currPos, 2) === peg$c338) {
+        s2 = peg$c338;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c336); }
+        if (peg$silentFails === 0) { peg$fail(peg$c339); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c333.test(input.charAt(peg$currPos))) {
+        if (peg$c336.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c334); }
+          if (peg$silentFails === 0) { peg$fail(peg$c337); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c335) {
-            s2 = peg$c335;
+          if (input.substr(peg$currPos, 2) === peg$c338) {
+            s2 = peg$c338;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c336); }
+            if (peg$silentFails === 0) { peg$fail(peg$c339); }
           }
         }
       }
@@ -6041,12 +6228,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c337.test(input.charAt(peg$currPos))) {
+    if (peg$c340.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
 
     return s0;
@@ -6056,51 +6243,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c339;
+      s0 = peg$c342;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c341;
+        s0 = peg$c344;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c342); }
+        if (peg$silentFails === 0) { peg$fail(peg$c345); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c343;
+          s0 = peg$c346;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c344); }
+          if (peg$silentFails === 0) { peg$fail(peg$c347); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c345;
+            s0 = peg$c348;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c346); }
+            if (peg$silentFails === 0) { peg$fail(peg$c349); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c347;
+              s0 = peg$c350;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c348); }
+              if (peg$silentFails === 0) { peg$fail(peg$c351); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c349;
+                s0 = peg$c352;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c350); }
+                if (peg$silentFails === 0) { peg$fail(peg$c353); }
               }
             }
           }
@@ -6128,7 +6315,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c351); }
+      if (peg$silentFails === 0) { peg$fail(peg$c354); }
     }
 
     return s0;
@@ -6144,7 +6331,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c304); }
+      if (peg$silentFails === 0) { peg$fail(peg$c307); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -260,6 +260,20 @@ fieldExprList
       RETURN(result)
   }
 
+fieldRefDotOnly
+  = base:fieldName refs:("." field:fieldName { RETURN(makeFieldCall("RecordFieldRead", NULL, field)) } )* {
+    RETURN(chainFieldCalls(base, refs))
+  }
+
+fieldRefDotOnlyList
+  = first:fieldRefDotOnly rest:(_? "," _? ref:fieldRefDotOnly { RETURN(ref) })* {
+  INIT_ASSIGN_VAR(result, ARRAY(first))
+  FOREACH(ASSERT_ARRAY(rest), r) {
+    APPEND(result, r)
+  }
+  RETURN(result)
+  }
+
 fieldNameList
   = first:fieldName rest:(_? "," _? fieldName)* {
       INIT_ASSIGN_VAR(result, ARRAY(first))
@@ -371,7 +385,7 @@ procLimitArg
   = _ "-limit" _ limit:integer { RETURN(limit) }
 
 cut
-  = "cut"i _ list:fieldNameList { RETURN(makeCutProc(list)) }
+  = "cut"i _ list:fieldRefDotOnlyList { RETURN(makeCutProc(list)) }
 head
   = "head"i _ count:integer { RETURN(makeHeadProc(count)) }
   / "head"i { RETURN(makeHeadProc(1)) }


### PR DESCRIPTION
This got a lot more gnarly that I anticipated but even if they're infrequently used, expressions that combine different fields like `cut a, b.c, b.d, x.y.z` are tricky to handle correctly and efficiently.
