### PR TITLE
remove defer from proc.Top.Pull loop

### DIFF
--- a/proc/top.go
+++ b/proc/top.go
@@ -47,10 +47,10 @@ func (s *Top) Pull() (zng.Batch, error) {
 		if batch == nil {
 			return s.sorted(), nil
 		}
-		defer batch.Unref()
 		for k := 0; k < batch.Length(); k++ {
 			s.consume(batch.Index(k))
 		}
+		batch.Unref()
 		if s.flushEvery {
 			return s.sorted(), nil
 		}


### PR DESCRIPTION
Each loop iteration in proc.Top.Pull defers a call to batch.Unref.  When
proc.Top.flushEvery is false, the accumulated runtime.newdefer
allocations (confusingly attributed to runtime.systemstack) consume
memory proportional to the number of batches produced by the parent
proc.  Remove the defer to eliminate those allocations.