### PR TITLE
Add -U flag for forcing output of utf-8 interpretation of zeek strings

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -103,7 +103,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.ShowTypes, "T", false, "display field types in text output")
 	f.BoolVar(&c.ShowFields, "F", false, "display field names in text output")
 	f.BoolVar(&c.EpochDates, "E", false, "display epoch timestamps in text output")
-	f.BoolVar(&c.Utf8, "U", false, "display zeek strings as UTF-8")
+	f.BoolVar(&c.UTF8, "U", false, "display zeek strings as UTF-8")
 	f.BoolVar(&c.showVersion, "version", false, "print version and exit")
 	return c, nil
 }

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mccanne/zq/filter"
 	"github.com/mccanne/zq/pkg/zsio"
 	"github.com/mccanne/zq/pkg/zsio/detector"
-	"github.com/mccanne/zq/pkg/zsio/text"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zson/resolver"
 	"github.com/mccanne/zq/proc"
@@ -87,7 +86,7 @@ type Command struct {
 	stats       bool
 	warnings    bool
 	showVersion bool
-	text.Config
+	zsio.Flags
 }
 
 func New(f *flag.FlagSet) (charm.Command, error) {
@@ -104,6 +103,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.ShowTypes, "T", false, "display field types in text output")
 	f.BoolVar(&c.ShowFields, "F", false, "display field names in text output")
 	f.BoolVar(&c.EpochDates, "E", false, "display epoch timestamps in text output")
+	f.BoolVar(&c.Utf8, "U", false, "display zeek strings as UTF-8")
 	f.BoolVar(&c.showVersion, "version", false, "print version and exit")
 	return c, nil
 }
@@ -231,7 +231,7 @@ func (c *Command) loadFile(path string) (zson.Reader, error) {
 	case "auto":
 		return detector.NewReader(f, c.dt)
 	case "ndjson", "bzson", "zeek", "zjson", "zson":
-		return zsio.LookupReader(c.ifmt, f, c.dt), nil
+		return detector.LookupReader(c.ifmt, f, c.dt), nil
 	default:
 		return nil, fmt.Errorf("unknown input format %s", c.ifmt)
 	}
