### PR TITLE
Add a simple ZNG README and point to it from elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Zeek was formerly known as "Bro".)
 * an [execution engine](proc) for log pattern search and analytics,
 * a [query language](pkg/zql/README.md) that compiles into a program that runs on
 the execution engine, and
-* an open specification for structured logs, called [ZNG](pkg/zng/docs/spec.md).<br>
+* an open specification for structured logs, called [ZNG](pkg/zng/docs/README.md).<br>
 (**Note**: The ZNG format is in Alpha and subject to change.)
 
 `zq` takes Zeek/ZNG logs as input and filters, transforms, and performs

--- a/pkg/zng/docs/README.md
+++ b/pkg/zng/docs/README.md
@@ -1,0 +1,6 @@
+# ZNG Documentation
+
+* [ZNG specification](spec.md)
+* [ZNG compatibility with Zeek logs](zeek-compat.md)
+* [ZNG over HTTP](zng-over-http.md)
+* [ZNG over JSON](zng-over-json.md)

--- a/pkg/zql/README.md
+++ b/pkg/zql/README.md
@@ -1,6 +1,6 @@
 # `zq` log query language (ZQL)
 
-ZQL is a powerful query language for searching and analyzing event data. It is in many ways optimal for working with [Zeek](https://www.zeek.org/) data, though it can be used to query any data in in [ZNG](../zng/docs/spec.md) or [NDJSON](http://ndjson.org/) format.
+ZQL is a powerful query language for searching and analyzing event data. It is in many ways optimal for working with [Zeek](https://www.zeek.org/) data, though it can be used to query any data in in [ZNG](../zng/docs/README.md) or [NDJSON](http://ndjson.org/) format.
 
 The language embraces a syntax that should be familiar to those who have worked with UNIX/Linux shells. At a high level, each query consists of a _[search](search-syntax/README.md)_ portion and an optional _pipeline_. Here's a simple example query:
 


### PR DESCRIPTION
At one time I'd thought the ZNG `spec.md` should be a README so that way GitHub would render it automatically when people browsed to that directory. However since we've already got more materials besides the spec and will likely add more, @mccanne made the better suggestion that we just have a top-level README that points off to the other materials. I've added a simple one here, and have started pointing to it from other locations that previously pointed only to the spec.