### PR TITLE
Fix gzip detection

### DIFF
--- a/pkg/zio/detector/gzip.go
+++ b/pkg/zio/detector/gzip.go
@@ -8,8 +8,10 @@ import (
 func GzipReader(r io.Reader) io.Reader {
 	recorder := NewRecorder(r)
 	track := NewTrack(recorder)
-	r, err := gzip.NewReader(track)
+	_, err := gzip.NewReader(track)
 	if err == nil {
+		// create a new reader from recorder (track keeps a copy of read data)
+		r, _ := gzip.NewReader(recorder)
 		return r
 	}
 	return recorder


### PR DESCRIPTION
Upon detecting gzip, we were returning a gzip reader that read from the `Track()` which keeps a copy of read data. Fix that by returning a gzip reader from the recorder, following the pattern of the input format detector in `detector/reader.go`. 