@@ -262,13 +262,13 @@ func (c *Command) loadFiles(paths []string) (zson.Reader, error) {
 
 func (c *Command) openOutput() (zson.WriteCloser, error) {
 	if c.dir != "" {
-		d, err := emitter.NewDir(c.dir, c.outputFile, c.ofmt, os.Stderr, &c.Config)
+		d, err := emitter.NewDir(c.dir, c.outputFile, c.ofmt, os.Stderr, &c.Flags)
 		if err != nil {
 			return nil, err
 		}
 		return d, nil
 	}
-	w, err := emitter.NewFile(c.outputFile, c.ofmt, &c.Config)
+	w, err := emitter.NewFile(c.outputFile, c.ofmt, &c.Flags)
 	if err != nil {
 		return nil, err
 	}

--- a/emitter/bytes.go
+++ b/emitter/bytes.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/mccanne/zq/pkg/zsio"
-	"github.com/mccanne/zq/pkg/zsio/text"
+	"github.com/mccanne/zq/pkg/zsio/detector"
 )
 
 type Bytes struct {
@@ -16,9 +16,9 @@ func (b *Bytes) Bytes() []byte {
 	return b.buf.Bytes()
 }
 
-func NewBytes(format string, tc *text.Config) (*Bytes, error) {
+func NewBytes(format string, flags *zsio.Flags) (*Bytes, error) {
 	b := &Bytes{}
-	b.Writer = zsio.LookupWriter(format, &noClose{&b.buf}, tc)
+	b.Writer = detector.LookupWriter(format, &noClose{&b.buf}, flags)
 	if b.Writer == nil {
 		return nil, unknownFormat(format)
 	}

--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/mccanne/zq/pkg/zsio"
-	"github.com/mccanne/zq/pkg/zsio/text"
 	"github.com/mccanne/zq/pkg/zson"
 )
 
@@ -28,7 +27,7 @@ type Dir struct {
 	ext     string
 	format  string
 	stderr  io.Writer // XXX use warnings channel
-	tc      *text.Config
+	flags   *zsio.Flags
 	writers map[*zson.Descriptor]*zsio.Writer
 	paths   map[string]*zsio.Writer
 }
@@ -37,7 +36,7 @@ func unknownFormat(format string) error {
 	return fmt.Errorf("unknown output format: %s", format)
 }
 
-func NewDir(dir, prefix, format string, stderr io.Writer, tc *text.Config) (*Dir, error) {
+func NewDir(dir, prefix, format string, stderr io.Writer, flags *zsio.Flags) (*Dir, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}
@@ -51,7 +50,7 @@ func NewDir(dir, prefix, format string, stderr io.Writer, tc *text.Config) (*Dir
 		ext:     e,
 		format:  format,
 		stderr:  stderr,
-		tc:      tc,
+		flags:   flags,
 		writers: make(map[*zson.Descriptor]*zsio.Writer),
 		paths:   make(map[string]*zsio.Writer),
 	}, nil
@@ -100,7 +99,7 @@ func (d *Dir) newFile(rec *zson.Record) (*zsio.Writer, error) {
 	if w, ok := d.paths[path]; ok {
 		return w, nil
 	}
-	w, err := NewFile(filename, d.format, d.tc)
+	w, err := NewFile(filename, d.format, d.flags)
 	if err != nil {
 		return nil, err
 	}

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mccanne/zq/pkg/bufwriter"
 	"github.com/mccanne/zq/pkg/zsio"
-	"github.com/mccanne/zq/pkg/zsio/text"
+	"github.com/mccanne/zq/pkg/zsio/detector"
 )
 
 type noClose struct {
@@ -17,7 +17,7 @@ func (p *noClose) Close() error {
 	return nil
 }
 
-func NewFile(path, format string, tc *text.Config) (*zsio.Writer, error) {
+func NewFile(path, format string, flags *zsio.Flags) (*zsio.Writer, error) {
 	var f io.WriteCloser
 	if path == "" {
 		// Don't close stdout in case we live inside something
@@ -35,7 +35,7 @@ func NewFile(path, format string, tc *text.Config) (*zsio.Writer, error) {
 	// On close, zsio.Writer.Close(), the zson WriteFlusher will be flushed
 	// then the bufwriter will closed (which will flush it's internal buffer
 	// then close the file)
-	w := zsio.LookupWriter(format, bufwriter.New(f), tc)
+	w := detector.LookupWriter(format, bufwriter.New(f), flags)
 	if w == nil {
 		return nil, unknownFormat(format)
 	}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/mccanne/zq/ast"
 	"github.com/mccanne/zq/filter"
-	"github.com/mccanne/zq/pkg/zsio"
+	"github.com/mccanne/zq/pkg/zsio/detector"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zson/resolver"
 	"github.com/mccanne/zq/zql"
@@ -83,7 +83,7 @@ func TestFilters(t *testing.T) {
 	t.Parallel()
 
 	ior := strings.NewReader(zsonsrc)
-	reader := zsio.LookupReader("zson", ior, resolver.NewTable())
+	reader := detector.LookupReader("zson", ior, resolver.NewTable())
 
 	nrecords := 11
 	records := make([]*zson.Record, 0, nrecords)

--- a/pkg/zeek/escape_test.go
+++ b/pkg/zeek/escape_test.go
@@ -38,3 +38,37 @@ func TestEscapeAndUnescape(t *testing.T) {
 		require.Exactly(t, []byte(expected), actual, "case: %#v", c)
 	}
 }
+
+func TestUnescapeUTF(t *testing.T) {
+	cases := []struct {
+		unescaped string
+		escaped   string
+	}{
+		{`\`, `\\`},
+		{`\\`, `\\\\`},
+		{`ascii`, `ascii`},
+		{"\a\b\f\n\r\t\v", `\x07\x08\x0c\x0a\x0d\x09\x0b`},
+		{"\x00\x19\x20\\\x7e\x7f\xff", "\\x00\\x19\x20\\\\\x7e\\x7f\\xff"},
+		{"\x00😁", `\x00\xf0\x9f\x98\x81`},
+	}
+	for _, c := range cases {
+		in, expected := c.unescaped, c.escaped
+
+		actual := Escape([]byte(in))
+		require.Exactly(t, expected, actual, "case: %#v", c)
+
+		actual = Escape([]byte("prefix" + in + "suffix"))
+		expected = "prefix" + expected + "suffix"
+		require.Exactly(t, expected, actual, "case: %#v", c)
+	}
+	for _, c := range cases {
+		in, expected := c.escaped, c.unescaped
+
+		actual := Unescape([]byte(in))
+		require.Exactly(t, []byte(expected), actual, "case: %#v", c)
+
+		actual = Unescape([]byte("prefix" + in + "suffix"))
+		expected = "prefix" + expected + "suffix"
+		require.Exactly(t, []byte(expected), actual, "case: %#v", c)
+	}
+}

--- a/pkg/zsio/detector/lookup.go
+++ b/pkg/zsio/detector/lookup.go
@@ -1,0 +1,60 @@
+package detector
+
+import (
+	"io"
+
+	"github.com/mccanne/zq/pkg/zsio"
+	"github.com/mccanne/zq/pkg/zsio/bzson"
+	"github.com/mccanne/zq/pkg/zsio/ndjson"
+	"github.com/mccanne/zq/pkg/zsio/table"
+	"github.com/mccanne/zq/pkg/zsio/text"
+	"github.com/mccanne/zq/pkg/zsio/zeek"
+	"github.com/mccanne/zq/pkg/zsio/zjson"
+	zsonio "github.com/mccanne/zq/pkg/zsio/zson"
+	"github.com/mccanne/zq/pkg/zson"
+	"github.com/mccanne/zq/pkg/zson/resolver"
+)
+
+func LookupWriter(format string, w io.WriteCloser, optionalFlags *zsio.Flags) *zsio.Writer {
+	var flags zsio.Flags
+	if optionalFlags != nil {
+		flags = *optionalFlags
+	}
+	var f zson.WriteFlusher
+	switch format {
+	default:
+		return nil
+	case "zson":
+		f = zson.NopFlusher(zsonio.NewWriter(w))
+	case "bzson":
+		f = zson.NopFlusher(bzson.NewWriter(w))
+	case "zeek":
+		f = zson.NopFlusher(zeek.NewWriter(w, flags))
+	case "ndjson":
+		f = zson.NopFlusher(ndjson.NewWriter(w))
+	case "zjson":
+		f = zson.NopFlusher(zjson.NewWriter(w))
+	case "text":
+		f = zson.NopFlusher(text.NewWriter(w, flags))
+	case "table":
+		f = table.NewWriter(w, flags)
+	}
+	return &zsio.Writer{
+		WriteFlusher: f,
+		Closer:       w,
+	}
+}
+
+func LookupReader(format string, r io.Reader, table *resolver.Table) zson.Reader {
+	switch format {
+	case "zson", "zeek":
+		return zsonio.NewReader(r, table)
+	case "ndjson":
+		return ndjson.NewReader(r, table)
+	case "zjson":
+		return zjson.NewReader(r, table)
+	case "bzson":
+		return bzson.NewReader(r, table)
+	}
+	return nil
+}

--- a/pkg/zsio/table/writer.go
+++ b/pkg/zsio/table/writer.go
@@ -64,7 +64,7 @@ func (t *Table) Write(r *zson.Record) error {
 		t.nline = 0
 	}
 	//XXX only works for zeek-oriented records right now (won't work for NDJSON nested records)
-	ss, changePrecision, err := r.ZeekStrings(t.precision, t.Utf8)
+	ss, changePrecision, err := r.ZeekStrings(t.precision, t.UTF8)
 	if err != nil {
 		return err
 	}

--- a/pkg/zsio/table/writer.go
+++ b/pkg/zsio/table/writer.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/mccanne/zq/pkg/zsio"
 	"github.com/mccanne/zq/pkg/zsio/zeek"
 	"github.com/mccanne/zq/pkg/zson"
 )
@@ -18,9 +19,10 @@ type Table struct {
 	limit      int
 	nline      int
 	precision  int
+	zsio.Flags
 }
 
-func NewWriter(w io.Writer) *Table {
+func NewWriter(w io.Writer, flags zsio.Flags) *Table {
 	writer := tabwriter.NewWriter(w, 0, 8, 1, ' ', 0)
 	return &Table{
 		Writer:    w,
@@ -28,6 +30,7 @@ func NewWriter(w io.Writer) *Table {
 		table:     writer,
 		limit:     1000,
 		precision: 6,
+		Flags:     flags,
 	}
 }
 
@@ -61,7 +64,7 @@ func (t *Table) Write(r *zson.Record) error {
 		t.nline = 0
 	}
 	//XXX only works for zeek-oriented records right now (won't work for NDJSON nested records)
-	ss, changePrecision, err := r.ZeekStrings(t.precision)
+	ss, changePrecision, err := r.ZeekStrings(t.precision, t.Utf8)
 	if err != nil {
 		return err
 	}

--- a/pkg/zsio/text/writer.go
+++ b/pkg/zsio/text/writer.go
@@ -44,7 +44,7 @@ func (t *Text) Write(rec *zson.Record) error {
 			} else {
 				body := rec.Slice(k)
 				typ := col.Type
-				v = zson.ZvalToZeekString(typ, body, zeek.IsContainerType(typ), t.Utf8)
+				v = zson.ZvalToZeekString(typ, body, zeek.IsContainerType(typ), t.UTF8)
 			}
 			if t.ShowFields {
 				s = col.Name + ":"
@@ -57,7 +57,7 @@ func (t *Text) Write(rec *zson.Record) error {
 	} else {
 		var err error
 		var changePrecision bool
-		out, changePrecision, err = rec.ZeekStrings(t.precision, t.Utf8)
+		out, changePrecision, err = rec.ZeekStrings(t.precision, t.UTF8)
 		if err != nil {
 			return err
 		}

--- a/pkg/zsio/zeek/writer.go
+++ b/pkg/zsio/zeek/writer.go
@@ -40,7 +40,7 @@ func (w *Writer) Write(r *zson.Record) error {
 		w.writeHeader(r, path)
 		w.descriptor = r.Descriptor
 	}
-	values, changePrecision, err := r.ZeekStrings(w.precision, w.Utf8)
+	values, changePrecision, err := r.ZeekStrings(w.precision, w.UTF8)
 	if err != nil {
 		return err
 	}

--- a/pkg/zsio/zeek/writer.go
+++ b/pkg/zsio/zeek/writer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/mccanne/zq/pkg/zsio"
 	"github.com/mccanne/zq/pkg/zson"
 )
 
@@ -17,13 +18,15 @@ type Writer struct {
 	flattener  *Flattener
 	descriptor *zson.Descriptor
 	precision  int
+	zsio.Flags
 }
 
-func NewWriter(w io.Writer) *Writer {
+func NewWriter(w io.Writer, flags zsio.Flags) *Writer {
 	return &Writer{
 		Writer:    w,
 		flattener: NewFlattener(),
 		precision: 6,
+		Flags:     flags,
 	}
 }
 
@@ -37,7 +40,7 @@ func (w *Writer) Write(r *zson.Record) error {
 		w.writeHeader(r, path)
 		w.descriptor = r.Descriptor
 	}
-	values, changePrecision, err := r.ZeekStrings(w.precision)
+	values, changePrecision, err := r.ZeekStrings(w.precision, w.Utf8)
 	if err != nil {
 		return err
 	}

--- a/pkg/zsio/zsio.go
+++ b/pkg/zsio/zsio.go
@@ -3,16 +3,15 @@ package zsio
 import (
 	"io"
 
-	"github.com/mccanne/zq/pkg/zsio/bzson"
-	"github.com/mccanne/zq/pkg/zsio/ndjson"
-	"github.com/mccanne/zq/pkg/zsio/table"
-	"github.com/mccanne/zq/pkg/zsio/text"
-	"github.com/mccanne/zq/pkg/zsio/zeek"
-	"github.com/mccanne/zq/pkg/zsio/zjson"
-	zsonio "github.com/mccanne/zq/pkg/zsio/zson"
 	"github.com/mccanne/zq/pkg/zson"
-	"github.com/mccanne/zq/pkg/zson/resolver"
 )
+
+type Flags struct {
+	Utf8       bool
+	ShowTypes  bool
+	ShowFields bool
+	EpochDates bool
+}
 
 type Writer struct {
 	zson.WriteFlusher
@@ -33,46 +32,6 @@ func (w *Writer) Close() error {
 		err = cerr
 	}
 	return err
-}
-
-func LookupWriter(format string, w io.WriteCloser, tc *text.Config) *Writer {
-	var f zson.WriteFlusher
-	switch format {
-	default:
-		return nil
-	case "zson":
-		f = zson.NopFlusher(zsonio.NewWriter(w))
-	case "bzson":
-		f = zson.NopFlusher(bzson.NewWriter(w))
-	case "zeek":
-		f = zson.NopFlusher(zeek.NewWriter(w))
-	case "ndjson":
-		f = zson.NopFlusher(ndjson.NewWriter(w))
-	case "zjson":
-		f = zson.NopFlusher(zjson.NewWriter(w))
-	case "text":
-		f = zson.NopFlusher(text.NewWriter(w, tc))
-	case "table":
-		f = table.NewWriter(w)
-	}
-	return &Writer{
-		WriteFlusher: f,
-		Closer:       w,
-	}
-}
-
-func LookupReader(format string, r io.Reader, table *resolver.Table) zson.Reader {
-	switch format {
-	case "zson", "zeek":
-		return zsonio.NewReader(r, table)
-	case "ndjson":
-		return ndjson.NewReader(r, table)
-	case "zjson":
-		return zjson.NewReader(r, table)
-	case "bzson":
-		return bzson.NewReader(r, table)
-	}
-	return nil
 }
 
 func Extension(format string) string {

--- a/pkg/zsio/zsio.go
+++ b/pkg/zsio/zsio.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Flags struct {
-	Utf8       bool
+	UTF8       bool
 	ShowTypes  bool
 	ShowFields bool
 	EpochDates bool

--- a/pkg/zsio/zsio_test.go
+++ b/pkg/zsio/zsio_test.go
@@ -1,4 +1,4 @@
-package zsio
+package zsio_test
 
 import (
 	"net"

--- a/pkg/zsio/zson_test.go
+++ b/pkg/zsio/zson_test.go
@@ -1,4 +1,4 @@
-package zsio
+package zsio_test
 
 //  This is really a system test dressed up as a unit test.
 

--- a/pkg/zson/record.go
+++ b/pkg/zson/record.go
@@ -168,7 +168,7 @@ func isHighPrecision(ns int64) bool {
 // This returns the zeek strings for this record.  It works only for records
 // that can be represented as legacy zeek values.  XXX We need to not use this.
 // XXX change to Pretty for output writers?... except zeek?
-func (r *Record) ZeekStrings(precision int) ([]string, bool, error) {
+func (r *Record) ZeekStrings(precision int, utf8 bool) ([]string, bool, error) {
 	var ss []string
 	it := r.ZvalIter()
 	var changePrecision bool
@@ -194,7 +194,7 @@ func (r *Record) ZeekStrings(precision int) ([]string, bool, error) {
 				field = fmt.Sprintf("%d.%09d", sec, ns)
 			}
 		} else {
-			field = ZvalToZeekString(col.Type, val, isContainer)
+			field = ZvalToZeekString(col.Type, val, isContainer, utf8)
 		}
 		ss = append(ss, field)
 	}

--- a/pkg/zson/zval.go
+++ b/pkg/zson/zval.go
@@ -45,9 +45,17 @@ func appendZvalFromZeek(dst zval.Encoding, typ zeek.Type, val []byte) zval.Encod
 	}
 }
 
+func escape(s string, utf8 bool) string {
+	if utf8 {
+		return zeek.EscapeUtf8([]byte(s))
+	} else {
+		return zeek.Escape([]byte(s))
+	}
+}
+
 // ZvalToZeekString returns a Zeek ASCII string representing the zval described
 // by typ and val.
-func ZvalToZeekString(typ zeek.Type, zv zval.Encoding, isContainer bool) string {
+func ZvalToZeekString(typ zeek.Type, zv zval.Encoding, isContainer bool, utf8 bool) string {
 	if zv == nil {
 		return "-"
 	}
@@ -70,7 +78,7 @@ func ZvalToZeekString(typ zeek.Type, zv zval.Encoding, isContainer bool) string 
 			if err != nil {
 				return "error in ZvalToZeekString"
 			}
-			fld := zeek.Escape([]byte(val.String()))
+			fld := escape(val.String(), utf8)
 			// Escape the set separator after ZeekEscape.
 			_, _ = b.WriteString(strings.ReplaceAll(fld, ",", "\\x2c"))
 			if it.Done() {
@@ -84,7 +92,7 @@ func ZvalToZeekString(typ zeek.Type, zv zval.Encoding, isContainer bool) string 
 		if err != nil {
 			return "error in ZvalToZeekString"
 		}
-		s = zeek.Escape([]byte(val.String()))
+		s = escape(val.String(), utf8)
 	}
 	if s == "-" {
 		return "\\x2d"

--- a/pkg/zson/zval.go
+++ b/pkg/zson/zval.go
@@ -47,7 +47,7 @@ func appendZvalFromZeek(dst zval.Encoding, typ zeek.Type, val []byte) zval.Encod
 
 func escape(s string, utf8 bool) string {
 	if utf8 {
-		return zeek.EscapeUtf8([]byte(s))
+		return zeek.EscapeUTF8([]byte(s))
 	} else {
 		return zeek.Escape([]byte(s))
 	}

--- a/pkg/zson/zval.go
+++ b/pkg/zson/zval.go
@@ -48,9 +48,8 @@ func appendZvalFromZeek(dst zval.Encoding, typ zeek.Type, val []byte) zval.Encod
 func escape(s string, utf8 bool) string {
 	if utf8 {
 		return zeek.EscapeUTF8([]byte(s))
-	} else {
-		return zeek.Escape([]byte(s))
 	}
+	return zeek.Escape([]byte(s))
 }
 
 // ZvalToZeekString returns a Zeek ASCII string representing the zval described

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/mccanne/zq/ast"
 	"github.com/mccanne/zq/pkg/nano"
-	"github.com/mccanne/zq/pkg/zsio"
+	"github.com/mccanne/zq/pkg/zsio/detector"
 	"github.com/mccanne/zq/pkg/zson"
 	"github.com/mccanne/zq/pkg/zson/resolver"
 	"github.com/mccanne/zq/zql"
@@ -197,7 +197,7 @@ func (t *ProcTest) Finish() error {
 }
 
 func parse(resolver *resolver.Table, src string) (*zson.Array, error) {
-	reader := zsio.LookupReader("zson", strings.NewReader(src), resolver)
+	reader := detector.LookupReader("zson", strings.NewReader(src), resolver)
 	records := make([]*zson.Record, 0)
 	for {
 		rec, err := reader.Read()

--- a/tests/suite.go
+++ b/tests/suite.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mccanne/zq/tests/suite/format"
 	"github.com/mccanne/zq/tests/suite/input"
 	"github.com/mccanne/zq/tests/suite/sort"
+	"github.com/mccanne/zq/tests/suite/utf8"
 )
 
 var RootDir = "./test-root"
@@ -24,6 +25,7 @@ var internals = []test.Internal{
 
 var commands = []test.Exec{
 	cut.Exec,
+	utf8.Exec,
 }
 
 var scripts = []test.Shell{

--- a/tests/suite/utf8/test.go
+++ b/tests/suite/utf8/test.go
@@ -1,0 +1,33 @@
+package utf8
+
+import (
+	"github.com/mccanne/zq/pkg/test"
+)
+
+var Exec = test.Exec{
+	Name:     "utf8",
+	Command:  `zq -f zeek -U -`,
+	Input:    test.Trim(in1),
+	Expected: test.Trim(out1),
+}
+
+const in1 = `
+#0:record[_path:string,foo:string]
+0:[;\xf0\x9f\x98\x81;]
+0:[magic;\xf0\x9f\x98\x81;]
+0:[;foo\xf0\x9f\x98\x81bar\x00\x01baz;]
+`
+
+const out1 = `
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#fields	foo
+#types	string
+😁
+#path	magic
+😁
+#path	-
+foo😁bar\x00\x01baz
+`


### PR DESCRIPTION
This commit adds the -U flag for printing zeek string in a "forced"
UTF-8 format.  It is applicable to formats zeek, text, and table.

This is the very same non-standard formatting of mixed-binary strings
that zeek does.  There is no way to disambiguate between random binary data
and a deliberate utf-8 string so it's left to the "presenation layer" to decide
how to format the data.  This would be remedied if a zeek string were a UTF-8
string and zeek had a bytes type to represent non-string data.

For now, we have -U.