### PR TITLE
Fix path computation in Exec.Run()

### DIFF
--- a/pkg/test/exec.go
+++ b/pkg/test/exec.go
@@ -16,7 +16,7 @@ type Exec struct {
 func (e *Exec) Run(path string) (string, error) {
 	src := e.Command
 	if path != "" {
-		src = "PATH=$PATH:" + path + " ; " + src
+		src = "PATH=" + path + ":$PATH " + src
 	}
 	cmd := exec.Command("/bin/bash", "-c", src)
 	var stdout bytes.Buffer


### PR DESCRIPTION
This had me confused for a while... (Why were CI tests failing and not mine, or vice versa? Because I was testing the installed zq and not the built zq).