### PR TITLE
ZNG-ify READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `zq` [![CI][ci-img]][ci] [![GoDoc][doc-img]][doc]
 
-`zq` is a command-line tool for processing
-[Zeek](https://www.zeek.org) logs.  If you are familiar with
+`zq` is a command-line tool that's useful for searching and analyzing logs;
+particularly [Zeek](https://www.zeek.org) logs.  If you are familiar with
 [`zeek-cut`](https://github.com/zeek/zeek-aux/tree/master/zeek-cut),
 you can think of `zq` as `zeek-cut` on steroids.  (If you missed
 [the name change](https://blog.zeek.org/2018/10/renaming-bro-project_11.html),
@@ -11,9 +11,10 @@ Zeek was formerly known as "Bro".)
 * an [execution engine](proc) for log pattern search and analytics,
 * a [query language](pkg/zql/README.md) that compiles into a program that runs on
 the execution engine, and
-* an open specification for structured logs, called [ZSON](pkg/zson/docs/spec.md).
+* an open specification for structured logs, called [ZNG](pkg/zson/docs/spec.md).<br>
+(**Note**: The ZNG format is in Alpha and subject to change.)
 
-`zq` takes Zeek/ZSON logs as input and filters, transforms, and performs
+`zq` takes Zeek/ZNG logs as input and filters, transforms, and performs
 analytics using the
 [zq query language](pkg/zql/README.md),
 producing a log stream as its output.
@@ -51,7 +52,7 @@ zq "* | cut ts,id.orig_h,id.orig_p" conn.log
 The "`*`" tells `zq` to match every line, which is sent to the `cut` processor
 using the UNIX-like pipe syntax.
 
-The default output is a ZSON file.  If you want just the tab-separated lines
+The default output is a ZNG file.  If you want just the tab-separated lines
 like `zeek-cut`, you can specify text output:
 ```
 zq -f text "* | cut ts,id.orig_h,id.orig_p" conn.log
@@ -70,11 +71,11 @@ zq "orig_bytes > 10000 | count()" conn.log
 zq "* | avg(orig_bytes)" conn.log
 ```
 
-The [ZSON specification](pkg/zson/docs/spec.md) describes the significance of the
+The [ZNG specification](pkg/zson/docs/spec.md) describes the significance of the
 `_path` field.  By leveraging this, diverse Zeek logs can be combined into a single
 file.
 ```
-zq "*" *.log > all.zson
+zq "*" *.log > all.zng
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Zeek was formerly known as "Bro".)
 * an [execution engine](proc) for log pattern search and analytics,
 * a [query language](pkg/zql/README.md) that compiles into a program that runs on
 the execution engine, and
-* an open specification for structured logs, called [ZNG](pkg/zson/docs/spec.md).<br>
+* an open specification for structured logs, called [ZNG](pkg/zng/docs/spec.md).<br>
 (**Note**: The ZNG format is in Alpha and subject to change.)
 
 `zq` takes Zeek/ZNG logs as input and filters, transforms, and performs
@@ -71,7 +71,7 @@ zq "orig_bytes > 10000 | count()" conn.log
 zq "* | avg(orig_bytes)" conn.log
 ```
 
-The [ZNG specification](pkg/zson/docs/spec.md) describes the significance of the
+The [ZNG specification](pkg/zng/docs/spec.md) describes the significance of the
 `_path` field.  By leveraging this, diverse Zeek logs can be combined into a single
 file.
 ```

--- a/pkg/zql/README.md
+++ b/pkg/zql/README.md
@@ -1,6 +1,6 @@
 # `zq` log query language (ZQL)
 
-ZQL is a powerful query language for searching and analyzing event data. It is in many ways optimal for working with [Zeek](https://www.zeek.org/) data, though it can be used to query any data in in [ZSON](../zson/docs/spec.md) or [NDJSON](http://ndjson.org/) format.
+ZQL is a powerful query language for searching and analyzing event data. It is in many ways optimal for working with [Zeek](https://www.zeek.org/) data, though it can be used to query any data in in [ZNG](../zson/docs/spec.md) or [NDJSON](http://ndjson.org/) format.
 
 The language embraces a syntax that should be familiar to those who have worked with UNIX/Linux shells. At a high level, each query consists of a _[search](search-syntax/README.md)_ portion and an optional _pipeline_. Here's a simple example query:
 

--- a/pkg/zql/README.md
+++ b/pkg/zql/README.md
@@ -1,6 +1,6 @@
 # `zq` log query language (ZQL)
 
-ZQL is a powerful query language for searching and analyzing event data. It is in many ways optimal for working with [Zeek](https://www.zeek.org/) data, though it can be used to query any data in in [ZNG](../zson/docs/spec.md) or [NDJSON](http://ndjson.org/) format.
+ZQL is a powerful query language for searching and analyzing event data. It is in many ways optimal for working with [Zeek](https://www.zeek.org/) data, though it can be used to query any data in in [ZNG](../zng/docs/spec.md) or [NDJSON](http://ndjson.org/) format.
 
 The language embraces a syntax that should be familiar to those who have worked with UNIX/Linux shells. At a high level, each query consists of a _[search](search-syntax/README.md)_ portion and an optional _pipeline_. Here's a simple example query:
 

--- a/pkg/zql/search-syntax/README.md
+++ b/pkg/zql/search-syntax/README.md
@@ -20,7 +20,7 @@
 
 ## Search all events
 
-The simplest possible ZQL search is a match against all events. This search is expressed in `zq` with the wildcard `*`. The response will be a ZSON-formatted dump of all events.
+The simplest possible ZQL search is a match against all events. This search is expressed in `zq` with the wildcard `*`. The response will be a ZNG-formatted dump of all events.
 
 #### Example:
 ```


### PR DESCRIPTION
In prep for pointing more members of the public at the repo, I've updated the top-level README and the markdown docs to say "ZNG" where we used to say "ZSON". I've not attempted to touch the actual [ZNG spec](https://github.com/mccanne/zq/blob/master/pkg/zng/docs/spec.md) since @mccanne is working on a larger refactor of that.

Since I was proofreading, I snuck in one other small change: The opening line of the top-level README used to imply `zq` was only for Zeek logs, and also used the generic term "processing". While I certainly don't want to jump to implying `zq` is all things to all people, I tweaked the wording to imply it has a potentially wider scope than Zeek, and also emphasized that its strengths are in search & analytics.