### PR TITLE
Return proper scalar/container type error during parsing

### DIFF
--- a/pkg/zio/zjsonio/reader.go
+++ b/pkg/zio/zjsonio/reader.go
@@ -176,7 +176,7 @@ func decodeType(columns []interface{}) (string, error) {
 func decodeContainer(builder *zval.Builder, typ zeek.Type, body []interface{}) error {
 	childType, columns := zeek.ContainedType(typ)
 	if childType == nil && columns == nil {
-		return zng.ErrSyntax
+		return zng.ErrNotScalar
 	}
 	builder.BeginContainer()
 	for k, column := range body {
@@ -199,7 +199,7 @@ func decodeContainer(builder *zval.Builder, typ zeek.Type, body []interface{}) e
 		s, ok := column.(string)
 		if ok {
 			if zeek.IsContainerType(childType) {
-				return zng.ErrSyntax
+				return zng.ErrNotContainer
 			}
 			zv, err := childType.Parse(zeek.Unescape([]byte(s)))
 			if err != nil {

--- a/pkg/zng/raw.go
+++ b/pkg/zng/raw.go
@@ -210,7 +210,7 @@ func zngParseContainer(builder *zval.Builder, typ zeek.Type, b []byte) ([]byte, 
 	b = b[1:]
 	childType, columns := zeek.ContainedType(typ)
 	if childType == nil && columns == nil {
-		return nil, ErrSyntax
+		return nil, ErrNotScalar
 	}
 	k := 0
 	for {
@@ -259,7 +259,7 @@ func zngParseField(builder *zval.Builder, typ zeek.Type, b []byte) ([]byte, erro
 		switch b[from] {
 		case semicolon:
 			if zeek.IsContainerType(typ) {
-				return nil, ErrSyntax
+				return nil, ErrNotContainer
 			}
 			zv, err := typ.Parse(zeek.Unescape(b[:to]))
 			if err != nil {

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -118,11 +118,11 @@ func (s *suite) add(t test.Internal) {
 func New(name, input, output, cmd string) test.Internal {
 	output = strings.ReplaceAll(output, "\n\n", "\n")
 	return test.Internal{
-		Name:     name,
-		Query:    "* | " + cmd,
-		Input:    input,
-		Format:   "zng",
-		Expected: test.Trim(output),
+		Name:         name,
+		Query:        "* | " + cmd,
+		Input:        input,
+		OutputFormat: "zng",
+		Expected:     test.Trim(output),
 	}
 }
 

--- a/tests/suite.go
+++ b/tests/suite.go
@@ -5,6 +5,7 @@ import (
 	"github.com/mccanne/zq/tests/suite/count"
 	"github.com/mccanne/zq/tests/suite/cut"
 	"github.com/mccanne/zq/tests/suite/diropt"
+	"github.com/mccanne/zq/tests/suite/errors"
 	"github.com/mccanne/zq/tests/suite/format"
 	"github.com/mccanne/zq/tests/suite/input"
 	"github.com/mccanne/zq/tests/suite/sort"
@@ -18,7 +19,13 @@ var internals = []test.Internal{
 	cut.Internal,
 	format.Internal,
 	input.Internal,
-	input.DuplicateFields,
+	errors.DuplicateFields,
+	errors.ErrNotScalar,
+	errors.ErrNotScalarZJSON,
+	errors.ErrNotContainer,
+	errors.ErrNotContainerZJSON,
+	errors.ErrMissingField,
+	errors.ErrExtraField,
 	sort.Internal1,
 	sort.Internal2,
 	sort.Internal3,

--- a/tests/suite/count/test.go
+++ b/tests/suite/count/test.go
@@ -5,11 +5,11 @@ import (
 )
 
 var Internal = test.Internal{
-	Name:     "count",
-	Query:    "* | count()",
-	Input:    test.Trim(input),
-	Format:   "table",
-	Expected: test.Trim(expected),
+	Name:         "count",
+	Query:        "* | count()",
+	Input:        test.Trim(input),
+	OutputFormat: "table",
+	Expected:     test.Trim(expected),
 }
 
 const input = `

--- a/tests/suite/cut/test.go
+++ b/tests/suite/cut/test.go
@@ -5,11 +5,11 @@ import (
 )
 
 var Internal = test.Internal{
-	Name:     "cut",
-	Query:    "* | cut foo",
-	Input:    test.Trim(input),
-	Format:   "table",
-	Expected: test.Trim(expected),
+	Name:         "cut",
+	Query:        "* | cut foo",
+	Input:        test.Trim(input),
+	OutputFormat: "table",
+	Expected:     test.Trim(expected),
 }
 
 var Exec = test.Exec{

--- a/tests/suite/errors/dupfields.go
+++ b/tests/suite/errors/dupfields.go
@@ -1,0 +1,21 @@
+package errors
+
+import (
+	"github.com/mccanne/zq/pkg/test"
+	"github.com/mccanne/zq/pkg/zeek"
+)
+
+const inputDuplicateFields = `
+#0:record[foo:record[foo:string,bar:string]]
+0:[["1";"2";]]
+#1:record[foo:record[foo:string,foo:string]]
+1:[["1";"2";]]
+`
+
+var DuplicateFields = test.Internal{
+	Name:         "duplicatefields",
+	Query:        "*",
+	Input:        test.Trim(inputDuplicateFields),
+	OutputFormat: "zng",
+	ExpectedErr:  zeek.ErrDuplicateFields,
+}

--- a/tests/suite/errors/records.go
+++ b/tests/suite/errors/records.go
@@ -1,0 +1,82 @@
+package errors
+
+import (
+	"github.com/mccanne/zq/pkg/test"
+	"github.com/mccanne/zq/pkg/zng"
+)
+
+const inputErrNotScalar = `
+#0:record[a:string]
+0:[[1;]]
+`
+
+// Container/scalar type checks are done while parsing, so
+// ErrNotScalar and ErrNotContainer get dual zng and zjson tests. The
+// other type checks are done after parsing and dont the dual tests.
+
+var ErrNotScalar = test.Internal{
+	Name:        "container where scalar expected",
+	Query:       "*",
+	Input:       test.Trim(inputErrNotScalar),
+	InputFormat: "zng",
+	ExpectedErr: zng.ErrNotScalar,
+}
+
+const inputErrNotScalarZJSON = `{"id":0,"type":[{"name":"a","type":"string"}],"values":[["1"]]}`
+
+var ErrNotScalarZJSON = test.Internal{
+	Name:        "container where scalar expected (zjson)",
+	Query:       "*",
+	Input:       test.Trim(inputErrNotScalarZJSON),
+	InputFormat: "zjson",
+	ExpectedErr: zng.ErrNotScalar,
+}
+
+const inputErrNotContainer = `
+#0:record[a:record[b:string]]
+0:[1;]
+`
+
+var ErrNotContainer = test.Internal{
+	Name:        "scalar where container expected",
+	Query:       "*",
+	Input:       test.Trim(inputErrNotContainer),
+	InputFormat: "zng",
+	ExpectedErr: zng.ErrNotContainer,
+}
+
+const inputErrNotContainerZJSON = `{"id":0,"type":[{"name":"a","type":[{"name":"b","type":"string"}]}],"values":["1"]}`
+
+var ErrNotContainerZJSON = test.Internal{
+	Name:        "scalar where container expected (zjson)",
+	Query:       "*",
+	Input:       test.Trim(inputErrNotContainerZJSON),
+	InputFormat: "zjson",
+	ExpectedErr: zng.ErrNotContainer,
+}
+
+const inputErrExtraField = `
+#0:record[a:string]
+0:[1;2;]
+`
+
+var ErrExtraField = test.Internal{
+	Name:        "extra field",
+	Query:       "*",
+	Input:       test.Trim(inputErrExtraField),
+	InputFormat: "zng",
+	ExpectedErr: zng.ErrExtraField,
+}
+
+const inputErrMissingField = `
+#0:record[a:string,b:string]
+0:[1;]
+`
+
+var ErrMissingField = test.Internal{
+	Name:        "missing field",
+	Query:       "*",
+	Input:       test.Trim(inputErrMissingField),
+	InputFormat: "zng",
+	ExpectedErr: zng.ErrMissingField,
+}

--- a/tests/suite/format/test.go
+++ b/tests/suite/format/test.go
@@ -5,11 +5,11 @@ import (
 )
 
 var Internal = test.Internal{
-	Name:     "format",
-	Query:    "*",
-	Input:    test.Trim(input),
-	Format:   "ndjson",
-	Expected: test.Trim(expected),
+	Name:         "format",
+	Query:        "*",
+	Input:        test.Trim(input),
+	OutputFormat: "ndjson",
+	Expected:     test.Trim(expected),
 }
 
 const input = `

--- a/tests/suite/input/test.go
+++ b/tests/suite/input/test.go
@@ -6,11 +6,11 @@ import (
 )
 
 var Internal = test.Internal{
-	Name:     "input",
-	Query:    "*",
-	Input:    test.Trim(input),
-	Format:   "zng",
-	Expected: test.Trim(expected),
+	Name:         "input",
+	Query:        "*",
+	Input:        test.Trim(input),
+	OutputFormat: "zng",
+	Expected:     test.Trim(expected),
 }
 
 const input = `

--- a/tests/suite/input/test.go
+++ b/tests/suite/input/test.go
@@ -2,7 +2,6 @@ package input
 
 import (
 	"github.com/mccanne/zq/pkg/test"
-	"github.com/mccanne/zq/pkg/zeek"
 )
 
 var Internal = test.Internal{
@@ -26,18 +25,3 @@ const expected = `
 0:[T;4;value2;value2;]
 #1:record[obj1:record[null1:string]]
 1:[[-;]]`
-
-const inputDuplicateFields = `
-#0:record[foo:record[foo:string,bar:string]]
-0:[["1";"2";]]
-#1:record[foo:record[foo:string,foo:string]]
-1:[["1";"2";]]
-`
-
-var DuplicateFields = test.Internal{
-	Name:        "duplicatefields",
-	Query:       "*",
-	Input:       test.Trim(inputDuplicateFields),
-	Format:      "zng",
-	ExpectedErr: zeek.ErrDuplicateFields,
-}

--- a/tests/suite/sort/test.go
+++ b/tests/suite/sort/test.go
@@ -5,11 +5,11 @@ import (
 )
 
 var Internal1 = test.Internal{
-	Name:     "sort1",
-	Query:    "* | sort x",
-	Input:    test.Trim(in1),
-	Format:   "zng",
-	Expected: test.Trim(out1),
+	Name:         "sort1",
+	Query:        "* | sort x",
+	Input:        test.Trim(in1),
+	OutputFormat: "zng",
+	Expected:     test.Trim(out1),
 }
 
 const in1 = `
@@ -25,11 +25,11 @@ const out1 = `
 `
 
 var Internal2 = test.Internal{
-	Name:     "sort2",
-	Query:    "* | sort x",
-	Input:    test.Trim(in2),
-	Format:   "zng",
-	Expected: test.Trim(out2),
+	Name:         "sort2",
+	Query:        "* | sort x",
+	Input:        test.Trim(in2),
+	OutputFormat: "zng",
+	Expected:     test.Trim(out2),
 }
 
 const in2 = `
@@ -105,9 +105,9 @@ const out3 = `
 `
 
 var Internal3 = test.Internal{
-	Name:     "sort3",
-	Query:    "* | sort TTLs",
-	Input:    test.Trim(in3),
-	Format:   "zng",
-	Expected: test.Trim(out3),
+	Name:         "sort3",
+	Query:        "* | sort TTLs",
+	Input:        test.Trim(in3),
+	OutputFormat: "zng",
+	Expected:     test.Trim(out3),
 }


### PR DESCRIPTION
@philrz noted that ErrNotContainer and ErrNotScalar weren't showing up as expected when presented with input that should have triggered those errors. 

This happened because these two errors were caught in the parsing phase (unlike ErrExtraField and ErrMissingField), and so `zng.TypeCheck()` was never called when such errors were present.  Fix this by returning the errors from the parsing code. 

(The reason we have this structural checking co-mingled with parsing is that the Builder API requires us to know when a field is a container vs scalar. That bit is elided for unset values, so we use the value type and check as we parse).