### PR TITLE
Fix naked glob searches

### DIFF
--- a/zql/valid.zql
+++ b/zql/valid.zql
@@ -24,3 +24,5 @@ top -limit 1 -flush
 foo\tbar
 foo\x11bar
 foo\x11\bar
+*
+*abc*

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -573,53 +573,44 @@ var g = &grammar{
 					&actionExpr{
 						pos: position{line: 74, col: 5, offset: 1764},
 						run: (*parser).callonsearchPred24,
-						expr: &litMatcher{
-							pos:        position{line: 74, col: 5, offset: 1764},
-							val:        "*",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 77, col: 5, offset: 1823},
-						run: (*parser).callonsearchPred26,
 						expr: &seqExpr{
-							pos: position{line: 77, col: 5, offset: 1823},
+							pos: position{line: 74, col: 5, offset: 1764},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 77, col: 5, offset: 1823},
+									pos:   position{line: 74, col: 5, offset: 1764},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 77, col: 7, offset: 1825},
+										pos:  position{line: 74, col: 7, offset: 1766},
 										name: "fieldExpr",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 77, col: 17, offset: 1835},
+									pos: position{line: 74, col: 17, offset: 1776},
 									expr: &ruleRefExpr{
-										pos:  position{line: 77, col: 17, offset: 1835},
+										pos:  position{line: 74, col: 17, offset: 1776},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 77, col: 20, offset: 1838},
+									pos:   position{line: 74, col: 20, offset: 1779},
 									label: "fieldComparator",
 									expr: &ruleRefExpr{
-										pos:  position{line: 77, col: 36, offset: 1854},
+										pos:  position{line: 74, col: 36, offset: 1795},
 										name: "equalityToken",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 77, col: 50, offset: 1868},
+									pos: position{line: 74, col: 50, offset: 1809},
 									expr: &ruleRefExpr{
-										pos:  position{line: 77, col: 50, offset: 1868},
+										pos:  position{line: 74, col: 50, offset: 1809},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 77, col: 53, offset: 1871},
+									pos:   position{line: 74, col: 53, offset: 1812},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 77, col: 55, offset: 1873},
+										pos:  position{line: 74, col: 55, offset: 1814},
 										name: "searchValue",
 									},
 								},
@@ -627,39 +618,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 80, col: 5, offset: 1955},
-						run: (*parser).callonsearchPred38,
+						pos: position{line: 77, col: 5, offset: 1896},
+						run: (*parser).callonsearchPred36,
 						expr: &seqExpr{
-							pos: position{line: 80, col: 5, offset: 1955},
+							pos: position{line: 77, col: 5, offset: 1896},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 80, col: 5, offset: 1955},
+									pos:   position{line: 77, col: 5, offset: 1896},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 80, col: 7, offset: 1957},
+										pos:  position{line: 77, col: 7, offset: 1898},
 										name: "searchValue",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 80, col: 19, offset: 1969},
+									pos: position{line: 77, col: 19, offset: 1910},
 									expr: &ruleRefExpr{
-										pos:  position{line: 80, col: 19, offset: 1969},
+										pos:  position{line: 77, col: 19, offset: 1910},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 80, col: 22, offset: 1972},
+									pos:  position{line: 77, col: 22, offset: 1913},
 									name: "inToken",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 80, col: 30, offset: 1980},
+									pos: position{line: 77, col: 30, offset: 1921},
 									expr: &ruleRefExpr{
-										pos:  position{line: 80, col: 30, offset: 1980},
+										pos:  position{line: 77, col: 30, offset: 1921},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 80, col: 33, offset: 1983},
+									pos:        position{line: 77, col: 33, offset: 1924},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -667,42 +658,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 83, col: 5, offset: 2048},
-						run: (*parser).callonsearchPred48,
+						pos: position{line: 80, col: 5, offset: 1989},
+						run: (*parser).callonsearchPred46,
 						expr: &seqExpr{
-							pos: position{line: 83, col: 5, offset: 2048},
+							pos: position{line: 80, col: 5, offset: 1989},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 83, col: 5, offset: 2048},
+									pos:   position{line: 80, col: 5, offset: 1989},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 7, offset: 2050},
+										pos:  position{line: 80, col: 7, offset: 1991},
 										name: "searchValue",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 83, col: 19, offset: 2062},
+									pos: position{line: 80, col: 19, offset: 2003},
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 19, offset: 2062},
+										pos:  position{line: 80, col: 19, offset: 2003},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 83, col: 22, offset: 2065},
+									pos:  position{line: 80, col: 22, offset: 2006},
 									name: "inToken",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 83, col: 30, offset: 2073},
+									pos: position{line: 80, col: 30, offset: 2014},
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 30, offset: 2073},
+										pos:  position{line: 80, col: 30, offset: 2014},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 83, col: 33, offset: 2076},
+									pos:   position{line: 80, col: 33, offset: 2017},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 83, col: 35, offset: 2078},
+										pos:  position{line: 80, col: 35, offset: 2019},
 										name: "fieldReference",
 									},
 								},
@@ -710,13 +701,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 86, col: 5, offset: 2152},
-						run: (*parser).callonsearchPred59,
+						pos: position{line: 83, col: 5, offset: 2093},
+						run: (*parser).callonsearchPred57,
 						expr: &labeledExpr{
-							pos:   position{line: 86, col: 5, offset: 2152},
+							pos:   position{line: 83, col: 5, offset: 2093},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 86, col: 7, offset: 2154},
+								pos:  position{line: 83, col: 7, offset: 2095},
 								name: "searchValue",
 							},
 						},
@@ -726,124 +717,124 @@ var g = &grammar{
 		},
 		{
 			name: "searchValue",
-			pos:  position{line: 95, col: 1, offset: 2629},
+			pos:  position{line: 97, col: 1, offset: 2790},
 			expr: &choiceExpr{
-				pos: position{line: 96, col: 5, offset: 2645},
+				pos: position{line: 98, col: 5, offset: 2806},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 96, col: 5, offset: 2645},
+						pos: position{line: 98, col: 5, offset: 2806},
 						run: (*parser).callonsearchValue2,
 						expr: &labeledExpr{
-							pos:   position{line: 96, col: 5, offset: 2645},
+							pos:   position{line: 98, col: 5, offset: 2806},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 96, col: 7, offset: 2647},
+								pos:  position{line: 98, col: 7, offset: 2808},
 								name: "quotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 99, col: 5, offset: 2718},
+						pos: position{line: 101, col: 5, offset: 2879},
 						run: (*parser).callonsearchValue5,
 						expr: &labeledExpr{
-							pos:   position{line: 99, col: 5, offset: 2718},
+							pos:   position{line: 101, col: 5, offset: 2879},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 99, col: 7, offset: 2720},
+								pos:  position{line: 101, col: 7, offset: 2881},
 								name: "reString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 102, col: 5, offset: 2787},
+						pos: position{line: 104, col: 5, offset: 2948},
 						run: (*parser).callonsearchValue8,
 						expr: &labeledExpr{
-							pos:   position{line: 102, col: 5, offset: 2787},
+							pos:   position{line: 104, col: 5, offset: 2948},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 102, col: 7, offset: 2789},
+								pos:  position{line: 104, col: 7, offset: 2950},
 								name: "port",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 105, col: 5, offset: 2848},
+						pos: position{line: 107, col: 5, offset: 3009},
 						run: (*parser).callonsearchValue11,
 						expr: &labeledExpr{
-							pos:   position{line: 105, col: 5, offset: 2848},
+							pos:   position{line: 107, col: 5, offset: 3009},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 105, col: 7, offset: 2850},
+								pos:  position{line: 107, col: 7, offset: 3011},
 								name: "ip6subnet",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 108, col: 5, offset: 2918},
+						pos: position{line: 110, col: 5, offset: 3079},
 						run: (*parser).callonsearchValue14,
 						expr: &labeledExpr{
-							pos:   position{line: 108, col: 5, offset: 2918},
+							pos:   position{line: 110, col: 5, offset: 3079},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 108, col: 7, offset: 2920},
+								pos:  position{line: 110, col: 7, offset: 3081},
 								name: "ip6addr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 111, col: 5, offset: 2984},
+						pos: position{line: 113, col: 5, offset: 3145},
 						run: (*parser).callonsearchValue17,
 						expr: &labeledExpr{
-							pos:   position{line: 111, col: 5, offset: 2984},
+							pos:   position{line: 113, col: 5, offset: 3145},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 111, col: 7, offset: 2986},
+								pos:  position{line: 113, col: 7, offset: 3147},
 								name: "subnet",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 114, col: 5, offset: 3051},
+						pos: position{line: 116, col: 5, offset: 3212},
 						run: (*parser).callonsearchValue20,
 						expr: &labeledExpr{
-							pos:   position{line: 114, col: 5, offset: 3051},
+							pos:   position{line: 116, col: 5, offset: 3212},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 114, col: 7, offset: 3053},
+								pos:  position{line: 116, col: 7, offset: 3214},
 								name: "addr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 117, col: 5, offset: 3114},
+						pos: position{line: 119, col: 5, offset: 3275},
 						run: (*parser).callonsearchValue23,
 						expr: &labeledExpr{
-							pos:   position{line: 117, col: 5, offset: 3114},
+							pos:   position{line: 119, col: 5, offset: 3275},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 117, col: 7, offset: 3116},
+								pos:  position{line: 119, col: 7, offset: 3277},
 								name: "sdouble",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 120, col: 5, offset: 3182},
+						pos: position{line: 122, col: 5, offset: 3343},
 						run: (*parser).callonsearchValue26,
 						expr: &seqExpr{
-							pos: position{line: 120, col: 5, offset: 3182},
+							pos: position{line: 122, col: 5, offset: 3343},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 120, col: 5, offset: 3182},
+									pos:   position{line: 122, col: 5, offset: 3343},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 120, col: 7, offset: 3184},
+										pos:  position{line: 122, col: 7, offset: 3345},
 										name: "sinteger",
 									},
 								},
 								&notExpr{
-									pos: position{line: 120, col: 16, offset: 3193},
+									pos: position{line: 122, col: 16, offset: 3354},
 									expr: &ruleRefExpr{
-										pos:  position{line: 120, col: 17, offset: 3194},
+										pos:  position{line: 122, col: 17, offset: 3355},
 										name: "boomWord",
 									},
 								},
@@ -851,32 +842,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 123, col: 5, offset: 3258},
+						pos: position{line: 125, col: 5, offset: 3419},
 						run: (*parser).callonsearchValue32,
 						expr: &seqExpr{
-							pos: position{line: 123, col: 5, offset: 3258},
+							pos: position{line: 125, col: 5, offset: 3419},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 123, col: 5, offset: 3258},
+									pos: position{line: 125, col: 5, offset: 3419},
 									expr: &seqExpr{
-										pos: position{line: 123, col: 7, offset: 3260},
+										pos: position{line: 125, col: 7, offset: 3421},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 123, col: 7, offset: 3260},
+												pos:  position{line: 125, col: 7, offset: 3421},
 												name: "searchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 123, col: 22, offset: 3275},
+												pos:  position{line: 125, col: 22, offset: 3436},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 123, col: 25, offset: 3278},
+									pos:   position{line: 125, col: 25, offset: 3439},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 123, col: 27, offset: 3280},
+										pos:  position{line: 125, col: 27, offset: 3441},
 										name: "booleanLiteral",
 									},
 								},
@@ -884,32 +875,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 124, col: 5, offset: 3317},
+						pos: position{line: 126, col: 5, offset: 3478},
 						run: (*parser).callonsearchValue40,
 						expr: &seqExpr{
-							pos: position{line: 124, col: 5, offset: 3317},
+							pos: position{line: 126, col: 5, offset: 3478},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 124, col: 5, offset: 3317},
+									pos: position{line: 126, col: 5, offset: 3478},
 									expr: &seqExpr{
-										pos: position{line: 124, col: 7, offset: 3319},
+										pos: position{line: 126, col: 7, offset: 3480},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 124, col: 7, offset: 3319},
+												pos:  position{line: 126, col: 7, offset: 3480},
 												name: "searchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 124, col: 22, offset: 3334},
+												pos:  position{line: 126, col: 22, offset: 3495},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 124, col: 25, offset: 3337},
+									pos:   position{line: 126, col: 25, offset: 3498},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 124, col: 27, offset: 3339},
+										pos:  position{line: 126, col: 27, offset: 3500},
 										name: "unsetLiteral",
 									},
 								},
@@ -917,32 +908,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 125, col: 5, offset: 3374},
+						pos: position{line: 127, col: 5, offset: 3535},
 						run: (*parser).callonsearchValue48,
 						expr: &seqExpr{
-							pos: position{line: 125, col: 5, offset: 3374},
+							pos: position{line: 127, col: 5, offset: 3535},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 125, col: 5, offset: 3374},
+									pos: position{line: 127, col: 5, offset: 3535},
 									expr: &seqExpr{
-										pos: position{line: 125, col: 7, offset: 3376},
+										pos: position{line: 127, col: 7, offset: 3537},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 125, col: 7, offset: 3376},
+												pos:  position{line: 127, col: 7, offset: 3537},
 												name: "searchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 125, col: 22, offset: 3391},
+												pos:  position{line: 127, col: 22, offset: 3552},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 125, col: 25, offset: 3394},
+									pos:   position{line: 127, col: 25, offset: 3555},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 125, col: 27, offset: 3396},
+										pos:  position{line: 127, col: 27, offset: 3557},
 										name: "boomWord",
 									},
 								},
@@ -954,20 +945,20 @@ var g = &grammar{
 		},
 		{
 			name: "searchKeywords",
-			pos:  position{line: 133, col: 1, offset: 3620},
+			pos:  position{line: 135, col: 1, offset: 3781},
 			expr: &choiceExpr{
-				pos: position{line: 134, col: 5, offset: 3639},
+				pos: position{line: 136, col: 5, offset: 3800},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 134, col: 5, offset: 3639},
+						pos:  position{line: 136, col: 5, offset: 3800},
 						name: "andToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 135, col: 5, offset: 3652},
+						pos:  position{line: 137, col: 5, offset: 3813},
 						name: "orToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 136, col: 5, offset: 3664},
+						pos:  position{line: 138, col: 5, offset: 3825},
 						name: "inToken",
 					},
 				},
@@ -975,24 +966,24 @@ var g = &grammar{
 		},
 		{
 			name: "booleanLiteral",
-			pos:  position{line: 138, col: 1, offset: 3673},
+			pos:  position{line: 140, col: 1, offset: 3834},
 			expr: &choiceExpr{
-				pos: position{line: 139, col: 5, offset: 3692},
+				pos: position{line: 141, col: 5, offset: 3853},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 139, col: 5, offset: 3692},
+						pos: position{line: 141, col: 5, offset: 3853},
 						run: (*parser).callonbooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 139, col: 5, offset: 3692},
+							pos:        position{line: 141, col: 5, offset: 3853},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 140, col: 5, offset: 3760},
+						pos: position{line: 142, col: 5, offset: 3921},
 						run: (*parser).callonbooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 140, col: 5, offset: 3760},
+							pos:        position{line: 142, col: 5, offset: 3921},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -1002,12 +993,12 @@ var g = &grammar{
 		},
 		{
 			name: "unsetLiteral",
-			pos:  position{line: 142, col: 1, offset: 3826},
+			pos:  position{line: 144, col: 1, offset: 3987},
 			expr: &actionExpr{
-				pos: position{line: 143, col: 5, offset: 3843},
+				pos: position{line: 145, col: 5, offset: 4004},
 				run: (*parser).callonunsetLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 143, col: 5, offset: 3843},
+					pos:        position{line: 145, col: 5, offset: 4004},
 					val:        "nil",
 					ignoreCase: false,
 				},
@@ -1015,28 +1006,28 @@ var g = &grammar{
 		},
 		{
 			name: "procList",
-			pos:  position{line: 145, col: 1, offset: 3904},
+			pos:  position{line: 147, col: 1, offset: 4065},
 			expr: &actionExpr{
-				pos: position{line: 146, col: 5, offset: 3917},
+				pos: position{line: 148, col: 5, offset: 4078},
 				run: (*parser).callonprocList1,
 				expr: &seqExpr{
-					pos: position{line: 146, col: 5, offset: 3917},
+					pos: position{line: 148, col: 5, offset: 4078},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 146, col: 5, offset: 3917},
+							pos:   position{line: 148, col: 5, offset: 4078},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 146, col: 11, offset: 3923},
+								pos:  position{line: 148, col: 11, offset: 4084},
 								name: "procChain",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 146, col: 21, offset: 3933},
+							pos:   position{line: 148, col: 21, offset: 4094},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 146, col: 26, offset: 3938},
+								pos: position{line: 148, col: 26, offset: 4099},
 								expr: &ruleRefExpr{
-									pos:  position{line: 146, col: 26, offset: 3938},
+									pos:  position{line: 148, col: 26, offset: 4099},
 									name: "parallelChain",
 								},
 							},
@@ -1047,37 +1038,37 @@ var g = &grammar{
 		},
 		{
 			name: "parallelChain",
-			pos:  position{line: 155, col: 1, offset: 4162},
+			pos:  position{line: 157, col: 1, offset: 4323},
 			expr: &actionExpr{
-				pos: position{line: 156, col: 5, offset: 4180},
+				pos: position{line: 158, col: 5, offset: 4341},
 				run: (*parser).callonparallelChain1,
 				expr: &seqExpr{
-					pos: position{line: 156, col: 5, offset: 4180},
+					pos: position{line: 158, col: 5, offset: 4341},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 156, col: 5, offset: 4180},
+							pos: position{line: 158, col: 5, offset: 4341},
 							expr: &ruleRefExpr{
-								pos:  position{line: 156, col: 5, offset: 4180},
+								pos:  position{line: 158, col: 5, offset: 4341},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 156, col: 8, offset: 4183},
+							pos:        position{line: 158, col: 8, offset: 4344},
 							val:        ";",
 							ignoreCase: false,
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 156, col: 12, offset: 4187},
+							pos: position{line: 158, col: 12, offset: 4348},
 							expr: &ruleRefExpr{
-								pos:  position{line: 156, col: 12, offset: 4187},
+								pos:  position{line: 158, col: 12, offset: 4348},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 156, col: 15, offset: 4190},
+							pos:   position{line: 158, col: 15, offset: 4351},
 							label: "ch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 156, col: 18, offset: 4193},
+								pos:  position{line: 158, col: 18, offset: 4354},
 								name: "procChain",
 							},
 						},
@@ -1087,53 +1078,53 @@ var g = &grammar{
 		},
 		{
 			name: "proc",
-			pos:  position{line: 158, col: 1, offset: 4243},
+			pos:  position{line: 160, col: 1, offset: 4404},
 			expr: &choiceExpr{
-				pos: position{line: 159, col: 5, offset: 4252},
+				pos: position{line: 161, col: 5, offset: 4413},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 159, col: 5, offset: 4252},
+						pos:  position{line: 161, col: 5, offset: 4413},
 						name: "simpleProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 160, col: 5, offset: 4267},
+						pos:  position{line: 162, col: 5, offset: 4428},
 						name: "reducerProc",
 					},
 					&actionExpr{
-						pos: position{line: 161, col: 5, offset: 4283},
+						pos: position{line: 163, col: 5, offset: 4444},
 						run: (*parser).callonproc4,
 						expr: &seqExpr{
-							pos: position{line: 161, col: 5, offset: 4283},
+							pos: position{line: 163, col: 5, offset: 4444},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 161, col: 5, offset: 4283},
+									pos:        position{line: 163, col: 5, offset: 4444},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 161, col: 9, offset: 4287},
+									pos: position{line: 163, col: 9, offset: 4448},
 									expr: &ruleRefExpr{
-										pos:  position{line: 161, col: 9, offset: 4287},
+										pos:  position{line: 163, col: 9, offset: 4448},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 161, col: 12, offset: 4290},
+									pos:   position{line: 163, col: 12, offset: 4451},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 161, col: 17, offset: 4295},
+										pos:  position{line: 163, col: 17, offset: 4456},
 										name: "procList",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 161, col: 26, offset: 4304},
+									pos: position{line: 163, col: 26, offset: 4465},
 									expr: &ruleRefExpr{
-										pos:  position{line: 161, col: 26, offset: 4304},
+										pos:  position{line: 163, col: 26, offset: 4465},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 161, col: 29, offset: 4307},
+									pos:        position{line: 163, col: 29, offset: 4468},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1145,27 +1136,27 @@ var g = &grammar{
 		},
 		{
 			name: "groupBy",
-			pos:  position{line: 165, col: 1, offset: 4343},
+			pos:  position{line: 167, col: 1, offset: 4504},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 5, offset: 4355},
+				pos: position{line: 168, col: 5, offset: 4516},
 				run: (*parser).callongroupBy1,
 				expr: &seqExpr{
-					pos: position{line: 166, col: 5, offset: 4355},
+					pos: position{line: 168, col: 5, offset: 4516},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 166, col: 5, offset: 4355},
+							pos:        position{line: 168, col: 5, offset: 4516},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 11, offset: 4361},
+							pos:  position{line: 168, col: 11, offset: 4522},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 166, col: 13, offset: 4363},
+							pos:   position{line: 168, col: 13, offset: 4524},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 18, offset: 4368},
+								pos:  position{line: 168, col: 18, offset: 4529},
 								name: "fieldExprList",
 							},
 						},
@@ -1175,27 +1166,27 @@ var g = &grammar{
 		},
 		{
 			name: "everyDur",
-			pos:  position{line: 168, col: 1, offset: 4404},
+			pos:  position{line: 170, col: 1, offset: 4565},
 			expr: &actionExpr{
-				pos: position{line: 169, col: 5, offset: 4417},
+				pos: position{line: 171, col: 5, offset: 4578},
 				run: (*parser).calloneveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 169, col: 5, offset: 4417},
+					pos: position{line: 171, col: 5, offset: 4578},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 169, col: 5, offset: 4417},
+							pos:        position{line: 171, col: 5, offset: 4578},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 169, col: 14, offset: 4426},
+							pos:  position{line: 171, col: 14, offset: 4587},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 169, col: 16, offset: 4428},
+							pos:   position{line: 171, col: 16, offset: 4589},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 169, col: 20, offset: 4432},
+								pos:  position{line: 171, col: 20, offset: 4593},
 								name: "duration",
 							},
 						},
@@ -1205,60 +1196,60 @@ var g = &grammar{
 		},
 		{
 			name: "equalityToken",
-			pos:  position{line: 171, col: 1, offset: 4462},
+			pos:  position{line: 173, col: 1, offset: 4623},
 			expr: &choiceExpr{
-				pos: position{line: 172, col: 5, offset: 4480},
+				pos: position{line: 174, col: 5, offset: 4641},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 172, col: 5, offset: 4480},
+						pos: position{line: 174, col: 5, offset: 4641},
 						run: (*parser).callonequalityToken2,
 						expr: &litMatcher{
-							pos:        position{line: 172, col: 5, offset: 4480},
+							pos:        position{line: 174, col: 5, offset: 4641},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 173, col: 5, offset: 4510},
+						pos: position{line: 175, col: 5, offset: 4671},
 						run: (*parser).callonequalityToken4,
 						expr: &litMatcher{
-							pos:        position{line: 173, col: 5, offset: 4510},
+							pos:        position{line: 175, col: 5, offset: 4671},
 							val:        "!=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 174, col: 5, offset: 4542},
+						pos: position{line: 176, col: 5, offset: 4703},
 						run: (*parser).callonequalityToken6,
 						expr: &litMatcher{
-							pos:        position{line: 174, col: 5, offset: 4542},
+							pos:        position{line: 176, col: 5, offset: 4703},
 							val:        "<=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 175, col: 5, offset: 4573},
+						pos: position{line: 177, col: 5, offset: 4734},
 						run: (*parser).callonequalityToken8,
 						expr: &litMatcher{
-							pos:        position{line: 175, col: 5, offset: 4573},
+							pos:        position{line: 177, col: 5, offset: 4734},
 							val:        ">=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 176, col: 5, offset: 4604},
+						pos: position{line: 178, col: 5, offset: 4765},
 						run: (*parser).callonequalityToken10,
 						expr: &litMatcher{
-							pos:        position{line: 176, col: 5, offset: 4604},
+							pos:        position{line: 178, col: 5, offset: 4765},
 							val:        "<",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 177, col: 5, offset: 4633},
+						pos: position{line: 179, col: 5, offset: 4794},
 						run: (*parser).callonequalityToken12,
 						expr: &litMatcher{
-							pos:        position{line: 177, col: 5, offset: 4633},
+							pos:        position{line: 179, col: 5, offset: 4794},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1268,47 +1259,47 @@ var g = &grammar{
 		},
 		{
 			name: "types",
-			pos:  position{line: 179, col: 1, offset: 4659},
+			pos:  position{line: 181, col: 1, offset: 4820},
 			expr: &choiceExpr{
-				pos: position{line: 180, col: 5, offset: 4669},
+				pos: position{line: 182, col: 5, offset: 4830},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 180, col: 5, offset: 4669},
+						pos:        position{line: 182, col: 5, offset: 4830},
 						val:        "bool",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 181, col: 5, offset: 4680},
+						pos:        position{line: 183, col: 5, offset: 4841},
 						val:        "int",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 182, col: 5, offset: 4690},
+						pos:        position{line: 184, col: 5, offset: 4851},
 						val:        "count",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 183, col: 5, offset: 4702},
+						pos:        position{line: 185, col: 5, offset: 4863},
 						val:        "double",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 184, col: 5, offset: 4715},
+						pos:        position{line: 186, col: 5, offset: 4876},
 						val:        "string",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 185, col: 5, offset: 4728},
+						pos:        position{line: 187, col: 5, offset: 4889},
 						val:        "addr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 186, col: 5, offset: 4739},
+						pos:        position{line: 188, col: 5, offset: 4900},
 						val:        "subnet",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 187, col: 5, offset: 4752},
+						pos:        position{line: 189, col: 5, offset: 4913},
 						val:        "port",
 						ignoreCase: false,
 					},
@@ -1317,37 +1308,37 @@ var g = &grammar{
 		},
 		{
 			name: "dash",
-			pos:  position{line: 189, col: 1, offset: 4760},
+			pos:  position{line: 191, col: 1, offset: 4921},
 			expr: &choiceExpr{
-				pos: position{line: 189, col: 8, offset: 4767},
+				pos: position{line: 191, col: 8, offset: 4928},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 189, col: 8, offset: 4767},
+						pos:        position{line: 191, col: 8, offset: 4928},
 						val:        "-",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 189, col: 14, offset: 4773},
+						pos:        position{line: 191, col: 14, offset: 4934},
 						val:        "—",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 189, col: 25, offset: 4784},
+						pos:        position{line: 191, col: 25, offset: 4945},
 						val:        "–",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 189, col: 36, offset: 4795},
+						pos: position{line: 191, col: 36, offset: 4956},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 189, col: 36, offset: 4795},
+								pos:        position{line: 191, col: 36, offset: 4956},
 								val:        "to",
 								ignoreCase: false,
 							},
 							&andExpr{
-								pos: position{line: 189, col: 40, offset: 4799},
+								pos: position{line: 191, col: 40, offset: 4960},
 								expr: &ruleRefExpr{
-									pos:  position{line: 189, col: 42, offset: 4801},
+									pos:  position{line: 191, col: 42, offset: 4962},
 									name: "_",
 								},
 							},
@@ -1358,57 +1349,57 @@ var g = &grammar{
 		},
 		{
 			name: "andToken",
-			pos:  position{line: 191, col: 1, offset: 4805},
+			pos:  position{line: 193, col: 1, offset: 4966},
 			expr: &litMatcher{
-				pos:        position{line: 191, col: 12, offset: 4816},
+				pos:        position{line: 193, col: 12, offset: 4977},
 				val:        "and",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "orToken",
-			pos:  position{line: 192, col: 1, offset: 4822},
+			pos:  position{line: 194, col: 1, offset: 4983},
 			expr: &litMatcher{
-				pos:        position{line: 192, col: 11, offset: 4832},
+				pos:        position{line: 194, col: 11, offset: 4993},
 				val:        "or",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "inToken",
-			pos:  position{line: 193, col: 1, offset: 4837},
+			pos:  position{line: 195, col: 1, offset: 4998},
 			expr: &litMatcher{
-				pos:        position{line: 193, col: 11, offset: 4847},
+				pos:        position{line: 195, col: 11, offset: 5008},
 				val:        "in",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "notToken",
-			pos:  position{line: 194, col: 1, offset: 4852},
+			pos:  position{line: 196, col: 1, offset: 5013},
 			expr: &litMatcher{
-				pos:        position{line: 194, col: 12, offset: 4863},
+				pos:        position{line: 196, col: 12, offset: 5024},
 				val:        "not",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "fieldName",
-			pos:  position{line: 196, col: 1, offset: 4870},
+			pos:  position{line: 198, col: 1, offset: 5031},
 			expr: &actionExpr{
-				pos: position{line: 196, col: 13, offset: 4882},
+				pos: position{line: 198, col: 13, offset: 5043},
 				run: (*parser).callonfieldName1,
 				expr: &seqExpr{
-					pos: position{line: 196, col: 13, offset: 4882},
+					pos: position{line: 198, col: 13, offset: 5043},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 13, offset: 4882},
+							pos:  position{line: 198, col: 13, offset: 5043},
 							name: "fieldNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 196, col: 28, offset: 4897},
+							pos: position{line: 198, col: 28, offset: 5058},
 							expr: &ruleRefExpr{
-								pos:  position{line: 196, col: 28, offset: 4897},
+								pos:  position{line: 198, col: 28, offset: 5058},
 								name: "fieldNameRest",
 							},
 						},
@@ -1418,9 +1409,9 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameStart",
-			pos:  position{line: 198, col: 1, offset: 4944},
+			pos:  position{line: 200, col: 1, offset: 5105},
 			expr: &charClassMatcher{
-				pos:        position{line: 198, col: 18, offset: 4961},
+				pos:        position{line: 200, col: 18, offset: 5122},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1430,16 +1421,16 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameRest",
-			pos:  position{line: 199, col: 1, offset: 4972},
+			pos:  position{line: 201, col: 1, offset: 5133},
 			expr: &choiceExpr{
-				pos: position{line: 199, col: 17, offset: 4988},
+				pos: position{line: 201, col: 17, offset: 5149},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 17, offset: 4988},
+						pos:  position{line: 201, col: 17, offset: 5149},
 						name: "fieldNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 199, col: 34, offset: 5005},
+						pos:        position{line: 201, col: 34, offset: 5166},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -1450,45 +1441,45 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReference",
-			pos:  position{line: 201, col: 1, offset: 5012},
+			pos:  position{line: 203, col: 1, offset: 5173},
 			expr: &actionExpr{
-				pos: position{line: 202, col: 4, offset: 5030},
+				pos: position{line: 204, col: 4, offset: 5191},
 				run: (*parser).callonfieldReference1,
 				expr: &seqExpr{
-					pos: position{line: 202, col: 4, offset: 5030},
+					pos: position{line: 204, col: 4, offset: 5191},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 202, col: 4, offset: 5030},
+							pos:   position{line: 204, col: 4, offset: 5191},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 202, col: 9, offset: 5035},
+								pos:  position{line: 204, col: 9, offset: 5196},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 202, col: 19, offset: 5045},
+							pos:   position{line: 204, col: 19, offset: 5206},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 202, col: 26, offset: 5052},
+								pos: position{line: 204, col: 26, offset: 5213},
 								expr: &choiceExpr{
-									pos: position{line: 203, col: 8, offset: 5061},
+									pos: position{line: 205, col: 8, offset: 5222},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 203, col: 8, offset: 5061},
+											pos: position{line: 205, col: 8, offset: 5222},
 											run: (*parser).callonfieldReference8,
 											expr: &seqExpr{
-												pos: position{line: 203, col: 8, offset: 5061},
+												pos: position{line: 205, col: 8, offset: 5222},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 203, col: 8, offset: 5061},
+														pos:        position{line: 205, col: 8, offset: 5222},
 														val:        ".",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 203, col: 12, offset: 5065},
+														pos:   position{line: 205, col: 12, offset: 5226},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 203, col: 18, offset: 5071},
+															pos:  position{line: 205, col: 18, offset: 5232},
 															name: "fieldName",
 														},
 													},
@@ -1496,26 +1487,26 @@ var g = &grammar{
 											},
 										},
 										&actionExpr{
-											pos: position{line: 204, col: 8, offset: 5152},
+											pos: position{line: 206, col: 8, offset: 5313},
 											run: (*parser).callonfieldReference13,
 											expr: &seqExpr{
-												pos: position{line: 204, col: 8, offset: 5152},
+												pos: position{line: 206, col: 8, offset: 5313},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 204, col: 8, offset: 5152},
+														pos:        position{line: 206, col: 8, offset: 5313},
 														val:        "[",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 204, col: 12, offset: 5156},
+														pos:   position{line: 206, col: 12, offset: 5317},
 														label: "index",
 														expr: &ruleRefExpr{
-															pos:  position{line: 204, col: 18, offset: 5162},
+															pos:  position{line: 206, col: 18, offset: 5323},
 															name: "sinteger",
 														},
 													},
 													&litMatcher{
-														pos:        position{line: 204, col: 27, offset: 5171},
+														pos:        position{line: 206, col: 27, offset: 5332},
 														val:        "]",
 														ignoreCase: false,
 													},
@@ -1532,60 +1523,60 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExpr",
-			pos:  position{line: 209, col: 1, offset: 5287},
+			pos:  position{line: 211, col: 1, offset: 5448},
 			expr: &choiceExpr{
-				pos: position{line: 210, col: 5, offset: 5301},
+				pos: position{line: 212, col: 5, offset: 5462},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 210, col: 5, offset: 5301},
+						pos: position{line: 212, col: 5, offset: 5462},
 						run: (*parser).callonfieldExpr2,
 						expr: &seqExpr{
-							pos: position{line: 210, col: 5, offset: 5301},
+							pos: position{line: 212, col: 5, offset: 5462},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 210, col: 5, offset: 5301},
+									pos:   position{line: 212, col: 5, offset: 5462},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 210, col: 8, offset: 5304},
+										pos:  position{line: 212, col: 8, offset: 5465},
 										name: "fieldOp",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 210, col: 16, offset: 5312},
+									pos: position{line: 212, col: 16, offset: 5473},
 									expr: &ruleRefExpr{
-										pos:  position{line: 210, col: 16, offset: 5312},
+										pos:  position{line: 212, col: 16, offset: 5473},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 210, col: 19, offset: 5315},
+									pos:        position{line: 212, col: 19, offset: 5476},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 210, col: 23, offset: 5319},
+									pos: position{line: 212, col: 23, offset: 5480},
 									expr: &ruleRefExpr{
-										pos:  position{line: 210, col: 23, offset: 5319},
+										pos:  position{line: 212, col: 23, offset: 5480},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 210, col: 26, offset: 5322},
+									pos:   position{line: 212, col: 26, offset: 5483},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 210, col: 32, offset: 5328},
+										pos:  position{line: 212, col: 32, offset: 5489},
 										name: "fieldReference",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 210, col: 47, offset: 5343},
+									pos: position{line: 212, col: 47, offset: 5504},
 									expr: &ruleRefExpr{
-										pos:  position{line: 210, col: 47, offset: 5343},
+										pos:  position{line: 212, col: 47, offset: 5504},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 210, col: 50, offset: 5346},
+									pos:        position{line: 212, col: 50, offset: 5507},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1593,7 +1584,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 213, col: 5, offset: 5410},
+						pos:  position{line: 215, col: 5, offset: 5571},
 						name: "fieldReference",
 					},
 				},
@@ -1601,12 +1592,12 @@ var g = &grammar{
 		},
 		{
 			name: "fieldOp",
-			pos:  position{line: 215, col: 1, offset: 5426},
+			pos:  position{line: 217, col: 1, offset: 5587},
 			expr: &actionExpr{
-				pos: position{line: 216, col: 5, offset: 5438},
+				pos: position{line: 218, col: 5, offset: 5599},
 				run: (*parser).callonfieldOp1,
 				expr: &litMatcher{
-					pos:        position{line: 216, col: 5, offset: 5438},
+					pos:        position{line: 218, col: 5, offset: 5599},
 					val:        "len",
 					ignoreCase: true,
 				},
@@ -1614,50 +1605,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExprList",
-			pos:  position{line: 218, col: 1, offset: 5468},
+			pos:  position{line: 220, col: 1, offset: 5629},
 			expr: &actionExpr{
-				pos: position{line: 219, col: 5, offset: 5486},
+				pos: position{line: 221, col: 5, offset: 5647},
 				run: (*parser).callonfieldExprList1,
 				expr: &seqExpr{
-					pos: position{line: 219, col: 5, offset: 5486},
+					pos: position{line: 221, col: 5, offset: 5647},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 219, col: 5, offset: 5486},
+							pos:   position{line: 221, col: 5, offset: 5647},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 219, col: 11, offset: 5492},
+								pos:  position{line: 221, col: 11, offset: 5653},
 								name: "fieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 219, col: 21, offset: 5502},
+							pos:   position{line: 221, col: 21, offset: 5663},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 219, col: 26, offset: 5507},
+								pos: position{line: 221, col: 26, offset: 5668},
 								expr: &seqExpr{
-									pos: position{line: 219, col: 27, offset: 5508},
+									pos: position{line: 221, col: 27, offset: 5669},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 219, col: 27, offset: 5508},
+											pos: position{line: 221, col: 27, offset: 5669},
 											expr: &ruleRefExpr{
-												pos:  position{line: 219, col: 27, offset: 5508},
+												pos:  position{line: 221, col: 27, offset: 5669},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 219, col: 30, offset: 5511},
+											pos:        position{line: 221, col: 30, offset: 5672},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 219, col: 34, offset: 5515},
+											pos: position{line: 221, col: 34, offset: 5676},
 											expr: &ruleRefExpr{
-												pos:  position{line: 219, col: 34, offset: 5515},
+												pos:  position{line: 221, col: 34, offset: 5676},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 219, col: 37, offset: 5518},
+											pos:  position{line: 221, col: 37, offset: 5679},
 											name: "fieldExpr",
 										},
 									},
@@ -1670,42 +1661,42 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnly",
-			pos:  position{line: 229, col: 1, offset: 5713},
+			pos:  position{line: 231, col: 1, offset: 5874},
 			expr: &actionExpr{
-				pos: position{line: 230, col: 5, offset: 5733},
+				pos: position{line: 232, col: 5, offset: 5894},
 				run: (*parser).callonfieldRefDotOnly1,
 				expr: &seqExpr{
-					pos: position{line: 230, col: 5, offset: 5733},
+					pos: position{line: 232, col: 5, offset: 5894},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 230, col: 5, offset: 5733},
+							pos:   position{line: 232, col: 5, offset: 5894},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 230, col: 10, offset: 5738},
+								pos:  position{line: 232, col: 10, offset: 5899},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 230, col: 20, offset: 5748},
+							pos:   position{line: 232, col: 20, offset: 5909},
 							label: "refs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 230, col: 25, offset: 5753},
+								pos: position{line: 232, col: 25, offset: 5914},
 								expr: &actionExpr{
-									pos: position{line: 230, col: 26, offset: 5754},
+									pos: position{line: 232, col: 26, offset: 5915},
 									run: (*parser).callonfieldRefDotOnly7,
 									expr: &seqExpr{
-										pos: position{line: 230, col: 26, offset: 5754},
+										pos: position{line: 232, col: 26, offset: 5915},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 230, col: 26, offset: 5754},
+												pos:        position{line: 232, col: 26, offset: 5915},
 												val:        ".",
 												ignoreCase: false,
 											},
 											&labeledExpr{
-												pos:   position{line: 230, col: 30, offset: 5758},
+												pos:   position{line: 232, col: 30, offset: 5919},
 												label: "field",
 												expr: &ruleRefExpr{
-													pos:  position{line: 230, col: 36, offset: 5764},
+													pos:  position{line: 232, col: 36, offset: 5925},
 													name: "fieldName",
 												},
 											},
@@ -1720,56 +1711,56 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnlyList",
-			pos:  position{line: 234, col: 1, offset: 5889},
+			pos:  position{line: 236, col: 1, offset: 6050},
 			expr: &actionExpr{
-				pos: position{line: 235, col: 5, offset: 5913},
+				pos: position{line: 237, col: 5, offset: 6074},
 				run: (*parser).callonfieldRefDotOnlyList1,
 				expr: &seqExpr{
-					pos: position{line: 235, col: 5, offset: 5913},
+					pos: position{line: 237, col: 5, offset: 6074},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 235, col: 5, offset: 5913},
+							pos:   position{line: 237, col: 5, offset: 6074},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 235, col: 11, offset: 5919},
+								pos:  position{line: 237, col: 11, offset: 6080},
 								name: "fieldRefDotOnly",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 235, col: 27, offset: 5935},
+							pos:   position{line: 237, col: 27, offset: 6096},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 235, col: 32, offset: 5940},
+								pos: position{line: 237, col: 32, offset: 6101},
 								expr: &actionExpr{
-									pos: position{line: 235, col: 33, offset: 5941},
+									pos: position{line: 237, col: 33, offset: 6102},
 									run: (*parser).callonfieldRefDotOnlyList7,
 									expr: &seqExpr{
-										pos: position{line: 235, col: 33, offset: 5941},
+										pos: position{line: 237, col: 33, offset: 6102},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 235, col: 33, offset: 5941},
+												pos: position{line: 237, col: 33, offset: 6102},
 												expr: &ruleRefExpr{
-													pos:  position{line: 235, col: 33, offset: 5941},
+													pos:  position{line: 237, col: 33, offset: 6102},
 													name: "_",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 235, col: 36, offset: 5944},
+												pos:        position{line: 237, col: 36, offset: 6105},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 235, col: 40, offset: 5948},
+												pos: position{line: 237, col: 40, offset: 6109},
 												expr: &ruleRefExpr{
-													pos:  position{line: 235, col: 40, offset: 5948},
+													pos:  position{line: 237, col: 40, offset: 6109},
 													name: "_",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 235, col: 43, offset: 5951},
+												pos:   position{line: 237, col: 43, offset: 6112},
 												label: "ref",
 												expr: &ruleRefExpr{
-													pos:  position{line: 235, col: 47, offset: 5955},
+													pos:  position{line: 237, col: 47, offset: 6116},
 													name: "fieldRefDotOnly",
 												},
 											},
@@ -1784,50 +1775,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameList",
-			pos:  position{line: 243, col: 1, offset: 6135},
+			pos:  position{line: 245, col: 1, offset: 6296},
 			expr: &actionExpr{
-				pos: position{line: 244, col: 5, offset: 6153},
+				pos: position{line: 246, col: 5, offset: 6314},
 				run: (*parser).callonfieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 244, col: 5, offset: 6153},
+					pos: position{line: 246, col: 5, offset: 6314},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 244, col: 5, offset: 6153},
+							pos:   position{line: 246, col: 5, offset: 6314},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 244, col: 11, offset: 6159},
+								pos:  position{line: 246, col: 11, offset: 6320},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 244, col: 21, offset: 6169},
+							pos:   position{line: 246, col: 21, offset: 6330},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 244, col: 26, offset: 6174},
+								pos: position{line: 246, col: 26, offset: 6335},
 								expr: &seqExpr{
-									pos: position{line: 244, col: 27, offset: 6175},
+									pos: position{line: 246, col: 27, offset: 6336},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 244, col: 27, offset: 6175},
+											pos: position{line: 246, col: 27, offset: 6336},
 											expr: &ruleRefExpr{
-												pos:  position{line: 244, col: 27, offset: 6175},
+												pos:  position{line: 246, col: 27, offset: 6336},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 244, col: 30, offset: 6178},
+											pos:        position{line: 246, col: 30, offset: 6339},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 244, col: 34, offset: 6182},
+											pos: position{line: 246, col: 34, offset: 6343},
 											expr: &ruleRefExpr{
-												pos:  position{line: 244, col: 34, offset: 6182},
+												pos:  position{line: 246, col: 34, offset: 6343},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 244, col: 37, offset: 6185},
+											pos:  position{line: 246, col: 37, offset: 6346},
 											name: "fieldName",
 										},
 									},
@@ -1840,12 +1831,12 @@ var g = &grammar{
 		},
 		{
 			name: "countOp",
-			pos:  position{line: 252, col: 1, offset: 6378},
+			pos:  position{line: 254, col: 1, offset: 6539},
 			expr: &actionExpr{
-				pos: position{line: 253, col: 5, offset: 6390},
+				pos: position{line: 255, col: 5, offset: 6551},
 				run: (*parser).calloncountOp1,
 				expr: &litMatcher{
-					pos:        position{line: 253, col: 5, offset: 6390},
+					pos:        position{line: 255, col: 5, offset: 6551},
 					val:        "count",
 					ignoreCase: true,
 				},
@@ -1853,105 +1844,105 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducerOp",
-			pos:  position{line: 255, col: 1, offset: 6424},
+			pos:  position{line: 257, col: 1, offset: 6585},
 			expr: &choiceExpr{
-				pos: position{line: 256, col: 5, offset: 6443},
+				pos: position{line: 258, col: 5, offset: 6604},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 256, col: 5, offset: 6443},
+						pos: position{line: 258, col: 5, offset: 6604},
 						run: (*parser).callonfieldReducerOp2,
 						expr: &litMatcher{
-							pos:        position{line: 256, col: 5, offset: 6443},
+							pos:        position{line: 258, col: 5, offset: 6604},
 							val:        "sum",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 257, col: 5, offset: 6477},
+						pos: position{line: 259, col: 5, offset: 6638},
 						run: (*parser).callonfieldReducerOp4,
 						expr: &litMatcher{
-							pos:        position{line: 257, col: 5, offset: 6477},
+							pos:        position{line: 259, col: 5, offset: 6638},
 							val:        "avg",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 258, col: 5, offset: 6511},
+						pos: position{line: 260, col: 5, offset: 6672},
 						run: (*parser).callonfieldReducerOp6,
 						expr: &litMatcher{
-							pos:        position{line: 258, col: 5, offset: 6511},
+							pos:        position{line: 260, col: 5, offset: 6672},
 							val:        "stdev",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 259, col: 5, offset: 6548},
+						pos: position{line: 261, col: 5, offset: 6709},
 						run: (*parser).callonfieldReducerOp8,
 						expr: &litMatcher{
-							pos:        position{line: 259, col: 5, offset: 6548},
+							pos:        position{line: 261, col: 5, offset: 6709},
 							val:        "sd",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 260, col: 5, offset: 6584},
+						pos: position{line: 262, col: 5, offset: 6745},
 						run: (*parser).callonfieldReducerOp10,
 						expr: &litMatcher{
-							pos:        position{line: 260, col: 5, offset: 6584},
+							pos:        position{line: 262, col: 5, offset: 6745},
 							val:        "var",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 6618},
+						pos: position{line: 263, col: 5, offset: 6779},
 						run: (*parser).callonfieldReducerOp12,
 						expr: &litMatcher{
-							pos:        position{line: 261, col: 5, offset: 6618},
+							pos:        position{line: 263, col: 5, offset: 6779},
 							val:        "entropy",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 262, col: 5, offset: 6659},
+						pos: position{line: 264, col: 5, offset: 6820},
 						run: (*parser).callonfieldReducerOp14,
 						expr: &litMatcher{
-							pos:        position{line: 262, col: 5, offset: 6659},
+							pos:        position{line: 264, col: 5, offset: 6820},
 							val:        "min",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 263, col: 5, offset: 6693},
+						pos: position{line: 265, col: 5, offset: 6854},
 						run: (*parser).callonfieldReducerOp16,
 						expr: &litMatcher{
-							pos:        position{line: 263, col: 5, offset: 6693},
+							pos:        position{line: 265, col: 5, offset: 6854},
 							val:        "max",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 264, col: 5, offset: 6727},
+						pos: position{line: 266, col: 5, offset: 6888},
 						run: (*parser).callonfieldReducerOp18,
 						expr: &litMatcher{
-							pos:        position{line: 264, col: 5, offset: 6727},
+							pos:        position{line: 266, col: 5, offset: 6888},
 							val:        "first",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 265, col: 5, offset: 6765},
+						pos: position{line: 267, col: 5, offset: 6926},
 						run: (*parser).callonfieldReducerOp20,
 						expr: &litMatcher{
-							pos:        position{line: 265, col: 5, offset: 6765},
+							pos:        position{line: 267, col: 5, offset: 6926},
 							val:        "last",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 266, col: 5, offset: 6801},
+						pos: position{line: 268, col: 5, offset: 6962},
 						run: (*parser).callonfieldReducerOp22,
 						expr: &litMatcher{
-							pos:        position{line: 266, col: 5, offset: 6801},
+							pos:        position{line: 268, col: 5, offset: 6962},
 							val:        "countdistinct",
 							ignoreCase: true,
 						},
@@ -1961,32 +1952,32 @@ var g = &grammar{
 		},
 		{
 			name: "paddedFieldName",
-			pos:  position{line: 268, col: 1, offset: 6851},
+			pos:  position{line: 270, col: 1, offset: 7012},
 			expr: &actionExpr{
-				pos: position{line: 268, col: 19, offset: 6869},
+				pos: position{line: 270, col: 19, offset: 7030},
 				run: (*parser).callonpaddedFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 268, col: 19, offset: 6869},
+					pos: position{line: 270, col: 19, offset: 7030},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 268, col: 19, offset: 6869},
+							pos: position{line: 270, col: 19, offset: 7030},
 							expr: &ruleRefExpr{
-								pos:  position{line: 268, col: 19, offset: 6869},
+								pos:  position{line: 270, col: 19, offset: 7030},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 268, col: 22, offset: 6872},
+							pos:   position{line: 270, col: 22, offset: 7033},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 268, col: 28, offset: 6878},
+								pos:  position{line: 270, col: 28, offset: 7039},
 								name: "fieldName",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 268, col: 38, offset: 6888},
+							pos: position{line: 270, col: 38, offset: 7049},
 							expr: &ruleRefExpr{
-								pos:  position{line: 268, col: 38, offset: 6888},
+								pos:  position{line: 270, col: 38, offset: 7049},
 								name: "_",
 							},
 						},
@@ -1996,53 +1987,53 @@ var g = &grammar{
 		},
 		{
 			name: "countReducer",
-			pos:  position{line: 270, col: 1, offset: 6914},
+			pos:  position{line: 272, col: 1, offset: 7075},
 			expr: &actionExpr{
-				pos: position{line: 271, col: 5, offset: 6931},
+				pos: position{line: 273, col: 5, offset: 7092},
 				run: (*parser).calloncountReducer1,
 				expr: &seqExpr{
-					pos: position{line: 271, col: 5, offset: 6931},
+					pos: position{line: 273, col: 5, offset: 7092},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 271, col: 5, offset: 6931},
+							pos:   position{line: 273, col: 5, offset: 7092},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 8, offset: 6934},
+								pos:  position{line: 273, col: 8, offset: 7095},
 								name: "countOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 271, col: 16, offset: 6942},
+							pos: position{line: 273, col: 16, offset: 7103},
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 16, offset: 6942},
+								pos:  position{line: 273, col: 16, offset: 7103},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 271, col: 19, offset: 6945},
+							pos:        position{line: 273, col: 19, offset: 7106},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 271, col: 23, offset: 6949},
+							pos:   position{line: 273, col: 23, offset: 7110},
 							label: "field",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 271, col: 29, offset: 6955},
+								pos: position{line: 273, col: 29, offset: 7116},
 								expr: &ruleRefExpr{
-									pos:  position{line: 271, col: 29, offset: 6955},
+									pos:  position{line: 273, col: 29, offset: 7116},
 									name: "paddedFieldName",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 271, col: 47, offset: 6973},
+							pos: position{line: 273, col: 47, offset: 7134},
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 47, offset: 6973},
+								pos:  position{line: 273, col: 47, offset: 7134},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 271, col: 50, offset: 6976},
+							pos:        position{line: 273, col: 50, offset: 7137},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2052,57 +2043,57 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducer",
-			pos:  position{line: 275, col: 1, offset: 7035},
+			pos:  position{line: 277, col: 1, offset: 7196},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 5, offset: 7052},
+				pos: position{line: 278, col: 5, offset: 7213},
 				run: (*parser).callonfieldReducer1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 5, offset: 7052},
+					pos: position{line: 278, col: 5, offset: 7213},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 276, col: 5, offset: 7052},
+							pos:   position{line: 278, col: 5, offset: 7213},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 8, offset: 7055},
+								pos:  position{line: 278, col: 8, offset: 7216},
 								name: "fieldReducerOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 23, offset: 7070},
+							pos: position{line: 278, col: 23, offset: 7231},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 23, offset: 7070},
+								pos:  position{line: 278, col: 23, offset: 7231},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 276, col: 26, offset: 7073},
+							pos:        position{line: 278, col: 26, offset: 7234},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 30, offset: 7077},
+							pos: position{line: 278, col: 30, offset: 7238},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 30, offset: 7077},
+								pos:  position{line: 278, col: 30, offset: 7238},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 33, offset: 7080},
+							pos:   position{line: 278, col: 33, offset: 7241},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 39, offset: 7086},
+								pos:  position{line: 278, col: 39, offset: 7247},
 								name: "fieldName",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 50, offset: 7097},
+							pos: position{line: 278, col: 50, offset: 7258},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 50, offset: 7097},
+								pos:  position{line: 278, col: 50, offset: 7258},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 276, col: 53, offset: 7100},
+							pos:        position{line: 278, col: 53, offset: 7261},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2112,27 +2103,27 @@ var g = &grammar{
 		},
 		{
 			name: "reducerProc",
-			pos:  position{line: 280, col: 1, offset: 7167},
+			pos:  position{line: 282, col: 1, offset: 7328},
 			expr: &actionExpr{
-				pos: position{line: 281, col: 5, offset: 7183},
+				pos: position{line: 283, col: 5, offset: 7344},
 				run: (*parser).callonreducerProc1,
 				expr: &seqExpr{
-					pos: position{line: 281, col: 5, offset: 7183},
+					pos: position{line: 283, col: 5, offset: 7344},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 281, col: 5, offset: 7183},
+							pos:   position{line: 283, col: 5, offset: 7344},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 11, offset: 7189},
+								pos: position{line: 283, col: 11, offset: 7350},
 								expr: &seqExpr{
-									pos: position{line: 281, col: 12, offset: 7190},
+									pos: position{line: 283, col: 12, offset: 7351},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 12, offset: 7190},
+											pos:  position{line: 283, col: 12, offset: 7351},
 											name: "everyDur",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 21, offset: 7199},
+											pos:  position{line: 283, col: 21, offset: 7360},
 											name: "_",
 										},
 									},
@@ -2140,27 +2131,27 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 25, offset: 7203},
+							pos:   position{line: 283, col: 25, offset: 7364},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 281, col: 34, offset: 7212},
+								pos:  position{line: 283, col: 34, offset: 7373},
 								name: "reducerList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 46, offset: 7224},
+							pos:   position{line: 283, col: 46, offset: 7385},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 51, offset: 7229},
+								pos: position{line: 283, col: 51, offset: 7390},
 								expr: &seqExpr{
-									pos: position{line: 281, col: 52, offset: 7230},
+									pos: position{line: 283, col: 52, offset: 7391},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 52, offset: 7230},
+											pos:  position{line: 283, col: 52, offset: 7391},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 54, offset: 7232},
+											pos:  position{line: 283, col: 54, offset: 7393},
 											name: "groupBy",
 										},
 									},
@@ -2168,12 +2159,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 64, offset: 7242},
+							pos:   position{line: 283, col: 64, offset: 7403},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 70, offset: 7248},
+								pos: position{line: 283, col: 70, offset: 7409},
 								expr: &ruleRefExpr{
-									pos:  position{line: 281, col: 70, offset: 7248},
+									pos:  position{line: 283, col: 70, offset: 7409},
 									name: "procLimitArg",
 								},
 							},
@@ -2184,27 +2175,27 @@ var g = &grammar{
 		},
 		{
 			name: "asClause",
-			pos:  position{line: 299, col: 1, offset: 7605},
+			pos:  position{line: 301, col: 1, offset: 7766},
 			expr: &actionExpr{
-				pos: position{line: 300, col: 5, offset: 7618},
+				pos: position{line: 302, col: 5, offset: 7779},
 				run: (*parser).callonasClause1,
 				expr: &seqExpr{
-					pos: position{line: 300, col: 5, offset: 7618},
+					pos: position{line: 302, col: 5, offset: 7779},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 300, col: 5, offset: 7618},
+							pos:        position{line: 302, col: 5, offset: 7779},
 							val:        "as",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 11, offset: 7624},
+							pos:  position{line: 302, col: 11, offset: 7785},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 13, offset: 7626},
+							pos:   position{line: 302, col: 13, offset: 7787},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 15, offset: 7628},
+								pos:  position{line: 302, col: 15, offset: 7789},
 								name: "fieldName",
 							},
 						},
@@ -2214,48 +2205,48 @@ var g = &grammar{
 		},
 		{
 			name: "reducerExpr",
-			pos:  position{line: 302, col: 1, offset: 7657},
+			pos:  position{line: 304, col: 1, offset: 7818},
 			expr: &choiceExpr{
-				pos: position{line: 303, col: 5, offset: 7673},
+				pos: position{line: 305, col: 5, offset: 7834},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 303, col: 5, offset: 7673},
+						pos: position{line: 305, col: 5, offset: 7834},
 						run: (*parser).callonreducerExpr2,
 						expr: &seqExpr{
-							pos: position{line: 303, col: 5, offset: 7673},
+							pos: position{line: 305, col: 5, offset: 7834},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 303, col: 5, offset: 7673},
+									pos:   position{line: 305, col: 5, offset: 7834},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 11, offset: 7679},
+										pos:  position{line: 305, col: 11, offset: 7840},
 										name: "fieldName",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 303, col: 21, offset: 7689},
+									pos: position{line: 305, col: 21, offset: 7850},
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 21, offset: 7689},
+										pos:  position{line: 305, col: 21, offset: 7850},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 303, col: 24, offset: 7692},
+									pos:        position{line: 305, col: 24, offset: 7853},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 303, col: 28, offset: 7696},
+									pos: position{line: 305, col: 28, offset: 7857},
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 28, offset: 7696},
+										pos:  position{line: 305, col: 28, offset: 7857},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 303, col: 31, offset: 7699},
+									pos:   position{line: 305, col: 31, offset: 7860},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 33, offset: 7701},
+										pos:  position{line: 305, col: 33, offset: 7862},
 										name: "reducer",
 									},
 								},
@@ -2263,28 +2254,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 306, col: 5, offset: 7764},
+						pos: position{line: 308, col: 5, offset: 7925},
 						run: (*parser).callonreducerExpr13,
 						expr: &seqExpr{
-							pos: position{line: 306, col: 5, offset: 7764},
+							pos: position{line: 308, col: 5, offset: 7925},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 306, col: 5, offset: 7764},
+									pos:   position{line: 308, col: 5, offset: 7925},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 306, col: 7, offset: 7766},
+										pos:  position{line: 308, col: 7, offset: 7927},
 										name: "reducer",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 306, col: 15, offset: 7774},
+									pos:  position{line: 308, col: 15, offset: 7935},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 306, col: 17, offset: 7776},
+									pos:   position{line: 308, col: 17, offset: 7937},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 306, col: 23, offset: 7782},
+										pos:  position{line: 308, col: 23, offset: 7943},
 										name: "asClause",
 									},
 								},
@@ -2292,7 +2283,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 5, offset: 7846},
+						pos:  position{line: 311, col: 5, offset: 8007},
 						name: "reducer",
 					},
 				},
@@ -2300,16 +2291,16 @@ var g = &grammar{
 		},
 		{
 			name: "reducer",
-			pos:  position{line: 311, col: 1, offset: 7855},
+			pos:  position{line: 313, col: 1, offset: 8016},
 			expr: &choiceExpr{
-				pos: position{line: 312, col: 5, offset: 7867},
+				pos: position{line: 314, col: 5, offset: 8028},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 5, offset: 7867},
+						pos:  position{line: 314, col: 5, offset: 8028},
 						name: "countReducer",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 313, col: 5, offset: 7884},
+						pos:  position{line: 315, col: 5, offset: 8045},
 						name: "fieldReducer",
 					},
 				},
@@ -2317,50 +2308,50 @@ var g = &grammar{
 		},
 		{
 			name: "reducerList",
-			pos:  position{line: 315, col: 1, offset: 7898},
+			pos:  position{line: 317, col: 1, offset: 8059},
 			expr: &actionExpr{
-				pos: position{line: 316, col: 5, offset: 7914},
+				pos: position{line: 318, col: 5, offset: 8075},
 				run: (*parser).callonreducerList1,
 				expr: &seqExpr{
-					pos: position{line: 316, col: 5, offset: 7914},
+					pos: position{line: 318, col: 5, offset: 8075},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 316, col: 5, offset: 7914},
+							pos:   position{line: 318, col: 5, offset: 8075},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 316, col: 11, offset: 7920},
+								pos:  position{line: 318, col: 11, offset: 8081},
 								name: "reducerExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 316, col: 23, offset: 7932},
+							pos:   position{line: 318, col: 23, offset: 8093},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 316, col: 28, offset: 7937},
+								pos: position{line: 318, col: 28, offset: 8098},
 								expr: &seqExpr{
-									pos: position{line: 316, col: 29, offset: 7938},
+									pos: position{line: 318, col: 29, offset: 8099},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 316, col: 29, offset: 7938},
+											pos: position{line: 318, col: 29, offset: 8099},
 											expr: &ruleRefExpr{
-												pos:  position{line: 316, col: 29, offset: 7938},
+												pos:  position{line: 318, col: 29, offset: 8099},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 316, col: 32, offset: 7941},
+											pos:        position{line: 318, col: 32, offset: 8102},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 316, col: 36, offset: 7945},
+											pos: position{line: 318, col: 36, offset: 8106},
 											expr: &ruleRefExpr{
-												pos:  position{line: 316, col: 36, offset: 7945},
+												pos:  position{line: 318, col: 36, offset: 8106},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 316, col: 39, offset: 7948},
+											pos:  position{line: 318, col: 39, offset: 8109},
 											name: "reducerExpr",
 										},
 									},
@@ -2373,36 +2364,36 @@ var g = &grammar{
 		},
 		{
 			name: "simpleProc",
-			pos:  position{line: 324, col: 1, offset: 8145},
+			pos:  position{line: 326, col: 1, offset: 8306},
 			expr: &choiceExpr{
-				pos: position{line: 325, col: 5, offset: 8160},
+				pos: position{line: 327, col: 5, offset: 8321},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 325, col: 5, offset: 8160},
+						pos:  position{line: 327, col: 5, offset: 8321},
 						name: "sort",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 326, col: 5, offset: 8169},
+						pos:  position{line: 328, col: 5, offset: 8330},
 						name: "top",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 327, col: 5, offset: 8177},
+						pos:  position{line: 329, col: 5, offset: 8338},
 						name: "cut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 328, col: 5, offset: 8185},
+						pos:  position{line: 330, col: 5, offset: 8346},
 						name: "head",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 329, col: 5, offset: 8194},
+						pos:  position{line: 331, col: 5, offset: 8355},
 						name: "tail",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 330, col: 5, offset: 8203},
+						pos:  position{line: 332, col: 5, offset: 8364},
 						name: "filter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 331, col: 5, offset: 8214},
+						pos:  position{line: 333, col: 5, offset: 8375},
 						name: "uniq",
 					},
 				},
@@ -2410,35 +2401,35 @@ var g = &grammar{
 		},
 		{
 			name: "sort",
-			pos:  position{line: 333, col: 1, offset: 8220},
+			pos:  position{line: 335, col: 1, offset: 8381},
 			expr: &choiceExpr{
-				pos: position{line: 334, col: 5, offset: 8229},
+				pos: position{line: 336, col: 5, offset: 8390},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 334, col: 5, offset: 8229},
+						pos: position{line: 336, col: 5, offset: 8390},
 						run: (*parser).callonsort2,
 						expr: &seqExpr{
-							pos: position{line: 334, col: 5, offset: 8229},
+							pos: position{line: 336, col: 5, offset: 8390},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 334, col: 5, offset: 8229},
+									pos:        position{line: 336, col: 5, offset: 8390},
 									val:        "sort",
 									ignoreCase: true,
 								},
 								&labeledExpr{
-									pos:   position{line: 334, col: 13, offset: 8237},
+									pos:   position{line: 336, col: 13, offset: 8398},
 									label: "rev",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 334, col: 17, offset: 8241},
+										pos: position{line: 336, col: 17, offset: 8402},
 										expr: &seqExpr{
-											pos: position{line: 334, col: 18, offset: 8242},
+											pos: position{line: 336, col: 18, offset: 8403},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 334, col: 18, offset: 8242},
+													pos:  position{line: 336, col: 18, offset: 8403},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 334, col: 20, offset: 8244},
+													pos:        position{line: 336, col: 20, offset: 8405},
 													val:        "-r",
 													ignoreCase: false,
 												},
@@ -2447,38 +2438,38 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 334, col: 27, offset: 8251},
+									pos:   position{line: 336, col: 27, offset: 8412},
 									label: "limit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 334, col: 33, offset: 8257},
+										pos: position{line: 336, col: 33, offset: 8418},
 										expr: &ruleRefExpr{
-											pos:  position{line: 334, col: 33, offset: 8257},
+											pos:  position{line: 336, col: 33, offset: 8418},
 											name: "procLimitArg",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 334, col: 48, offset: 8272},
+									pos: position{line: 336, col: 48, offset: 8433},
 									expr: &ruleRefExpr{
-										pos:  position{line: 334, col: 48, offset: 8272},
+										pos:  position{line: 336, col: 48, offset: 8433},
 										name: "_",
 									},
 								},
 								&notExpr{
-									pos: position{line: 334, col: 51, offset: 8275},
+									pos: position{line: 336, col: 51, offset: 8436},
 									expr: &litMatcher{
-										pos:        position{line: 334, col: 52, offset: 8276},
+										pos:        position{line: 336, col: 52, offset: 8437},
 										val:        "-r",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 334, col: 57, offset: 8281},
+									pos:   position{line: 336, col: 57, offset: 8442},
 									label: "list",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 334, col: 62, offset: 8286},
+										pos: position{line: 336, col: 62, offset: 8447},
 										expr: &ruleRefExpr{
-											pos:  position{line: 334, col: 63, offset: 8287},
+											pos:  position{line: 336, col: 63, offset: 8448},
 											name: "fieldExprList",
 										},
 									},
@@ -2487,41 +2478,41 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 339, col: 5, offset: 8417},
+						pos: position{line: 341, col: 5, offset: 8578},
 						run: (*parser).callonsort20,
 						expr: &seqExpr{
-							pos: position{line: 339, col: 5, offset: 8417},
+							pos: position{line: 341, col: 5, offset: 8578},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 339, col: 5, offset: 8417},
+									pos:        position{line: 341, col: 5, offset: 8578},
 									val:        "sort",
 									ignoreCase: true,
 								},
 								&labeledExpr{
-									pos:   position{line: 339, col: 13, offset: 8425},
+									pos:   position{line: 341, col: 13, offset: 8586},
 									label: "limit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 339, col: 19, offset: 8431},
+										pos: position{line: 341, col: 19, offset: 8592},
 										expr: &ruleRefExpr{
-											pos:  position{line: 339, col: 19, offset: 8431},
+											pos:  position{line: 341, col: 19, offset: 8592},
 											name: "procLimitArg",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 339, col: 33, offset: 8445},
+									pos:   position{line: 341, col: 33, offset: 8606},
 									label: "rev",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 339, col: 37, offset: 8449},
+										pos: position{line: 341, col: 37, offset: 8610},
 										expr: &seqExpr{
-											pos: position{line: 339, col: 38, offset: 8450},
+											pos: position{line: 341, col: 38, offset: 8611},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 339, col: 38, offset: 8450},
+													pos:  position{line: 341, col: 38, offset: 8611},
 													name: "_",
 												},
 												&litMatcher{
-													pos:        position{line: 339, col: 40, offset: 8452},
+													pos:        position{line: 341, col: 40, offset: 8613},
 													val:        "-r",
 													ignoreCase: false,
 												},
@@ -2530,19 +2521,19 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 339, col: 47, offset: 8459},
+									pos: position{line: 341, col: 47, offset: 8620},
 									expr: &ruleRefExpr{
-										pos:  position{line: 339, col: 47, offset: 8459},
+										pos:  position{line: 341, col: 47, offset: 8620},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 339, col: 50, offset: 8462},
+									pos:   position{line: 341, col: 50, offset: 8623},
 									label: "list",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 339, col: 55, offset: 8467},
+										pos: position{line: 341, col: 55, offset: 8628},
 										expr: &ruleRefExpr{
-											pos:  position{line: 339, col: 56, offset: 8468},
+											pos:  position{line: 341, col: 56, offset: 8629},
 											name: "fieldExprList",
 										},
 									},
@@ -2555,43 +2546,43 @@ var g = &grammar{
 		},
 		{
 			name: "top",
-			pos:  position{line: 345, col: 1, offset: 8595},
+			pos:  position{line: 347, col: 1, offset: 8756},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 5, offset: 8603},
+				pos: position{line: 348, col: 5, offset: 8764},
 				run: (*parser).callontop1,
 				expr: &seqExpr{
-					pos: position{line: 346, col: 5, offset: 8603},
+					pos: position{line: 348, col: 5, offset: 8764},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 346, col: 5, offset: 8603},
+							pos:        position{line: 348, col: 5, offset: 8764},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 12, offset: 8610},
+							pos:   position{line: 348, col: 12, offset: 8771},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 346, col: 18, offset: 8616},
+								pos: position{line: 348, col: 18, offset: 8777},
 								expr: &ruleRefExpr{
-									pos:  position{line: 346, col: 18, offset: 8616},
+									pos:  position{line: 348, col: 18, offset: 8777},
 									name: "procLimitArg",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 32, offset: 8630},
+							pos:   position{line: 348, col: 32, offset: 8791},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 346, col: 38, offset: 8636},
+								pos: position{line: 348, col: 38, offset: 8797},
 								expr: &seqExpr{
-									pos: position{line: 346, col: 39, offset: 8637},
+									pos: position{line: 348, col: 39, offset: 8798},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 346, col: 39, offset: 8637},
+											pos:  position{line: 348, col: 39, offset: 8798},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 346, col: 41, offset: 8639},
+											pos:        position{line: 348, col: 41, offset: 8800},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2600,19 +2591,19 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 346, col: 52, offset: 8650},
+							pos: position{line: 348, col: 52, offset: 8811},
 							expr: &ruleRefExpr{
-								pos:  position{line: 346, col: 52, offset: 8650},
+								pos:  position{line: 348, col: 52, offset: 8811},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 55, offset: 8653},
+							pos:   position{line: 348, col: 55, offset: 8814},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 346, col: 60, offset: 8658},
+								pos: position{line: 348, col: 60, offset: 8819},
 								expr: &ruleRefExpr{
-									pos:  position{line: 346, col: 61, offset: 8659},
+									pos:  position{line: 348, col: 61, offset: 8820},
 									name: "fieldExprList",
 								},
 							},
@@ -2623,31 +2614,31 @@ var g = &grammar{
 		},
 		{
 			name: "procLimitArg",
-			pos:  position{line: 350, col: 1, offset: 8730},
+			pos:  position{line: 352, col: 1, offset: 8891},
 			expr: &actionExpr{
-				pos: position{line: 351, col: 5, offset: 8747},
+				pos: position{line: 353, col: 5, offset: 8908},
 				run: (*parser).callonprocLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 351, col: 5, offset: 8747},
+					pos: position{line: 353, col: 5, offset: 8908},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 351, col: 5, offset: 8747},
+							pos:  position{line: 353, col: 5, offset: 8908},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 351, col: 7, offset: 8749},
+							pos:        position{line: 353, col: 7, offset: 8910},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 351, col: 16, offset: 8758},
+							pos:  position{line: 353, col: 16, offset: 8919},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 351, col: 18, offset: 8760},
+							pos:   position{line: 353, col: 18, offset: 8921},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 351, col: 24, offset: 8766},
+								pos:  position{line: 353, col: 24, offset: 8927},
 								name: "integer",
 							},
 						},
@@ -2657,27 +2648,27 @@ var g = &grammar{
 		},
 		{
 			name: "cut",
-			pos:  position{line: 353, col: 1, offset: 8797},
+			pos:  position{line: 355, col: 1, offset: 8958},
 			expr: &actionExpr{
-				pos: position{line: 354, col: 5, offset: 8805},
+				pos: position{line: 356, col: 5, offset: 8966},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 354, col: 5, offset: 8805},
+					pos: position{line: 356, col: 5, offset: 8966},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 354, col: 5, offset: 8805},
+							pos:        position{line: 356, col: 5, offset: 8966},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 354, col: 12, offset: 8812},
+							pos:  position{line: 356, col: 12, offset: 8973},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 14, offset: 8814},
+							pos:   position{line: 356, col: 14, offset: 8975},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 354, col: 19, offset: 8819},
+								pos:  position{line: 356, col: 19, offset: 8980},
 								name: "fieldRefDotOnlyList",
 							},
 						},
@@ -2687,30 +2678,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 355, col: 1, offset: 8873},
+			pos:  position{line: 357, col: 1, offset: 9034},
 			expr: &choiceExpr{
-				pos: position{line: 356, col: 5, offset: 8882},
+				pos: position{line: 358, col: 5, offset: 9043},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 356, col: 5, offset: 8882},
+						pos: position{line: 358, col: 5, offset: 9043},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 356, col: 5, offset: 8882},
+							pos: position{line: 358, col: 5, offset: 9043},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 356, col: 5, offset: 8882},
+									pos:        position{line: 358, col: 5, offset: 9043},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 356, col: 13, offset: 8890},
+									pos:  position{line: 358, col: 13, offset: 9051},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 356, col: 15, offset: 8892},
+									pos:   position{line: 358, col: 15, offset: 9053},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 356, col: 21, offset: 8898},
+										pos:  position{line: 358, col: 21, offset: 9059},
 										name: "integer",
 									},
 								},
@@ -2718,10 +2709,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 357, col: 5, offset: 8946},
+						pos: position{line: 359, col: 5, offset: 9107},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 357, col: 5, offset: 8946},
+							pos:        position{line: 359, col: 5, offset: 9107},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2731,30 +2722,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 358, col: 1, offset: 8986},
+			pos:  position{line: 360, col: 1, offset: 9147},
 			expr: &choiceExpr{
-				pos: position{line: 359, col: 5, offset: 8995},
+				pos: position{line: 361, col: 5, offset: 9156},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 359, col: 5, offset: 8995},
+						pos: position{line: 361, col: 5, offset: 9156},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 359, col: 5, offset: 8995},
+							pos: position{line: 361, col: 5, offset: 9156},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 359, col: 5, offset: 8995},
+									pos:        position{line: 361, col: 5, offset: 9156},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 359, col: 13, offset: 9003},
+									pos:  position{line: 361, col: 13, offset: 9164},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 359, col: 15, offset: 9005},
+									pos:   position{line: 361, col: 15, offset: 9166},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 359, col: 21, offset: 9011},
+										pos:  position{line: 361, col: 21, offset: 9172},
 										name: "integer",
 									},
 								},
@@ -2762,10 +2753,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 360, col: 5, offset: 9059},
+						pos: position{line: 362, col: 5, offset: 9220},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 360, col: 5, offset: 9059},
+							pos:        position{line: 362, col: 5, offset: 9220},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2775,27 +2766,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 362, col: 1, offset: 9100},
+			pos:  position{line: 364, col: 1, offset: 9261},
 			expr: &actionExpr{
-				pos: position{line: 363, col: 5, offset: 9111},
+				pos: position{line: 365, col: 5, offset: 9272},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 363, col: 5, offset: 9111},
+					pos: position{line: 365, col: 5, offset: 9272},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 363, col: 5, offset: 9111},
+							pos:        position{line: 365, col: 5, offset: 9272},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 363, col: 15, offset: 9121},
+							pos:  position{line: 365, col: 15, offset: 9282},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 363, col: 17, offset: 9123},
+							pos:   position{line: 365, col: 17, offset: 9284},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 363, col: 22, offset: 9128},
+								pos:  position{line: 365, col: 22, offset: 9289},
 								name: "searchExpr",
 							},
 						},
@@ -2805,27 +2796,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 366, col: 1, offset: 9186},
+			pos:  position{line: 368, col: 1, offset: 9347},
 			expr: &choiceExpr{
-				pos: position{line: 367, col: 5, offset: 9195},
+				pos: position{line: 369, col: 5, offset: 9356},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 367, col: 5, offset: 9195},
+						pos: position{line: 369, col: 5, offset: 9356},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 367, col: 5, offset: 9195},
+							pos: position{line: 369, col: 5, offset: 9356},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 367, col: 5, offset: 9195},
+									pos:        position{line: 369, col: 5, offset: 9356},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 367, col: 13, offset: 9203},
+									pos:  position{line: 369, col: 13, offset: 9364},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 367, col: 15, offset: 9205},
+									pos:        position{line: 369, col: 15, offset: 9366},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2833,10 +2824,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 9259},
+						pos: position{line: 372, col: 5, offset: 9420},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 370, col: 5, offset: 9259},
+							pos:        position{line: 372, col: 5, offset: 9420},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2846,54 +2837,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 374, col: 1, offset: 9314},
+			pos:  position{line: 376, col: 1, offset: 9475},
 			expr: &choiceExpr{
-				pos: position{line: 375, col: 5, offset: 9327},
+				pos: position{line: 377, col: 5, offset: 9488},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 375, col: 5, offset: 9327},
+						pos:  position{line: 377, col: 5, offset: 9488},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 376, col: 5, offset: 9339},
+						pos:  position{line: 378, col: 5, offset: 9500},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 377, col: 5, offset: 9351},
+						pos:  position{line: 379, col: 5, offset: 9512},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 378, col: 5, offset: 9361},
+						pos: position{line: 380, col: 5, offset: 9522},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 378, col: 5, offset: 9361},
+								pos:  position{line: 380, col: 5, offset: 9522},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 378, col: 11, offset: 9367},
+								pos:  position{line: 380, col: 11, offset: 9528},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 378, col: 13, offset: 9369},
+								pos:        position{line: 380, col: 13, offset: 9530},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 378, col: 19, offset: 9375},
+								pos:  position{line: 380, col: 19, offset: 9536},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 378, col: 21, offset: 9377},
+								pos:  position{line: 380, col: 21, offset: 9538},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 379, col: 5, offset: 9389},
+						pos:  position{line: 381, col: 5, offset: 9550},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 380, col: 5, offset: 9398},
+						pos:  position{line: 382, col: 5, offset: 9559},
 						name: "weeks",
 					},
 				},
@@ -2901,32 +2892,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 382, col: 1, offset: 9405},
+			pos:  position{line: 384, col: 1, offset: 9566},
 			expr: &choiceExpr{
-				pos: position{line: 383, col: 5, offset: 9420},
+				pos: position{line: 385, col: 5, offset: 9581},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 383, col: 5, offset: 9420},
+						pos:        position{line: 385, col: 5, offset: 9581},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 384, col: 5, offset: 9434},
+						pos:        position{line: 386, col: 5, offset: 9595},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 385, col: 5, offset: 9447},
+						pos:        position{line: 387, col: 5, offset: 9608},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 386, col: 5, offset: 9458},
+						pos:        position{line: 388, col: 5, offset: 9619},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 387, col: 5, offset: 9468},
+						pos:        position{line: 389, col: 5, offset: 9629},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -2935,32 +2926,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 389, col: 1, offset: 9473},
+			pos:  position{line: 391, col: 1, offset: 9634},
 			expr: &choiceExpr{
-				pos: position{line: 390, col: 5, offset: 9488},
+				pos: position{line: 392, col: 5, offset: 9649},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 390, col: 5, offset: 9488},
+						pos:        position{line: 392, col: 5, offset: 9649},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 391, col: 5, offset: 9502},
+						pos:        position{line: 393, col: 5, offset: 9663},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 392, col: 5, offset: 9515},
+						pos:        position{line: 394, col: 5, offset: 9676},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 393, col: 5, offset: 9526},
+						pos:        position{line: 395, col: 5, offset: 9687},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 394, col: 5, offset: 9536},
+						pos:        position{line: 396, col: 5, offset: 9697},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -2969,32 +2960,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 396, col: 1, offset: 9541},
+			pos:  position{line: 398, col: 1, offset: 9702},
 			expr: &choiceExpr{
-				pos: position{line: 397, col: 5, offset: 9557},
+				pos: position{line: 399, col: 5, offset: 9718},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 397, col: 5, offset: 9557},
+						pos:        position{line: 399, col: 5, offset: 9718},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 398, col: 5, offset: 9569},
+						pos:        position{line: 400, col: 5, offset: 9730},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 399, col: 5, offset: 9579},
+						pos:        position{line: 401, col: 5, offset: 9740},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 400, col: 5, offset: 9588},
+						pos:        position{line: 402, col: 5, offset: 9749},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 401, col: 5, offset: 9596},
+						pos:        position{line: 403, col: 5, offset: 9757},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -3003,22 +2994,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 403, col: 1, offset: 9604},
+			pos:  position{line: 405, col: 1, offset: 9765},
 			expr: &choiceExpr{
-				pos: position{line: 403, col: 14, offset: 9617},
+				pos: position{line: 405, col: 14, offset: 9778},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 403, col: 14, offset: 9617},
+						pos:        position{line: 405, col: 14, offset: 9778},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 403, col: 21, offset: 9624},
+						pos:        position{line: 405, col: 21, offset: 9785},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 403, col: 27, offset: 9630},
+						pos:        position{line: 405, col: 27, offset: 9791},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -3027,32 +3018,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 404, col: 1, offset: 9634},
+			pos:  position{line: 406, col: 1, offset: 9795},
 			expr: &choiceExpr{
-				pos: position{line: 404, col: 15, offset: 9648},
+				pos: position{line: 406, col: 15, offset: 9809},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 404, col: 15, offset: 9648},
+						pos:        position{line: 406, col: 15, offset: 9809},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 404, col: 23, offset: 9656},
+						pos:        position{line: 406, col: 23, offset: 9817},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 404, col: 30, offset: 9663},
+						pos:        position{line: 406, col: 30, offset: 9824},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 404, col: 36, offset: 9669},
+						pos:        position{line: 406, col: 36, offset: 9830},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 404, col: 41, offset: 9674},
+						pos:        position{line: 406, col: 41, offset: 9835},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -3061,42 +3052,42 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 406, col: 1, offset: 9679},
+			pos:  position{line: 408, col: 1, offset: 9840},
 			expr: &choiceExpr{
-				pos: position{line: 407, col: 5, offset: 9691},
+				pos: position{line: 409, col: 5, offset: 9852},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 407, col: 5, offset: 9691},
+						pos: position{line: 409, col: 5, offset: 9852},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 407, col: 5, offset: 9691},
+							pos:        position{line: 409, col: 5, offset: 9852},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 408, col: 5, offset: 9736},
+						pos: position{line: 410, col: 5, offset: 9897},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 408, col: 5, offset: 9736},
+							pos: position{line: 410, col: 5, offset: 9897},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 408, col: 5, offset: 9736},
+									pos:   position{line: 410, col: 5, offset: 9897},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 408, col: 9, offset: 9740},
+										pos:  position{line: 410, col: 9, offset: 9901},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 408, col: 16, offset: 9747},
+									pos: position{line: 410, col: 16, offset: 9908},
 									expr: &ruleRefExpr{
-										pos:  position{line: 408, col: 16, offset: 9747},
+										pos:  position{line: 410, col: 16, offset: 9908},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 408, col: 19, offset: 9750},
+									pos:  position{line: 410, col: 19, offset: 9911},
 									name: "sec_abbrev",
 								},
 							},
@@ -3107,42 +3098,42 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 410, col: 1, offset: 9796},
+			pos:  position{line: 412, col: 1, offset: 9957},
 			expr: &choiceExpr{
-				pos: position{line: 411, col: 5, offset: 9808},
+				pos: position{line: 413, col: 5, offset: 9969},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 411, col: 5, offset: 9808},
+						pos: position{line: 413, col: 5, offset: 9969},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 411, col: 5, offset: 9808},
+							pos:        position{line: 413, col: 5, offset: 9969},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 412, col: 5, offset: 9854},
+						pos: position{line: 414, col: 5, offset: 10015},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 412, col: 5, offset: 9854},
+							pos: position{line: 414, col: 5, offset: 10015},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 412, col: 5, offset: 9854},
+									pos:   position{line: 414, col: 5, offset: 10015},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 412, col: 9, offset: 9858},
+										pos:  position{line: 414, col: 9, offset: 10019},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 412, col: 16, offset: 9865},
+									pos: position{line: 414, col: 16, offset: 10026},
 									expr: &ruleRefExpr{
-										pos:  position{line: 412, col: 16, offset: 9865},
+										pos:  position{line: 414, col: 16, offset: 10026},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 412, col: 19, offset: 9868},
+									pos:  position{line: 414, col: 19, offset: 10029},
 									name: "min_abbrev",
 								},
 							},
@@ -3153,42 +3144,42 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 414, col: 1, offset: 9923},
+			pos:  position{line: 416, col: 1, offset: 10084},
 			expr: &choiceExpr{
-				pos: position{line: 415, col: 5, offset: 9933},
+				pos: position{line: 417, col: 5, offset: 10094},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 415, col: 5, offset: 9933},
+						pos: position{line: 417, col: 5, offset: 10094},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 415, col: 5, offset: 9933},
+							pos:        position{line: 417, col: 5, offset: 10094},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 416, col: 5, offset: 9979},
+						pos: position{line: 418, col: 5, offset: 10140},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 416, col: 5, offset: 9979},
+							pos: position{line: 418, col: 5, offset: 10140},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 416, col: 5, offset: 9979},
+									pos:   position{line: 418, col: 5, offset: 10140},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 416, col: 9, offset: 9983},
+										pos:  position{line: 418, col: 9, offset: 10144},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 416, col: 16, offset: 9990},
+									pos: position{line: 418, col: 16, offset: 10151},
 									expr: &ruleRefExpr{
-										pos:  position{line: 416, col: 16, offset: 9990},
+										pos:  position{line: 418, col: 16, offset: 10151},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 416, col: 19, offset: 9993},
+									pos:  position{line: 418, col: 19, offset: 10154},
 									name: "hour_abbrev",
 								},
 							},
@@ -3199,42 +3190,42 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 418, col: 1, offset: 10051},
+			pos:  position{line: 420, col: 1, offset: 10212},
 			expr: &choiceExpr{
-				pos: position{line: 419, col: 5, offset: 10060},
+				pos: position{line: 421, col: 5, offset: 10221},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 419, col: 5, offset: 10060},
+						pos: position{line: 421, col: 5, offset: 10221},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 419, col: 5, offset: 10060},
+							pos:        position{line: 421, col: 5, offset: 10221},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 420, col: 5, offset: 10108},
+						pos: position{line: 422, col: 5, offset: 10269},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 420, col: 5, offset: 10108},
+							pos: position{line: 422, col: 5, offset: 10269},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 420, col: 5, offset: 10108},
+									pos:   position{line: 422, col: 5, offset: 10269},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 420, col: 9, offset: 10112},
+										pos:  position{line: 422, col: 9, offset: 10273},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 420, col: 16, offset: 10119},
+									pos: position{line: 422, col: 16, offset: 10280},
 									expr: &ruleRefExpr{
-										pos:  position{line: 420, col: 16, offset: 10119},
+										pos:  position{line: 422, col: 16, offset: 10280},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 420, col: 19, offset: 10122},
+									pos:  position{line: 422, col: 19, offset: 10283},
 									name: "day_abbrev",
 								},
 							},
@@ -3245,30 +3236,30 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 422, col: 1, offset: 10182},
+			pos:  position{line: 424, col: 1, offset: 10343},
 			expr: &actionExpr{
-				pos: position{line: 423, col: 5, offset: 10192},
+				pos: position{line: 425, col: 5, offset: 10353},
 				run: (*parser).callonweeks1,
 				expr: &seqExpr{
-					pos: position{line: 423, col: 5, offset: 10192},
+					pos: position{line: 425, col: 5, offset: 10353},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 423, col: 5, offset: 10192},
+							pos:   position{line: 425, col: 5, offset: 10353},
 							label: "num",
 							expr: &ruleRefExpr{
-								pos:  position{line: 423, col: 9, offset: 10196},
+								pos:  position{line: 425, col: 9, offset: 10357},
 								name: "number",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 423, col: 16, offset: 10203},
+							pos: position{line: 425, col: 16, offset: 10364},
 							expr: &ruleRefExpr{
-								pos:  position{line: 423, col: 16, offset: 10203},
+								pos:  position{line: 425, col: 16, offset: 10364},
 								name: "_",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 423, col: 19, offset: 10206},
+							pos:  position{line: 425, col: 19, offset: 10367},
 							name: "week_abbrev",
 						},
 					},
@@ -3277,53 +3268,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 425, col: 1, offset: 10269},
+			pos:  position{line: 427, col: 1, offset: 10430},
 			expr: &ruleRefExpr{
-				pos:  position{line: 425, col: 10, offset: 10278},
+				pos:  position{line: 427, col: 10, offset: 10439},
 				name: "integer",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 429, col: 1, offset: 10316},
+			pos:  position{line: 431, col: 1, offset: 10477},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 10325},
+				pos: position{line: 432, col: 5, offset: 10486},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 430, col: 5, offset: 10325},
+					pos:   position{line: 432, col: 5, offset: 10486},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 430, col: 8, offset: 10328},
+						pos: position{line: 432, col: 8, offset: 10489},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 430, col: 8, offset: 10328},
+								pos:  position{line: 432, col: 8, offset: 10489},
 								name: "integer",
 							},
 							&litMatcher{
-								pos:        position{line: 430, col: 16, offset: 10336},
+								pos:        position{line: 432, col: 16, offset: 10497},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 430, col: 20, offset: 10340},
+								pos:  position{line: 432, col: 20, offset: 10501},
 								name: "integer",
 							},
 							&litMatcher{
-								pos:        position{line: 430, col: 28, offset: 10348},
+								pos:        position{line: 432, col: 28, offset: 10509},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 430, col: 32, offset: 10352},
+								pos:  position{line: 432, col: 32, offset: 10513},
 								name: "integer",
 							},
 							&litMatcher{
-								pos:        position{line: 430, col: 40, offset: 10360},
+								pos:        position{line: 432, col: 40, offset: 10521},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 430, col: 44, offset: 10364},
+								pos:  position{line: 432, col: 44, offset: 10525},
 								name: "integer",
 							},
 						},
@@ -3333,23 +3324,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 432, col: 1, offset: 10405},
+			pos:  position{line: 434, col: 1, offset: 10566},
 			expr: &actionExpr{
-				pos: position{line: 433, col: 5, offset: 10414},
+				pos: position{line: 435, col: 5, offset: 10575},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 433, col: 5, offset: 10414},
+					pos: position{line: 435, col: 5, offset: 10575},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 433, col: 5, offset: 10414},
+							pos:        position{line: 435, col: 5, offset: 10575},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 433, col: 9, offset: 10418},
+							pos:   position{line: 435, col: 9, offset: 10579},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 433, col: 11, offset: 10420},
+								pos:  position{line: 435, col: 11, offset: 10581},
 								name: "sinteger",
 							},
 						},
@@ -3359,32 +3350,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 437, col: 1, offset: 10579},
+			pos:  position{line: 439, col: 1, offset: 10740},
 			expr: &choiceExpr{
-				pos: position{line: 438, col: 5, offset: 10591},
+				pos: position{line: 440, col: 5, offset: 10752},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 438, col: 5, offset: 10591},
+						pos: position{line: 440, col: 5, offset: 10752},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 438, col: 5, offset: 10591},
+							pos: position{line: 440, col: 5, offset: 10752},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 438, col: 5, offset: 10591},
+									pos:   position{line: 440, col: 5, offset: 10752},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 438, col: 7, offset: 10593},
+										pos: position{line: 440, col: 7, offset: 10754},
 										expr: &ruleRefExpr{
-											pos:  position{line: 438, col: 8, offset: 10594},
+											pos:  position{line: 440, col: 8, offset: 10755},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 438, col: 20, offset: 10606},
+									pos:   position{line: 440, col: 20, offset: 10767},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 438, col: 22, offset: 10608},
+										pos:  position{line: 440, col: 22, offset: 10769},
 										name: "ip6tail",
 									},
 								},
@@ -3392,51 +3383,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 441, col: 5, offset: 10672},
+						pos: position{line: 443, col: 5, offset: 10833},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 441, col: 5, offset: 10672},
+							pos: position{line: 443, col: 5, offset: 10833},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 441, col: 5, offset: 10672},
+									pos:   position{line: 443, col: 5, offset: 10833},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 441, col: 7, offset: 10674},
+										pos:  position{line: 443, col: 7, offset: 10835},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 441, col: 11, offset: 10678},
+									pos:   position{line: 443, col: 11, offset: 10839},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 441, col: 13, offset: 10680},
+										pos: position{line: 443, col: 13, offset: 10841},
 										expr: &ruleRefExpr{
-											pos:  position{line: 441, col: 14, offset: 10681},
+											pos:  position{line: 443, col: 14, offset: 10842},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 441, col: 25, offset: 10692},
+									pos:        position{line: 443, col: 25, offset: 10853},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 441, col: 30, offset: 10697},
+									pos:   position{line: 443, col: 30, offset: 10858},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 441, col: 32, offset: 10699},
+										pos: position{line: 443, col: 32, offset: 10860},
 										expr: &ruleRefExpr{
-											pos:  position{line: 441, col: 33, offset: 10700},
+											pos:  position{line: 443, col: 33, offset: 10861},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 441, col: 45, offset: 10712},
+									pos:   position{line: 443, col: 45, offset: 10873},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 441, col: 47, offset: 10714},
+										pos:  position{line: 443, col: 47, offset: 10875},
 										name: "ip6tail",
 									},
 								},
@@ -3444,32 +3435,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 444, col: 5, offset: 10813},
+						pos: position{line: 446, col: 5, offset: 10974},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 444, col: 5, offset: 10813},
+							pos: position{line: 446, col: 5, offset: 10974},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 444, col: 5, offset: 10813},
+									pos:        position{line: 446, col: 5, offset: 10974},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 444, col: 10, offset: 10818},
+									pos:   position{line: 446, col: 10, offset: 10979},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 444, col: 12, offset: 10820},
+										pos: position{line: 446, col: 12, offset: 10981},
 										expr: &ruleRefExpr{
-											pos:  position{line: 444, col: 13, offset: 10821},
+											pos:  position{line: 446, col: 13, offset: 10982},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 444, col: 25, offset: 10833},
+									pos:   position{line: 446, col: 25, offset: 10994},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 444, col: 27, offset: 10835},
+										pos:  position{line: 446, col: 27, offset: 10996},
 										name: "ip6tail",
 									},
 								},
@@ -3477,32 +3468,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 447, col: 5, offset: 10906},
+						pos: position{line: 449, col: 5, offset: 11067},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 447, col: 5, offset: 10906},
+							pos: position{line: 449, col: 5, offset: 11067},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 447, col: 5, offset: 10906},
+									pos:   position{line: 449, col: 5, offset: 11067},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 447, col: 7, offset: 10908},
+										pos:  position{line: 449, col: 7, offset: 11069},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 447, col: 11, offset: 10912},
+									pos:   position{line: 449, col: 11, offset: 11073},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 447, col: 13, offset: 10914},
+										pos: position{line: 449, col: 13, offset: 11075},
 										expr: &ruleRefExpr{
-											pos:  position{line: 447, col: 14, offset: 10915},
+											pos:  position{line: 449, col: 14, offset: 11076},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 447, col: 25, offset: 10926},
+									pos:        position{line: 449, col: 25, offset: 11087},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -3510,10 +3501,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 450, col: 5, offset: 10994},
+						pos: position{line: 452, col: 5, offset: 11155},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 450, col: 5, offset: 10994},
+							pos:        position{line: 452, col: 5, offset: 11155},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -3523,16 +3514,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 454, col: 1, offset: 11031},
+			pos:  position{line: 456, col: 1, offset: 11192},
 			expr: &choiceExpr{
-				pos: position{line: 455, col: 5, offset: 11043},
+				pos: position{line: 457, col: 5, offset: 11204},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 455, col: 5, offset: 11043},
+						pos:  position{line: 457, col: 5, offset: 11204},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 456, col: 5, offset: 11052},
+						pos:  position{line: 458, col: 5, offset: 11213},
 						name: "h16",
 					},
 				},
@@ -3540,23 +3531,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 458, col: 1, offset: 11057},
+			pos:  position{line: 460, col: 1, offset: 11218},
 			expr: &actionExpr{
-				pos: position{line: 458, col: 12, offset: 11068},
+				pos: position{line: 460, col: 12, offset: 11229},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 458, col: 12, offset: 11068},
+					pos: position{line: 460, col: 12, offset: 11229},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 458, col: 12, offset: 11068},
+							pos:        position{line: 460, col: 12, offset: 11229},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 458, col: 16, offset: 11072},
+							pos:   position{line: 460, col: 16, offset: 11233},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 458, col: 18, offset: 11074},
+								pos:  position{line: 460, col: 18, offset: 11235},
 								name: "h16",
 							},
 						},
@@ -3566,23 +3557,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 459, col: 1, offset: 11111},
+			pos:  position{line: 461, col: 1, offset: 11272},
 			expr: &actionExpr{
-				pos: position{line: 459, col: 13, offset: 11123},
+				pos: position{line: 461, col: 13, offset: 11284},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 459, col: 13, offset: 11123},
+					pos: position{line: 461, col: 13, offset: 11284},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 459, col: 13, offset: 11123},
+							pos:   position{line: 461, col: 13, offset: 11284},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 15, offset: 11125},
+								pos:  position{line: 461, col: 15, offset: 11286},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 459, col: 19, offset: 11129},
+							pos:        position{line: 461, col: 19, offset: 11290},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -3592,43 +3583,43 @@ var g = &grammar{
 		},
 		{
 			name: "sub_addr",
-			pos:  position{line: 461, col: 1, offset: 11167},
+			pos:  position{line: 463, col: 1, offset: 11328},
 			expr: &choiceExpr{
-				pos: position{line: 462, col: 5, offset: 11180},
+				pos: position{line: 464, col: 5, offset: 11341},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 462, col: 5, offset: 11180},
+						pos:  position{line: 464, col: 5, offset: 11341},
 						name: "addr",
 					},
 					&actionExpr{
-						pos: position{line: 463, col: 5, offset: 11189},
+						pos: position{line: 465, col: 5, offset: 11350},
 						run: (*parser).callonsub_addr3,
 						expr: &labeledExpr{
-							pos:   position{line: 463, col: 5, offset: 11189},
+							pos:   position{line: 465, col: 5, offset: 11350},
 							label: "a",
 							expr: &seqExpr{
-								pos: position{line: 463, col: 8, offset: 11192},
+								pos: position{line: 465, col: 8, offset: 11353},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 463, col: 8, offset: 11192},
+										pos:  position{line: 465, col: 8, offset: 11353},
 										name: "integer",
 									},
 									&litMatcher{
-										pos:        position{line: 463, col: 16, offset: 11200},
+										pos:        position{line: 465, col: 16, offset: 11361},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 463, col: 20, offset: 11204},
+										pos:  position{line: 465, col: 20, offset: 11365},
 										name: "integer",
 									},
 									&litMatcher{
-										pos:        position{line: 463, col: 28, offset: 11212},
+										pos:        position{line: 465, col: 28, offset: 11373},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 463, col: 32, offset: 11216},
+										pos:  position{line: 465, col: 32, offset: 11377},
 										name: "integer",
 									},
 								},
@@ -3636,25 +3627,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 464, col: 5, offset: 11268},
+						pos: position{line: 466, col: 5, offset: 11429},
 						run: (*parser).callonsub_addr11,
 						expr: &labeledExpr{
-							pos:   position{line: 464, col: 5, offset: 11268},
+							pos:   position{line: 466, col: 5, offset: 11429},
 							label: "a",
 							expr: &seqExpr{
-								pos: position{line: 464, col: 8, offset: 11271},
+								pos: position{line: 466, col: 8, offset: 11432},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 464, col: 8, offset: 11271},
+										pos:  position{line: 466, col: 8, offset: 11432},
 										name: "integer",
 									},
 									&litMatcher{
-										pos:        position{line: 464, col: 16, offset: 11279},
+										pos:        position{line: 466, col: 16, offset: 11440},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 464, col: 20, offset: 11283},
+										pos:  position{line: 466, col: 20, offset: 11444},
 										name: "integer",
 									},
 								},
@@ -3662,13 +3653,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 465, col: 5, offset: 11337},
+						pos: position{line: 467, col: 5, offset: 11498},
 						run: (*parser).callonsub_addr17,
 						expr: &labeledExpr{
-							pos:   position{line: 465, col: 5, offset: 11337},
+							pos:   position{line: 467, col: 5, offset: 11498},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 465, col: 7, offset: 11339},
+								pos:  position{line: 467, col: 7, offset: 11500},
 								name: "integer",
 							},
 						},
@@ -3678,31 +3669,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 467, col: 1, offset: 11390},
+			pos:  position{line: 469, col: 1, offset: 11551},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 5, offset: 11401},
+				pos: position{line: 470, col: 5, offset: 11562},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 468, col: 5, offset: 11401},
+					pos: position{line: 470, col: 5, offset: 11562},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 468, col: 5, offset: 11401},
+							pos:   position{line: 470, col: 5, offset: 11562},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 7, offset: 11403},
+								pos:  position{line: 470, col: 7, offset: 11564},
 								name: "sub_addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 16, offset: 11412},
+							pos:        position{line: 470, col: 16, offset: 11573},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 20, offset: 11416},
+							pos:   position{line: 470, col: 20, offset: 11577},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 468, col: 22, offset: 11418},
+								pos:  position{line: 470, col: 22, offset: 11579},
 								name: "integer",
 							},
 						},
@@ -3712,31 +3703,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 472, col: 1, offset: 11494},
+			pos:  position{line: 474, col: 1, offset: 11655},
 			expr: &actionExpr{
-				pos: position{line: 473, col: 5, offset: 11508},
+				pos: position{line: 475, col: 5, offset: 11669},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 473, col: 5, offset: 11508},
+					pos: position{line: 475, col: 5, offset: 11669},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 473, col: 5, offset: 11508},
+							pos:   position{line: 475, col: 5, offset: 11669},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 473, col: 7, offset: 11510},
+								pos:  position{line: 475, col: 7, offset: 11671},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 473, col: 15, offset: 11518},
+							pos:        position{line: 475, col: 15, offset: 11679},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 473, col: 19, offset: 11522},
+							pos:   position{line: 475, col: 19, offset: 11683},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 473, col: 21, offset: 11524},
+								pos:  position{line: 475, col: 21, offset: 11685},
 								name: "integer",
 							},
 						},
@@ -3746,15 +3737,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 477, col: 1, offset: 11590},
+			pos:  position{line: 479, col: 1, offset: 11751},
 			expr: &actionExpr{
-				pos: position{line: 478, col: 5, offset: 11602},
+				pos: position{line: 480, col: 5, offset: 11763},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 478, col: 5, offset: 11602},
+					pos:   position{line: 480, col: 5, offset: 11763},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 478, col: 7, offset: 11604},
+						pos:  position{line: 480, col: 7, offset: 11765},
 						name: "sinteger",
 					},
 				},
@@ -3762,17 +3753,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 482, col: 1, offset: 11648},
+			pos:  position{line: 484, col: 1, offset: 11809},
 			expr: &actionExpr{
-				pos: position{line: 483, col: 5, offset: 11661},
+				pos: position{line: 485, col: 5, offset: 11822},
 				run: (*parser).callonsinteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 483, col: 5, offset: 11661},
+					pos:   position{line: 485, col: 5, offset: 11822},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 483, col: 11, offset: 11667},
+						pos: position{line: 485, col: 11, offset: 11828},
 						expr: &charClassMatcher{
-							pos:        position{line: 483, col: 11, offset: 11667},
+							pos:        position{line: 485, col: 11, offset: 11828},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -3784,15 +3775,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 487, col: 1, offset: 11712},
+			pos:  position{line: 489, col: 1, offset: 11873},
 			expr: &actionExpr{
-				pos: position{line: 488, col: 5, offset: 11723},
+				pos: position{line: 490, col: 5, offset: 11884},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 488, col: 5, offset: 11723},
+					pos:   position{line: 490, col: 5, offset: 11884},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 488, col: 7, offset: 11725},
+						pos:  position{line: 490, col: 7, offset: 11886},
 						name: "sdouble",
 					},
 				},
@@ -3800,39 +3791,39 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 492, col: 1, offset: 11772},
+			pos:  position{line: 494, col: 1, offset: 11933},
 			expr: &choiceExpr{
-				pos: position{line: 493, col: 5, offset: 11784},
+				pos: position{line: 495, col: 5, offset: 11945},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 493, col: 5, offset: 11784},
+						pos: position{line: 495, col: 5, offset: 11945},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 493, col: 5, offset: 11784},
+							pos: position{line: 495, col: 5, offset: 11945},
 							exprs: []interface{}{
 								&oneOrMoreExpr{
-									pos: position{line: 493, col: 5, offset: 11784},
+									pos: position{line: 495, col: 5, offset: 11945},
 									expr: &ruleRefExpr{
-										pos:  position{line: 493, col: 5, offset: 11784},
+										pos:  position{line: 495, col: 5, offset: 11945},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 493, col: 20, offset: 11799},
+									pos:        position{line: 495, col: 20, offset: 11960},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 493, col: 24, offset: 11803},
+									pos: position{line: 495, col: 24, offset: 11964},
 									expr: &ruleRefExpr{
-										pos:  position{line: 493, col: 24, offset: 11803},
+										pos:  position{line: 495, col: 24, offset: 11964},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 493, col: 37, offset: 11816},
+									pos: position{line: 495, col: 37, offset: 11977},
 									expr: &ruleRefExpr{
-										pos:  position{line: 493, col: 37, offset: 11816},
+										pos:  position{line: 495, col: 37, offset: 11977},
 										name: "exponentPart",
 									},
 								},
@@ -3840,27 +3831,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 496, col: 5, offset: 11875},
+						pos: position{line: 498, col: 5, offset: 12036},
 						run: (*parser).callonsdouble11,
 						expr: &seqExpr{
-							pos: position{line: 496, col: 5, offset: 11875},
+							pos: position{line: 498, col: 5, offset: 12036},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 496, col: 5, offset: 11875},
+									pos:        position{line: 498, col: 5, offset: 12036},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 496, col: 9, offset: 11879},
+									pos: position{line: 498, col: 9, offset: 12040},
 									expr: &ruleRefExpr{
-										pos:  position{line: 496, col: 9, offset: 11879},
+										pos:  position{line: 498, col: 9, offset: 12040},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 496, col: 22, offset: 11892},
+									pos: position{line: 498, col: 22, offset: 12053},
 									expr: &ruleRefExpr{
-										pos:  position{line: 496, col: 22, offset: 11892},
+										pos:  position{line: 498, col: 22, offset: 12053},
 										name: "exponentPart",
 									},
 								},
@@ -3872,29 +3863,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 500, col: 1, offset: 11948},
+			pos:  position{line: 502, col: 1, offset: 12109},
 			expr: &choiceExpr{
-				pos: position{line: 501, col: 5, offset: 11966},
+				pos: position{line: 503, col: 5, offset: 12127},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 501, col: 5, offset: 11966},
+						pos:        position{line: 503, col: 5, offset: 12127},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 502, col: 5, offset: 11974},
+						pos: position{line: 504, col: 5, offset: 12135},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 502, col: 5, offset: 11974},
+								pos:        position{line: 504, col: 5, offset: 12135},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 502, col: 11, offset: 11980},
+								pos: position{line: 504, col: 11, offset: 12141},
 								expr: &charClassMatcher{
-									pos:        position{line: 502, col: 11, offset: 11980},
+									pos:        position{line: 504, col: 11, offset: 12141},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -3908,9 +3899,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 504, col: 1, offset: 11988},
+			pos:  position{line: 506, col: 1, offset: 12149},
 			expr: &charClassMatcher{
-				pos:        position{line: 504, col: 15, offset: 12002},
+				pos:        position{line: 506, col: 15, offset: 12163},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -3919,14 +3910,14 @@ var g = &grammar{
 		},
 		{
 			name: "signedInteger",
-			pos:  position{line: 506, col: 1, offset: 12009},
+			pos:  position{line: 508, col: 1, offset: 12170},
 			expr: &seqExpr{
-				pos: position{line: 506, col: 17, offset: 12025},
+				pos: position{line: 508, col: 17, offset: 12186},
 				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 506, col: 17, offset: 12025},
+						pos: position{line: 508, col: 17, offset: 12186},
 						expr: &charClassMatcher{
-							pos:        position{line: 506, col: 17, offset: 12025},
+							pos:        position{line: 508, col: 17, offset: 12186},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -3934,9 +3925,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 506, col: 23, offset: 12031},
+						pos: position{line: 508, col: 23, offset: 12192},
 						expr: &ruleRefExpr{
-							pos:  position{line: 506, col: 23, offset: 12031},
+							pos:  position{line: 508, col: 23, offset: 12192},
 							name: "doubleDigit",
 						},
 					},
@@ -3945,17 +3936,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 508, col: 1, offset: 12045},
+			pos:  position{line: 510, col: 1, offset: 12206},
 			expr: &seqExpr{
-				pos: position{line: 508, col: 16, offset: 12060},
+				pos: position{line: 510, col: 16, offset: 12221},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 508, col: 16, offset: 12060},
+						pos:        position{line: 510, col: 16, offset: 12221},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 508, col: 21, offset: 12065},
+						pos:  position{line: 510, col: 21, offset: 12226},
 						name: "signedInteger",
 					},
 				},
@@ -3963,17 +3954,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 510, col: 1, offset: 12080},
+			pos:  position{line: 512, col: 1, offset: 12241},
 			expr: &actionExpr{
-				pos: position{line: 510, col: 7, offset: 12086},
+				pos: position{line: 512, col: 7, offset: 12247},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 510, col: 7, offset: 12086},
+					pos:   position{line: 512, col: 7, offset: 12247},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 510, col: 13, offset: 12092},
+						pos: position{line: 512, col: 13, offset: 12253},
 						expr: &ruleRefExpr{
-							pos:  position{line: 510, col: 13, offset: 12092},
+							pos:  position{line: 512, col: 13, offset: 12253},
 							name: "hexdigit",
 						},
 					},
@@ -3982,9 +3973,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 512, col: 1, offset: 12134},
+			pos:  position{line: 514, col: 1, offset: 12295},
 			expr: &charClassMatcher{
-				pos:        position{line: 512, col: 12, offset: 12145},
+				pos:        position{line: 514, col: 12, offset: 12306},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -3994,17 +3985,17 @@ var g = &grammar{
 		{
 			name:        "boomWord",
 			displayName: "\"boomWord\"",
-			pos:         position{line: 514, col: 1, offset: 12158},
+			pos:         position{line: 516, col: 1, offset: 12319},
 			expr: &actionExpr{
-				pos: position{line: 514, col: 23, offset: 12180},
+				pos: position{line: 516, col: 23, offset: 12341},
 				run: (*parser).callonboomWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 514, col: 23, offset: 12180},
+					pos:   position{line: 516, col: 23, offset: 12341},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 514, col: 29, offset: 12186},
+						pos: position{line: 516, col: 29, offset: 12347},
 						expr: &ruleRefExpr{
-							pos:  position{line: 514, col: 29, offset: 12186},
+							pos:  position{line: 516, col: 29, offset: 12347},
 							name: "boomWordPart",
 						},
 					},
@@ -4013,26 +4004,26 @@ var g = &grammar{
 		},
 		{
 			name: "boomWordPart",
-			pos:  position{line: 516, col: 1, offset: 12234},
+			pos:  position{line: 518, col: 1, offset: 12395},
 			expr: &choiceExpr{
-				pos: position{line: 517, col: 5, offset: 12251},
+				pos: position{line: 519, col: 5, offset: 12412},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 517, col: 5, offset: 12251},
+						pos: position{line: 519, col: 5, offset: 12412},
 						run: (*parser).callonboomWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 517, col: 5, offset: 12251},
+							pos: position{line: 519, col: 5, offset: 12412},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 517, col: 5, offset: 12251},
+									pos:        position{line: 519, col: 5, offset: 12412},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 517, col: 10, offset: 12256},
+									pos:   position{line: 519, col: 10, offset: 12417},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 517, col: 12, offset: 12258},
+										pos:  position{line: 519, col: 12, offset: 12419},
 										name: "escapeSequence",
 									},
 								},
@@ -4040,18 +4031,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 518, col: 5, offset: 12296},
+						pos: position{line: 520, col: 5, offset: 12457},
 						run: (*parser).callonboomWordPart7,
 						expr: &seqExpr{
-							pos: position{line: 518, col: 5, offset: 12296},
+							pos: position{line: 520, col: 5, offset: 12457},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 518, col: 5, offset: 12296},
+									pos: position{line: 520, col: 5, offset: 12457},
 									expr: &choiceExpr{
-										pos: position{line: 518, col: 7, offset: 12298},
+										pos: position{line: 520, col: 7, offset: 12459},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 518, col: 7, offset: 12298},
+												pos:        position{line: 520, col: 7, offset: 12459},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -4059,14 +4050,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 518, col: 42, offset: 12333},
+												pos:  position{line: 520, col: 42, offset: 12494},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 518, col: 46, offset: 12337,
+									line: 520, col: 46, offset: 12498,
 								},
 							},
 						},
@@ -4076,34 +4067,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 520, col: 1, offset: 12371},
+			pos:  position{line: 522, col: 1, offset: 12532},
 			expr: &choiceExpr{
-				pos: position{line: 521, col: 5, offset: 12388},
+				pos: position{line: 523, col: 5, offset: 12549},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 521, col: 5, offset: 12388},
+						pos: position{line: 523, col: 5, offset: 12549},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 521, col: 5, offset: 12388},
+							pos: position{line: 523, col: 5, offset: 12549},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 521, col: 5, offset: 12388},
+									pos:        position{line: 523, col: 5, offset: 12549},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 521, col: 9, offset: 12392},
+									pos:   position{line: 523, col: 9, offset: 12553},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 521, col: 11, offset: 12394},
+										pos: position{line: 523, col: 11, offset: 12555},
 										expr: &ruleRefExpr{
-											pos:  position{line: 521, col: 11, offset: 12394},
+											pos:  position{line: 523, col: 11, offset: 12555},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 521, col: 29, offset: 12412},
+									pos:        position{line: 523, col: 29, offset: 12573},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -4111,29 +4102,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 522, col: 5, offset: 12449},
+						pos: position{line: 524, col: 5, offset: 12610},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 522, col: 5, offset: 12449},
+							pos: position{line: 524, col: 5, offset: 12610},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 522, col: 5, offset: 12449},
+									pos:        position{line: 524, col: 5, offset: 12610},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 522, col: 9, offset: 12453},
+									pos:   position{line: 524, col: 9, offset: 12614},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 522, col: 11, offset: 12455},
+										pos: position{line: 524, col: 11, offset: 12616},
 										expr: &ruleRefExpr{
-											pos:  position{line: 522, col: 11, offset: 12455},
+											pos:  position{line: 524, col: 11, offset: 12616},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 522, col: 29, offset: 12473},
+									pos:        position{line: 524, col: 29, offset: 12634},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -4145,55 +4136,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 524, col: 1, offset: 12507},
+			pos:  position{line: 526, col: 1, offset: 12668},
 			expr: &choiceExpr{
-				pos: position{line: 525, col: 5, offset: 12528},
+				pos: position{line: 527, col: 5, offset: 12689},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 525, col: 5, offset: 12528},
+						pos: position{line: 527, col: 5, offset: 12689},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 525, col: 5, offset: 12528},
+							pos: position{line: 527, col: 5, offset: 12689},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 525, col: 5, offset: 12528},
+									pos: position{line: 527, col: 5, offset: 12689},
 									expr: &choiceExpr{
-										pos: position{line: 525, col: 7, offset: 12530},
+										pos: position{line: 527, col: 7, offset: 12691},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 525, col: 7, offset: 12530},
+												pos:        position{line: 527, col: 7, offset: 12691},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 525, col: 13, offset: 12536},
+												pos:  position{line: 527, col: 13, offset: 12697},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 525, col: 26, offset: 12549,
+									line: 527, col: 26, offset: 12710,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 526, col: 5, offset: 12586},
+						pos: position{line: 528, col: 5, offset: 12747},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 526, col: 5, offset: 12586},
+							pos: position{line: 528, col: 5, offset: 12747},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 526, col: 5, offset: 12586},
+									pos:        position{line: 528, col: 5, offset: 12747},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 526, col: 10, offset: 12591},
+									pos:   position{line: 528, col: 10, offset: 12752},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 526, col: 12, offset: 12593},
+										pos:  position{line: 528, col: 12, offset: 12754},
 										name: "escapeSequence",
 									},
 								},
@@ -4205,55 +4196,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 528, col: 1, offset: 12627},
+			pos:  position{line: 530, col: 1, offset: 12788},
 			expr: &choiceExpr{
-				pos: position{line: 529, col: 5, offset: 12648},
+				pos: position{line: 531, col: 5, offset: 12809},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 529, col: 5, offset: 12648},
+						pos: position{line: 531, col: 5, offset: 12809},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 529, col: 5, offset: 12648},
+							pos: position{line: 531, col: 5, offset: 12809},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 529, col: 5, offset: 12648},
+									pos: position{line: 531, col: 5, offset: 12809},
 									expr: &choiceExpr{
-										pos: position{line: 529, col: 7, offset: 12650},
+										pos: position{line: 531, col: 7, offset: 12811},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 529, col: 7, offset: 12650},
+												pos:        position{line: 531, col: 7, offset: 12811},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 529, col: 13, offset: 12656},
+												pos:  position{line: 531, col: 13, offset: 12817},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 529, col: 26, offset: 12669,
+									line: 531, col: 26, offset: 12830,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 530, col: 5, offset: 12706},
+						pos: position{line: 532, col: 5, offset: 12867},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 530, col: 5, offset: 12706},
+							pos: position{line: 532, col: 5, offset: 12867},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 530, col: 5, offset: 12706},
+									pos:        position{line: 532, col: 5, offset: 12867},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 530, col: 10, offset: 12711},
+									pos:   position{line: 532, col: 10, offset: 12872},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 530, col: 12, offset: 12713},
+										pos:  position{line: 532, col: 12, offset: 12874},
 										name: "escapeSequence",
 									},
 								},
@@ -4265,38 +4256,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 532, col: 1, offset: 12747},
+			pos:  position{line: 534, col: 1, offset: 12908},
 			expr: &choiceExpr{
-				pos: position{line: 533, col: 5, offset: 12766},
+				pos: position{line: 535, col: 5, offset: 12927},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 533, col: 5, offset: 12766},
+						pos: position{line: 535, col: 5, offset: 12927},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 533, col: 5, offset: 12766},
+							pos: position{line: 535, col: 5, offset: 12927},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 533, col: 5, offset: 12766},
+									pos:        position{line: 535, col: 5, offset: 12927},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 9, offset: 12770},
+									pos:  position{line: 535, col: 9, offset: 12931},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 18, offset: 12779},
+									pos:  position{line: 535, col: 18, offset: 12940},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 534, col: 5, offset: 12830},
+						pos:  position{line: 536, col: 5, offset: 12991},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 535, col: 5, offset: 12851},
+						pos:  position{line: 537, col: 5, offset: 13012},
 						name: "unicodeEscape",
 					},
 				},
@@ -4304,75 +4295,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 537, col: 1, offset: 12866},
+			pos:  position{line: 539, col: 1, offset: 13027},
 			expr: &choiceExpr{
-				pos: position{line: 538, col: 5, offset: 12887},
+				pos: position{line: 540, col: 5, offset: 13048},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 538, col: 5, offset: 12887},
+						pos:        position{line: 540, col: 5, offset: 13048},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 539, col: 5, offset: 12895},
+						pos:        position{line: 541, col: 5, offset: 13056},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 540, col: 5, offset: 12903},
+						pos:        position{line: 542, col: 5, offset: 13064},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 12912},
+						pos: position{line: 543, col: 5, offset: 13073},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 541, col: 5, offset: 12912},
+							pos:        position{line: 543, col: 5, offset: 13073},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 12941},
+						pos: position{line: 544, col: 5, offset: 13102},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 542, col: 5, offset: 12941},
+							pos:        position{line: 544, col: 5, offset: 13102},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 543, col: 5, offset: 12970},
+						pos: position{line: 545, col: 5, offset: 13131},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 543, col: 5, offset: 12970},
+							pos:        position{line: 545, col: 5, offset: 13131},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 544, col: 5, offset: 12999},
+						pos: position{line: 546, col: 5, offset: 13160},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 544, col: 5, offset: 12999},
+							pos:        position{line: 546, col: 5, offset: 13160},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 545, col: 5, offset: 13028},
+						pos: position{line: 547, col: 5, offset: 13189},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 545, col: 5, offset: 13028},
+							pos:        position{line: 547, col: 5, offset: 13189},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 5, offset: 13057},
+						pos: position{line: 548, col: 5, offset: 13218},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 546, col: 5, offset: 13057},
+							pos:        position{line: 548, col: 5, offset: 13218},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -4382,29 +4373,29 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 548, col: 1, offset: 13083},
+			pos:  position{line: 550, col: 1, offset: 13244},
 			expr: &seqExpr{
-				pos: position{line: 549, col: 5, offset: 13101},
+				pos: position{line: 551, col: 5, offset: 13262},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 549, col: 5, offset: 13101},
+						pos:        position{line: 551, col: 5, offset: 13262},
 						val:        "u",
 						ignoreCase: false,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 9, offset: 13105},
+						pos:  position{line: 551, col: 9, offset: 13266},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 18, offset: 13114},
+						pos:  position{line: 551, col: 18, offset: 13275},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 27, offset: 13123},
+						pos:  position{line: 551, col: 27, offset: 13284},
 						name: "hexdigit",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 36, offset: 13132},
+						pos:  position{line: 551, col: 36, offset: 13293},
 						name: "hexdigit",
 					},
 				},
@@ -4412,28 +4403,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 551, col: 1, offset: 13142},
+			pos:  position{line: 553, col: 1, offset: 13303},
 			expr: &actionExpr{
-				pos: position{line: 552, col: 5, offset: 13155},
+				pos: position{line: 554, col: 5, offset: 13316},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 552, col: 5, offset: 13155},
+					pos: position{line: 554, col: 5, offset: 13316},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 552, col: 5, offset: 13155},
+							pos:        position{line: 554, col: 5, offset: 13316},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 552, col: 9, offset: 13159},
+							pos:   position{line: 554, col: 9, offset: 13320},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 552, col: 11, offset: 13161},
+								pos:  position{line: 554, col: 11, offset: 13322},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 552, col: 18, offset: 13168},
+							pos:        position{line: 554, col: 18, offset: 13329},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4443,24 +4434,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 554, col: 1, offset: 13191},
+			pos:  position{line: 556, col: 1, offset: 13352},
 			expr: &actionExpr{
-				pos: position{line: 555, col: 5, offset: 13202},
+				pos: position{line: 557, col: 5, offset: 13363},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 555, col: 5, offset: 13202},
+					pos: position{line: 557, col: 5, offset: 13363},
 					expr: &choiceExpr{
-						pos: position{line: 555, col: 6, offset: 13203},
+						pos: position{line: 557, col: 6, offset: 13364},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 555, col: 6, offset: 13203},
+								pos:        position{line: 557, col: 6, offset: 13364},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 555, col: 13, offset: 13210},
+								pos:        position{line: 557, col: 13, offset: 13371},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -4471,9 +4462,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 557, col: 1, offset: 13250},
+			pos:  position{line: 559, col: 1, offset: 13411},
 			expr: &charClassMatcher{
-				pos:        position{line: 558, col: 5, offset: 13266},
+				pos:        position{line: 560, col: 5, offset: 13427},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -4483,37 +4474,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 560, col: 1, offset: 13281},
+			pos:  position{line: 562, col: 1, offset: 13442},
 			expr: &choiceExpr{
-				pos: position{line: 561, col: 5, offset: 13288},
+				pos: position{line: 563, col: 5, offset: 13449},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 561, col: 5, offset: 13288},
+						pos:        position{line: 563, col: 5, offset: 13449},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 562, col: 5, offset: 13297},
+						pos:        position{line: 564, col: 5, offset: 13458},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 563, col: 5, offset: 13306},
+						pos:        position{line: 565, col: 5, offset: 13467},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 564, col: 5, offset: 13315},
+						pos:        position{line: 566, col: 5, offset: 13476},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 565, col: 5, offset: 13323},
+						pos:        position{line: 567, col: 5, offset: 13484},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 566, col: 5, offset: 13336},
+						pos:        position{line: 568, col: 5, offset: 13497},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -4523,22 +4514,22 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 568, col: 1, offset: 13346},
+			pos:         position{line: 570, col: 1, offset: 13507},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 568, col: 18, offset: 13363},
+				pos: position{line: 570, col: 18, offset: 13524},
 				expr: &ruleRefExpr{
-					pos:  position{line: 568, col: 18, offset: 13363},
+					pos:  position{line: 570, col: 18, offset: 13524},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 570, col: 1, offset: 13368},
+			pos:  position{line: 572, col: 1, offset: 13529},
 			expr: &notExpr{
-				pos: position{line: 570, col: 7, offset: 13374},
+				pos: position{line: 572, col: 7, offset: 13535},
 				expr: &anyMatcher{
-					line: 570, col: 8, offset: 13375,
+					line: 572, col: 8, offset: 13536,
 				},
 			},
 		},
@@ -4724,64 +4715,58 @@ func (p *parser) callonsearchPred13() (interface{}, error) {
 	return p.cur.onsearchPred13(stack["fieldComparator"], stack["v"])
 }
 
-func (c *current) onsearchPred24() (interface{}, error) {
-	return makeBooleanLiteral(true), nil
+func (c *current) onsearchPred24(f, fieldComparator, v interface{}) (interface{}, error) {
+	return makeCompareField(fieldComparator, f, v), nil
 
 }
 
 func (p *parser) callonsearchPred24() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred24()
+	return p.cur.onsearchPred24(stack["f"], stack["fieldComparator"], stack["v"])
 }
 
-func (c *current) onsearchPred26(f, fieldComparator, v interface{}) (interface{}, error) {
-	return makeCompareField(fieldComparator, f, v), nil
-
-}
-
-func (p *parser) callonsearchPred26() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onsearchPred26(stack["f"], stack["fieldComparator"], stack["v"])
-}
-
-func (c *current) onsearchPred38(v interface{}) (interface{}, error) {
+func (c *current) onsearchPred36(v interface{}) (interface{}, error) {
 	return makeCompareAny("in", false, v), nil
 
 }
 
-func (p *parser) callonsearchPred38() (interface{}, error) {
+func (p *parser) callonsearchPred36() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred38(stack["v"])
+	return p.cur.onsearchPred36(stack["v"])
 }
 
-func (c *current) onsearchPred48(v, f interface{}) (interface{}, error) {
+func (c *current) onsearchPred46(v, f interface{}) (interface{}, error) {
 	return makeCompareField("in", f, v), nil
 
 }
 
-func (p *parser) callonsearchPred48() (interface{}, error) {
+func (p *parser) callonsearchPred46() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred48(stack["v"], stack["f"])
+	return p.cur.onsearchPred46(stack["v"], stack["f"])
 }
 
-func (c *current) onsearchPred59(v interface{}) (interface{}, error) {
-	ss := makeCompareAny("search", true, v)
+func (c *current) onsearchPred57(v interface{}) (interface{}, error) {
 	if getValueType(v) == "string" {
-		return makeOrChain(ss, []interface{}{makeCompareAny("searchin", true, v)}), nil
+		return makeOrChain(makeCompareAny("search", true, v), []interface{}{makeCompareAny("searchin", true, v)}), nil
 	}
-	ss = makeCompareAny("search", true, makeTypedValue("string", string(c.text)))
-	return makeOrChain(ss, []interface{}{makeCompareAny("searchin", true, makeTypedValue("string", string(c.text))), makeCompareAny("eql", true, v), makeCompareAny("in", true, v)}), nil
+	if getValueType(v) == "regexp" {
+		if string(c.text) == "*" {
+			return makeBooleanLiteral(true), nil
+		}
+		return makeOrChain(makeCompareAny("eql", true, v), []interface{}{makeCompareAny("in", true, v)}), nil
+	}
+
+	return makeOrChain(makeCompareAny("search", true, makeTypedValue("string", string(c.text))), []interface{}{makeCompareAny("searchin", true, makeTypedValue("string", string(c.text))), makeCompareAny("eql", true, v), makeCompareAny("in", true, v)}), nil
 
 }
 
-func (p *parser) callonsearchPred59() (interface{}, error) {
+func (p *parser) callonsearchPred57() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred59(stack["v"])
+	return p.cur.onsearchPred57(stack["v"])
 }
 
 func (c *current) onsearchValue2(v interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -200,65 +200,67 @@ function peg$parse(input, options) {
       peg$c29 = function(fieldComparator, v) {
             return makeCompareAny(fieldComparator, true, v)
           },
-      peg$c30 = function() {
-            return makeBooleanLiteral(true)
-          },
-      peg$c31 = function(f, fieldComparator, v) {
+      peg$c30 = function(f, fieldComparator, v) {
             return makeCompareField(fieldComparator, f, v)
           },
-      peg$c32 = function(v) {
+      peg$c31 = function(v) {
             return makeCompareAny("in", false, v)
           },
-      peg$c33 = function(v, f) {
+      peg$c32 = function(v, f) {
             return makeCompareField("in", f, v)
           },
-      peg$c34 = function(v) {
-            let ss =  makeCompareAny("search", true, v)
+      peg$c33 = function(v) {
             if (getValueType(v) == "string") {
-              return makeOrChain(ss, [makeCompareAny("searchin", true, v)])
+              return makeOrChain(makeCompareAny("search", true, v), [makeCompareAny("searchin", true, v)])
             }
-            ss = makeCompareAny("search", true, makeTypedValue("string", text()))
-            return makeOrChain(ss, [makeCompareAny("searchin", true, makeTypedValue("string", text())), makeCompareAny("eql", true, v), makeCompareAny("in", true, v)])
+            if (getValueType(v) == "regexp") {
+              if (text() == "*") {
+                return makeBooleanLiteral(true)
+              }
+              return makeOrChain(makeCompareAny("eql", true, v), [makeCompareAny("in", true, v)])
+            }
+
+            return makeOrChain(makeCompareAny("search", true, makeTypedValue("string", text())), [makeCompareAny("searchin", true, makeTypedValue("string", text())), makeCompareAny("eql", true, v), makeCompareAny("in", true, v)])
           },
-      peg$c35 = function(v) {
+      peg$c34 = function(v) {
             return makeTypedValue("string", v)
           },
-      peg$c36 = function(v) {
+      peg$c35 = function(v) {
             return makeTypedValue("regexp", v)
           },
-      peg$c37 = function(v) {
+      peg$c36 = function(v) {
             return makeTypedValue("port", v)
         },
-      peg$c38 = function(v) {
+      peg$c37 = function(v) {
             return makeTypedValue("subnet", v)
           },
-      peg$c39 = function(v) {
+      peg$c38 = function(v) {
             return makeTypedValue("addr", v)
           },
-      peg$c40 = function(v) {
+      peg$c39 = function(v) {
             return makeTypedValue("double", v)
           },
-      peg$c41 = function(v) {
+      peg$c40 = function(v) {
             return makeTypedValue("int", v)
           },
-      peg$c42 = function(v) { return v },
-      peg$c43 = function(v) {
+      peg$c41 = function(v) { return v },
+      peg$c42 = function(v) {
             if (reglob.IsGlobby(v) || v == "*") {
                let re =  reglob.Reglob(v)
                return makeTypedValue("regexp", re)
             }
             return makeTypedValue("string", v)
           },
-      peg$c44 = "true",
-      peg$c45 = peg$literalExpectation("true", false),
-      peg$c46 = function() { return makeTypedValue("bool", "true") },
-      peg$c47 = "false",
-      peg$c48 = peg$literalExpectation("false", false),
-      peg$c49 = function() { return makeTypedValue("bool", "false") },
-      peg$c50 = "nil",
-      peg$c51 = peg$literalExpectation("nil", false),
-      peg$c52 = function() { return makeTypedValue("unset", "") },
-      peg$c53 = function(first, rest) {
+      peg$c43 = "true",
+      peg$c44 = peg$literalExpectation("true", false),
+      peg$c45 = function() { return makeTypedValue("bool", "true") },
+      peg$c46 = "false",
+      peg$c47 = peg$literalExpectation("false", false),
+      peg$c48 = function() { return makeTypedValue("bool", "false") },
+      peg$c49 = "nil",
+      peg$c50 = peg$literalExpectation("nil", false),
+      peg$c51 = function() { return makeTypedValue("unset", "") },
+      peg$c52 = function(first, rest) {
             let fp =  makeSequentialProc(first)
             if ((rest)) {
               return makeParallelProc([fp, ... rest])
@@ -266,91 +268,91 @@ function peg$parse(input, options) {
               return fp
             }
           },
-      peg$c54 = ";",
-      peg$c55 = peg$literalExpectation(";", false),
-      peg$c56 = function(ch) { return makeSequentialProc(ch) },
-      peg$c57 = function(proc) {
+      peg$c53 = ";",
+      peg$c54 = peg$literalExpectation(";", false),
+      peg$c55 = function(ch) { return makeSequentialProc(ch) },
+      peg$c56 = function(proc) {
             return proc
           },
-      peg$c58 = "by",
-      peg$c59 = peg$literalExpectation("by", true),
-      peg$c60 = function(list) { return list },
-      peg$c61 = "every",
-      peg$c62 = peg$literalExpectation("every", true),
-      peg$c63 = function(dur) { return dur },
-      peg$c64 = "=",
-      peg$c65 = peg$literalExpectation("=", false),
-      peg$c66 = function() { return "eql" },
-      peg$c67 = "!=",
-      peg$c68 = peg$literalExpectation("!=", false),
-      peg$c69 = function() { return "neql" },
-      peg$c70 = "<=",
-      peg$c71 = peg$literalExpectation("<=", false),
-      peg$c72 = function() { return "lte" },
-      peg$c73 = ">=",
-      peg$c74 = peg$literalExpectation(">=", false),
-      peg$c75 = function() { return "gte" },
-      peg$c76 = "<",
-      peg$c77 = peg$literalExpectation("<", false),
-      peg$c78 = function() { return "lt" },
-      peg$c79 = ">",
-      peg$c80 = peg$literalExpectation(">", false),
-      peg$c81 = function() { return "gt" },
-      peg$c82 = "bool",
-      peg$c83 = peg$literalExpectation("bool", false),
-      peg$c84 = "int",
-      peg$c85 = peg$literalExpectation("int", false),
-      peg$c86 = "count",
-      peg$c87 = peg$literalExpectation("count", false),
-      peg$c88 = "double",
-      peg$c89 = peg$literalExpectation("double", false),
-      peg$c90 = "string",
-      peg$c91 = peg$literalExpectation("string", false),
-      peg$c92 = "addr",
-      peg$c93 = peg$literalExpectation("addr", false),
-      peg$c94 = "subnet",
-      peg$c95 = peg$literalExpectation("subnet", false),
-      peg$c96 = "port",
-      peg$c97 = peg$literalExpectation("port", false),
-      peg$c98 = "\u2014",
-      peg$c99 = peg$literalExpectation("\u2014", false),
-      peg$c100 = "\u2013",
-      peg$c101 = peg$literalExpectation("\u2013", false),
-      peg$c102 = "to",
-      peg$c103 = peg$literalExpectation("to", false),
-      peg$c104 = "and",
-      peg$c105 = peg$literalExpectation("and", false),
-      peg$c106 = "or",
-      peg$c107 = peg$literalExpectation("or", false),
-      peg$c108 = "in",
-      peg$c109 = peg$literalExpectation("in", false),
-      peg$c110 = "not",
-      peg$c111 = peg$literalExpectation("not", false),
-      peg$c112 = function() { return text() },
-      peg$c113 = /^[A-Za-z_$]/,
-      peg$c114 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c115 = /^[0-9]/,
-      peg$c116 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c117 = ".",
-      peg$c118 = peg$literalExpectation(".", false),
-      peg$c119 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
-      peg$c120 = "[",
-      peg$c121 = peg$literalExpectation("[", false),
-      peg$c122 = "]",
-      peg$c123 = peg$literalExpectation("]", false),
-      peg$c124 = function(base, index) { return makeFieldCall("Index", null, index) },
-      peg$c125 = function(base, derefs) {
+      peg$c57 = "by",
+      peg$c58 = peg$literalExpectation("by", true),
+      peg$c59 = function(list) { return list },
+      peg$c60 = "every",
+      peg$c61 = peg$literalExpectation("every", true),
+      peg$c62 = function(dur) { return dur },
+      peg$c63 = "=",
+      peg$c64 = peg$literalExpectation("=", false),
+      peg$c65 = function() { return "eql" },
+      peg$c66 = "!=",
+      peg$c67 = peg$literalExpectation("!=", false),
+      peg$c68 = function() { return "neql" },
+      peg$c69 = "<=",
+      peg$c70 = peg$literalExpectation("<=", false),
+      peg$c71 = function() { return "lte" },
+      peg$c72 = ">=",
+      peg$c73 = peg$literalExpectation(">=", false),
+      peg$c74 = function() { return "gte" },
+      peg$c75 = "<",
+      peg$c76 = peg$literalExpectation("<", false),
+      peg$c77 = function() { return "lt" },
+      peg$c78 = ">",
+      peg$c79 = peg$literalExpectation(">", false),
+      peg$c80 = function() { return "gt" },
+      peg$c81 = "bool",
+      peg$c82 = peg$literalExpectation("bool", false),
+      peg$c83 = "int",
+      peg$c84 = peg$literalExpectation("int", false),
+      peg$c85 = "count",
+      peg$c86 = peg$literalExpectation("count", false),
+      peg$c87 = "double",
+      peg$c88 = peg$literalExpectation("double", false),
+      peg$c89 = "string",
+      peg$c90 = peg$literalExpectation("string", false),
+      peg$c91 = "addr",
+      peg$c92 = peg$literalExpectation("addr", false),
+      peg$c93 = "subnet",
+      peg$c94 = peg$literalExpectation("subnet", false),
+      peg$c95 = "port",
+      peg$c96 = peg$literalExpectation("port", false),
+      peg$c97 = "\u2014",
+      peg$c98 = peg$literalExpectation("\u2014", false),
+      peg$c99 = "\u2013",
+      peg$c100 = peg$literalExpectation("\u2013", false),
+      peg$c101 = "to",
+      peg$c102 = peg$literalExpectation("to", false),
+      peg$c103 = "and",
+      peg$c104 = peg$literalExpectation("and", false),
+      peg$c105 = "or",
+      peg$c106 = peg$literalExpectation("or", false),
+      peg$c107 = "in",
+      peg$c108 = peg$literalExpectation("in", false),
+      peg$c109 = "not",
+      peg$c110 = peg$literalExpectation("not", false),
+      peg$c111 = function() { return text() },
+      peg$c112 = /^[A-Za-z_$]/,
+      peg$c113 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c114 = /^[0-9]/,
+      peg$c115 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c116 = ".",
+      peg$c117 = peg$literalExpectation(".", false),
+      peg$c118 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
+      peg$c119 = "[",
+      peg$c120 = peg$literalExpectation("[", false),
+      peg$c121 = "]",
+      peg$c122 = peg$literalExpectation("]", false),
+      peg$c123 = function(base, index) { return makeFieldCall("Index", null, index) },
+      peg$c124 = function(base, derefs) {
            return chainFieldCalls(base, derefs)
          },
-      peg$c126 = function(op, field) {
+      peg$c125 = function(op, field) {
             return makeFieldCall(op, field, nil)
           },
-      peg$c127 = "len",
-      peg$c128 = peg$literalExpectation("len", true),
-      peg$c129 = function() { return "Len" },
-      peg$c130 = ",",
-      peg$c131 = peg$literalExpectation(",", false),
-      peg$c132 = function(first, rest) {
+      peg$c126 = "len",
+      peg$c127 = peg$literalExpectation("len", true),
+      peg$c128 = function() { return "Len" },
+      peg$c129 = ",",
+      peg$c130 = peg$literalExpectation(",", false),
+      peg$c131 = function(first, rest) {
             let result =  [first]
 
             for(let  r of rest) {
@@ -359,66 +361,66 @@ function peg$parse(input, options) {
 
             return result
         },
-      peg$c133 = function(base, refs) {
+      peg$c132 = function(base, refs) {
           return chainFieldCalls(base, refs)
         },
-      peg$c134 = function(first, ref) { return ref },
-      peg$c135 = function(first, rest) {
+      peg$c133 = function(first, ref) { return ref },
+      peg$c134 = function(first, rest) {
         let result =  [first]
         for(let  r of rest) {
           result.push( r)
         }
         return result
         },
-      peg$c136 = function(first, rest) {
+      peg$c135 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
         },
-      peg$c137 = peg$literalExpectation("count", true),
-      peg$c138 = function() { return "Count" },
-      peg$c139 = "sum",
-      peg$c140 = peg$literalExpectation("sum", true),
-      peg$c141 = function() { return "Sum" },
-      peg$c142 = "avg",
-      peg$c143 = peg$literalExpectation("avg", true),
-      peg$c144 = function() { return "Avg" },
-      peg$c145 = "stdev",
-      peg$c146 = peg$literalExpectation("stdev", true),
-      peg$c147 = function() { return "Stdev" },
-      peg$c148 = "sd",
-      peg$c149 = peg$literalExpectation("sd", true),
-      peg$c150 = "var",
-      peg$c151 = peg$literalExpectation("var", true),
-      peg$c152 = function() { return "Var" },
-      peg$c153 = "entropy",
-      peg$c154 = peg$literalExpectation("entropy", true),
-      peg$c155 = function() { return "Entropy" },
-      peg$c156 = "min",
-      peg$c157 = peg$literalExpectation("min", true),
-      peg$c158 = function() { return "Min" },
-      peg$c159 = "max",
-      peg$c160 = peg$literalExpectation("max", true),
-      peg$c161 = function() { return "Max" },
-      peg$c162 = "first",
-      peg$c163 = peg$literalExpectation("first", true),
-      peg$c164 = function() { return "First" },
-      peg$c165 = "last",
-      peg$c166 = peg$literalExpectation("last", true),
-      peg$c167 = function() { return "Last" },
-      peg$c168 = "countdistinct",
-      peg$c169 = peg$literalExpectation("countdistinct", true),
-      peg$c170 = function() { return "CountDistinct" },
-      peg$c171 = function(field) { return field },
-      peg$c172 = function(op, field) {
+      peg$c136 = peg$literalExpectation("count", true),
+      peg$c137 = function() { return "Count" },
+      peg$c138 = "sum",
+      peg$c139 = peg$literalExpectation("sum", true),
+      peg$c140 = function() { return "Sum" },
+      peg$c141 = "avg",
+      peg$c142 = peg$literalExpectation("avg", true),
+      peg$c143 = function() { return "Avg" },
+      peg$c144 = "stdev",
+      peg$c145 = peg$literalExpectation("stdev", true),
+      peg$c146 = function() { return "Stdev" },
+      peg$c147 = "sd",
+      peg$c148 = peg$literalExpectation("sd", true),
+      peg$c149 = "var",
+      peg$c150 = peg$literalExpectation("var", true),
+      peg$c151 = function() { return "Var" },
+      peg$c152 = "entropy",
+      peg$c153 = peg$literalExpectation("entropy", true),
+      peg$c154 = function() { return "Entropy" },
+      peg$c155 = "min",
+      peg$c156 = peg$literalExpectation("min", true),
+      peg$c157 = function() { return "Min" },
+      peg$c158 = "max",
+      peg$c159 = peg$literalExpectation("max", true),
+      peg$c160 = function() { return "Max" },
+      peg$c161 = "first",
+      peg$c162 = peg$literalExpectation("first", true),
+      peg$c163 = function() { return "First" },
+      peg$c164 = "last",
+      peg$c165 = peg$literalExpectation("last", true),
+      peg$c166 = function() { return "Last" },
+      peg$c167 = "countdistinct",
+      peg$c168 = peg$literalExpectation("countdistinct", true),
+      peg$c169 = function() { return "CountDistinct" },
+      peg$c170 = function(field) { return field },
+      peg$c171 = function(op, field) {
           return makeReducer(op, "count", field)
         },
-      peg$c173 = function(op, field) {
+      peg$c172 = function(op, field) {
           return makeReducer(op, toLowerCase(op), field)
         },
-      peg$c174 = function(every, reducers, keys, limit) {
+      peg$c173 = function(every, reducers, keys, limit) {
           if (OR(keys, every)) {
             if (keys) {
               keys = keys[1]
@@ -435,232 +437,232 @@ function peg$parse(input, options) {
 
           return makeReducerProc(reducers)
         },
-      peg$c175 = "as",
-      peg$c176 = peg$literalExpectation("as", true),
-      peg$c177 = function(field, f) {
+      peg$c174 = "as",
+      peg$c175 = peg$literalExpectation("as", true),
+      peg$c176 = function(field, f) {
           return overrideReducerVar(f, field)
         },
-      peg$c178 = function(f, field) {
+      peg$c177 = function(f, field) {
           return overrideReducerVar(f, field)
         },
-      peg$c179 = function(first, rest) {
+      peg$c178 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c180 = "sort",
-      peg$c181 = peg$literalExpectation("sort", true),
-      peg$c182 = "-r",
-      peg$c183 = peg$literalExpectation("-r", false),
-      peg$c184 = function(rev, limit, list) {
+      peg$c179 = "sort",
+      peg$c180 = peg$literalExpectation("sort", true),
+      peg$c181 = "-r",
+      peg$c182 = peg$literalExpectation("-r", false),
+      peg$c183 = function(rev, limit, list) {
           let sortdir =  1
           if ((rev)) { sortdir = -1 }
           return makeSortProc(list, sortdir, limit)
         },
-      peg$c185 = function(limit, rev, list) {
+      peg$c184 = function(limit, rev, list) {
           let sortdir =  1
           if ((rev)) { sortdir = -1 }
           return makeSortProc(list, sortdir, limit)
         },
-      peg$c186 = "top",
-      peg$c187 = peg$literalExpectation("top", true),
-      peg$c188 = "-flush",
-      peg$c189 = peg$literalExpectation("-flush", false),
-      peg$c190 = function(limit, flush, list) {
+      peg$c185 = "top",
+      peg$c186 = peg$literalExpectation("top", true),
+      peg$c187 = "-flush",
+      peg$c188 = peg$literalExpectation("-flush", false),
+      peg$c189 = function(limit, flush, list) {
           return makeTopProc(list, limit, flush)
         },
-      peg$c191 = "-limit",
-      peg$c192 = peg$literalExpectation("-limit", false),
-      peg$c193 = function(limit) { return limit },
-      peg$c194 = "cut",
-      peg$c195 = peg$literalExpectation("cut", true),
-      peg$c196 = function(list) { return makeCutProc(list) },
-      peg$c197 = "head",
-      peg$c198 = peg$literalExpectation("head", true),
-      peg$c199 = function(count) { return makeHeadProc(count) },
-      peg$c200 = function() { return makeHeadProc(1) },
-      peg$c201 = "tail",
-      peg$c202 = peg$literalExpectation("tail", true),
-      peg$c203 = function(count) { return makeTailProc(count) },
-      peg$c204 = function() { return makeTailProc(1) },
-      peg$c205 = "filter",
-      peg$c206 = peg$literalExpectation("filter", true),
-      peg$c207 = "uniq",
-      peg$c208 = peg$literalExpectation("uniq", true),
-      peg$c209 = "-c",
-      peg$c210 = peg$literalExpectation("-c", false),
-      peg$c211 = function() {
+      peg$c190 = "-limit",
+      peg$c191 = peg$literalExpectation("-limit", false),
+      peg$c192 = function(limit) { return limit },
+      peg$c193 = "cut",
+      peg$c194 = peg$literalExpectation("cut", true),
+      peg$c195 = function(list) { return makeCutProc(list) },
+      peg$c196 = "head",
+      peg$c197 = peg$literalExpectation("head", true),
+      peg$c198 = function(count) { return makeHeadProc(count) },
+      peg$c199 = function() { return makeHeadProc(1) },
+      peg$c200 = "tail",
+      peg$c201 = peg$literalExpectation("tail", true),
+      peg$c202 = function(count) { return makeTailProc(count) },
+      peg$c203 = function() { return makeTailProc(1) },
+      peg$c204 = "filter",
+      peg$c205 = peg$literalExpectation("filter", true),
+      peg$c206 = "uniq",
+      peg$c207 = peg$literalExpectation("uniq", true),
+      peg$c208 = "-c",
+      peg$c209 = peg$literalExpectation("-c", false),
+      peg$c210 = function() {
             return makeUniqProc(true)
           },
-      peg$c212 = function() {
+      peg$c211 = function() {
             return makeUniqProc(false)
           },
-      peg$c213 = "seconds",
-      peg$c214 = peg$literalExpectation("seconds", false),
-      peg$c215 = "second",
-      peg$c216 = peg$literalExpectation("second", false),
-      peg$c217 = "secs",
-      peg$c218 = peg$literalExpectation("secs", false),
-      peg$c219 = "sec",
-      peg$c220 = peg$literalExpectation("sec", false),
-      peg$c221 = "s",
-      peg$c222 = peg$literalExpectation("s", false),
-      peg$c223 = "minutes",
-      peg$c224 = peg$literalExpectation("minutes", false),
-      peg$c225 = "minute",
-      peg$c226 = peg$literalExpectation("minute", false),
-      peg$c227 = "mins",
-      peg$c228 = peg$literalExpectation("mins", false),
-      peg$c229 = peg$literalExpectation("min", false),
-      peg$c230 = "m",
-      peg$c231 = peg$literalExpectation("m", false),
-      peg$c232 = "hours",
-      peg$c233 = peg$literalExpectation("hours", false),
-      peg$c234 = "hrs",
-      peg$c235 = peg$literalExpectation("hrs", false),
-      peg$c236 = "hr",
-      peg$c237 = peg$literalExpectation("hr", false),
-      peg$c238 = "h",
-      peg$c239 = peg$literalExpectation("h", false),
-      peg$c240 = "hour",
-      peg$c241 = peg$literalExpectation("hour", false),
-      peg$c242 = "days",
-      peg$c243 = peg$literalExpectation("days", false),
-      peg$c244 = "day",
-      peg$c245 = peg$literalExpectation("day", false),
-      peg$c246 = "d",
-      peg$c247 = peg$literalExpectation("d", false),
-      peg$c248 = "weeks",
-      peg$c249 = peg$literalExpectation("weeks", false),
-      peg$c250 = "week",
-      peg$c251 = peg$literalExpectation("week", false),
-      peg$c252 = "wks",
-      peg$c253 = peg$literalExpectation("wks", false),
-      peg$c254 = "wk",
-      peg$c255 = peg$literalExpectation("wk", false),
-      peg$c256 = "w",
-      peg$c257 = peg$literalExpectation("w", false),
-      peg$c258 = function() { return makeDuration(1) },
-      peg$c259 = function(num) { return makeDuration(num) },
-      peg$c260 = function() { return makeDuration(60) },
-      peg$c261 = function(num) { return makeDuration(num*60) },
-      peg$c262 = function() { return makeDuration(3600) },
-      peg$c263 = function(num) { return makeDuration(num*3600) },
-      peg$c264 = function() { return makeDuration(3600*24) },
-      peg$c265 = function(num) { return makeDuration(num*3600*24) },
-      peg$c266 = function(num) { return makeDuration(num*3600*24*7) },
-      peg$c267 = function(a) { return text() },
-      peg$c268 = ":",
-      peg$c269 = peg$literalExpectation(":", false),
-      peg$c270 = function(a, b) {
+      peg$c212 = "seconds",
+      peg$c213 = peg$literalExpectation("seconds", false),
+      peg$c214 = "second",
+      peg$c215 = peg$literalExpectation("second", false),
+      peg$c216 = "secs",
+      peg$c217 = peg$literalExpectation("secs", false),
+      peg$c218 = "sec",
+      peg$c219 = peg$literalExpectation("sec", false),
+      peg$c220 = "s",
+      peg$c221 = peg$literalExpectation("s", false),
+      peg$c222 = "minutes",
+      peg$c223 = peg$literalExpectation("minutes", false),
+      peg$c224 = "minute",
+      peg$c225 = peg$literalExpectation("minute", false),
+      peg$c226 = "mins",
+      peg$c227 = peg$literalExpectation("mins", false),
+      peg$c228 = peg$literalExpectation("min", false),
+      peg$c229 = "m",
+      peg$c230 = peg$literalExpectation("m", false),
+      peg$c231 = "hours",
+      peg$c232 = peg$literalExpectation("hours", false),
+      peg$c233 = "hrs",
+      peg$c234 = peg$literalExpectation("hrs", false),
+      peg$c235 = "hr",
+      peg$c236 = peg$literalExpectation("hr", false),
+      peg$c237 = "h",
+      peg$c238 = peg$literalExpectation("h", false),
+      peg$c239 = "hour",
+      peg$c240 = peg$literalExpectation("hour", false),
+      peg$c241 = "days",
+      peg$c242 = peg$literalExpectation("days", false),
+      peg$c243 = "day",
+      peg$c244 = peg$literalExpectation("day", false),
+      peg$c245 = "d",
+      peg$c246 = peg$literalExpectation("d", false),
+      peg$c247 = "weeks",
+      peg$c248 = peg$literalExpectation("weeks", false),
+      peg$c249 = "week",
+      peg$c250 = peg$literalExpectation("week", false),
+      peg$c251 = "wks",
+      peg$c252 = peg$literalExpectation("wks", false),
+      peg$c253 = "wk",
+      peg$c254 = peg$literalExpectation("wk", false),
+      peg$c255 = "w",
+      peg$c256 = peg$literalExpectation("w", false),
+      peg$c257 = function() { return makeDuration(1) },
+      peg$c258 = function(num) { return makeDuration(num) },
+      peg$c259 = function() { return makeDuration(60) },
+      peg$c260 = function(num) { return makeDuration(num*60) },
+      peg$c261 = function() { return makeDuration(3600) },
+      peg$c262 = function(num) { return makeDuration(num*3600) },
+      peg$c263 = function() { return makeDuration(3600*24) },
+      peg$c264 = function(num) { return makeDuration(num*3600*24) },
+      peg$c265 = function(num) { return makeDuration(num*3600*24*7) },
+      peg$c266 = function(a) { return text() },
+      peg$c267 = ":",
+      peg$c268 = peg$literalExpectation(":", false),
+      peg$c269 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c271 = "::",
-      peg$c272 = peg$literalExpectation("::", false),
-      peg$c273 = function(a, b, d, e) {
+      peg$c270 = "::",
+      peg$c271 = peg$literalExpectation("::", false),
+      peg$c272 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c274 = function(a, b) {
+      peg$c273 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c275 = function(a, b) {
+      peg$c274 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c276 = function() {
+      peg$c275 = function() {
             return "::"
           },
-      peg$c277 = function(v) { return ":" + v },
-      peg$c278 = function(v) { return v + ":" },
-      peg$c279 = function(a) { return text() + ".0" },
-      peg$c280 = function(a) { return text() + ".0.0" },
-      peg$c281 = function(a) { return text() + ".0.0.0" },
-      peg$c282 = "/",
-      peg$c283 = peg$literalExpectation("/", false),
-      peg$c284 = function(a, m) {
+      peg$c276 = function(v) { return ":" + v },
+      peg$c277 = function(v) { return v + ":" },
+      peg$c278 = function(a) { return text() + ".0" },
+      peg$c279 = function(a) { return text() + ".0.0" },
+      peg$c280 = function(a) { return text() + ".0.0.0" },
+      peg$c281 = "/",
+      peg$c282 = peg$literalExpectation("/", false),
+      peg$c283 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c285 = function(a, m) {
+      peg$c284 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c286 = function(s) {
+      peg$c285 = function(s) {
           return parseInt(s)
         },
-      peg$c287 = function(chars) {
+      peg$c286 = function(chars) {
           return text()
         },
-      peg$c288 = function(s) {
+      peg$c287 = function(s) {
             return parseFloat(s)
         },
-      peg$c289 = function() {
+      peg$c288 = function() {
             return text()
           },
-      peg$c290 = "0",
-      peg$c291 = peg$literalExpectation("0", false),
-      peg$c292 = /^[1-9]/,
-      peg$c293 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c294 = /^[+\-]/,
-      peg$c295 = peg$classExpectation(["+", "-"], false, false),
-      peg$c296 = "e",
-      peg$c297 = peg$literalExpectation("e", true),
-      peg$c298 = function(chars) { return text() },
-      peg$c299 = /^[0-9a-fA-F]/,
-      peg$c300 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c301 = peg$otherExpectation("boomWord"),
-      peg$c302 = function(chars) { return joinChars(chars) },
-      peg$c303 = "\\",
-      peg$c304 = peg$literalExpectation("\\", false),
-      peg$c305 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c306 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c307 = peg$anyExpectation(),
-      peg$c308 = "\"",
-      peg$c309 = peg$literalExpectation("\"", false),
-      peg$c310 = function(v) { return joinChars(v) },
-      peg$c311 = "'",
-      peg$c312 = peg$literalExpectation("'", false),
-      peg$c313 = "x",
-      peg$c314 = peg$literalExpectation("x", false),
-      peg$c315 = function() { return "\\" + text() },
-      peg$c316 = "b",
-      peg$c317 = peg$literalExpectation("b", false),
-      peg$c318 = function() { return "\b" },
-      peg$c319 = "f",
-      peg$c320 = peg$literalExpectation("f", false),
-      peg$c321 = function() { return "\f" },
-      peg$c322 = "n",
-      peg$c323 = peg$literalExpectation("n", false),
-      peg$c324 = function() { return "\n" },
-      peg$c325 = "r",
-      peg$c326 = peg$literalExpectation("r", false),
-      peg$c327 = function() { return "\r" },
-      peg$c328 = "t",
-      peg$c329 = peg$literalExpectation("t", false),
-      peg$c330 = function() { return "\t" },
-      peg$c331 = "v",
-      peg$c332 = peg$literalExpectation("v", false),
-      peg$c333 = function() { return "\v" },
-      peg$c334 = "u",
-      peg$c335 = peg$literalExpectation("u", false),
-      peg$c336 = /^[^\/\\]/,
-      peg$c337 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c338 = "\\/",
-      peg$c339 = peg$literalExpectation("\\/", false),
-      peg$c340 = /^[\0-\x1F\\]/,
-      peg$c341 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c342 = "\t",
-      peg$c343 = peg$literalExpectation("\t", false),
-      peg$c344 = "\x0B",
-      peg$c345 = peg$literalExpectation("\x0B", false),
-      peg$c346 = "\f",
-      peg$c347 = peg$literalExpectation("\f", false),
-      peg$c348 = " ",
-      peg$c349 = peg$literalExpectation(" ", false),
-      peg$c350 = "\xA0",
-      peg$c351 = peg$literalExpectation("\xA0", false),
-      peg$c352 = "\uFEFF",
-      peg$c353 = peg$literalExpectation("\uFEFF", false),
-      peg$c354 = peg$otherExpectation("whitespace"),
+      peg$c289 = "0",
+      peg$c290 = peg$literalExpectation("0", false),
+      peg$c291 = /^[1-9]/,
+      peg$c292 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c293 = /^[+\-]/,
+      peg$c294 = peg$classExpectation(["+", "-"], false, false),
+      peg$c295 = "e",
+      peg$c296 = peg$literalExpectation("e", true),
+      peg$c297 = function(chars) { return text() },
+      peg$c298 = /^[0-9a-fA-F]/,
+      peg$c299 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c300 = peg$otherExpectation("boomWord"),
+      peg$c301 = function(chars) { return joinChars(chars) },
+      peg$c302 = "\\",
+      peg$c303 = peg$literalExpectation("\\", false),
+      peg$c304 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c305 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c306 = peg$anyExpectation(),
+      peg$c307 = "\"",
+      peg$c308 = peg$literalExpectation("\"", false),
+      peg$c309 = function(v) { return joinChars(v) },
+      peg$c310 = "'",
+      peg$c311 = peg$literalExpectation("'", false),
+      peg$c312 = "x",
+      peg$c313 = peg$literalExpectation("x", false),
+      peg$c314 = function() { return "\\" + text() },
+      peg$c315 = "b",
+      peg$c316 = peg$literalExpectation("b", false),
+      peg$c317 = function() { return "\b" },
+      peg$c318 = "f",
+      peg$c319 = peg$literalExpectation("f", false),
+      peg$c320 = function() { return "\f" },
+      peg$c321 = "n",
+      peg$c322 = peg$literalExpectation("n", false),
+      peg$c323 = function() { return "\n" },
+      peg$c324 = "r",
+      peg$c325 = peg$literalExpectation("r", false),
+      peg$c326 = function() { return "\r" },
+      peg$c327 = "t",
+      peg$c328 = peg$literalExpectation("t", false),
+      peg$c329 = function() { return "\t" },
+      peg$c330 = "v",
+      peg$c331 = peg$literalExpectation("v", false),
+      peg$c332 = function() { return "\v" },
+      peg$c333 = "u",
+      peg$c334 = peg$literalExpectation("u", false),
+      peg$c335 = /^[^\/\\]/,
+      peg$c336 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c337 = "\\/",
+      peg$c338 = peg$literalExpectation("\\/", false),
+      peg$c339 = /^[\0-\x1F\\]/,
+      peg$c340 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c341 = "\t",
+      peg$c342 = peg$literalExpectation("\t", false),
+      peg$c343 = "\x0B",
+      peg$c344 = peg$literalExpectation("\x0B", false),
+      peg$c345 = "\f",
+      peg$c346 = peg$literalExpectation("\f", false),
+      peg$c347 = " ",
+      peg$c348 = peg$literalExpectation(" ", false),
+      peg$c349 = "\xA0",
+      peg$c350 = peg$literalExpectation("\xA0", false),
+      peg$c351 = "\uFEFF",
+      peg$c352 = peg$literalExpectation("\uFEFF", false),
+      peg$c353 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1368,38 +1370,71 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 42) {
-          s1 = peg$c24;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c25); }
-        }
+        s1 = peg$parsefieldExpr();
         if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c30();
+          s2 = peg$parse_();
+          if (s2 === peg$FAILED) {
+            s2 = null;
+          }
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parseequalityToken();
+            if (s3 !== peg$FAILED) {
+              s4 = peg$parse_();
+              if (s4 === peg$FAILED) {
+                s4 = null;
+              }
+              if (s4 !== peg$FAILED) {
+                s5 = peg$parsesearchValue();
+                if (s5 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c30(s1, s3, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
-        s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parsefieldExpr();
+          s1 = peg$parsesearchValue();
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 === peg$FAILED) {
               s2 = null;
             }
             if (s2 !== peg$FAILED) {
-              s3 = peg$parseequalityToken();
+              s3 = peg$parseinToken();
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
                 if (s4 === peg$FAILED) {
                   s4 = null;
                 }
                 if (s4 !== peg$FAILED) {
-                  s5 = peg$parsesearchValue();
+                  if (input.charCodeAt(peg$currPos) === 42) {
+                    s5 = peg$c24;
+                    peg$currPos++;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c25); }
+                  }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c31(s1, s3, s5);
+                    s1 = peg$c31(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1437,16 +1472,10 @@ function peg$parse(input, options) {
                     s4 = null;
                   }
                   if (s4 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 42) {
-                      s5 = peg$c24;
-                      peg$currPos++;
-                    } else {
-                      s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c25); }
-                    }
+                    s5 = peg$parsefieldReference();
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c32(s1);
+                      s1 = peg$c32(s1, s5);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1472,52 +1501,10 @@ function peg$parse(input, options) {
               s0 = peg$currPos;
               s1 = peg$parsesearchValue();
               if (s1 !== peg$FAILED) {
-                s2 = peg$parse_();
-                if (s2 === peg$FAILED) {
-                  s2 = null;
-                }
-                if (s2 !== peg$FAILED) {
-                  s3 = peg$parseinToken();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse_();
-                    if (s4 === peg$FAILED) {
-                      s4 = null;
-                    }
-                    if (s4 !== peg$FAILED) {
-                      s5 = peg$parsefieldReference();
-                      if (s5 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c33(s1, s5);
-                        s0 = s1;
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
+                peg$savedPos = s0;
+                s1 = peg$c33(s1);
               }
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parsesearchValue();
-                if (s1 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c34(s1);
-                }
-                s0 = s1;
-              }
+              s0 = s1;
             }
           }
         }
@@ -1534,7 +1521,7 @@ function peg$parse(input, options) {
     s1 = peg$parsequotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c35(s1);
+      s1 = peg$c34(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1542,7 +1529,7 @@ function peg$parse(input, options) {
       s1 = peg$parsereString();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c36(s1);
+        s1 = peg$c35(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1550,7 +1537,7 @@ function peg$parse(input, options) {
         s1 = peg$parseport();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c37(s1);
+          s1 = peg$c36(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -1558,7 +1545,7 @@ function peg$parse(input, options) {
           s1 = peg$parseip6subnet();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c38(s1);
+            s1 = peg$c37(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -1566,7 +1553,7 @@ function peg$parse(input, options) {
             s1 = peg$parseip6addr();
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c39(s1);
+              s1 = peg$c38(s1);
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -1574,7 +1561,7 @@ function peg$parse(input, options) {
               s1 = peg$parsesubnet();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c38(s1);
+                s1 = peg$c37(s1);
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -1582,7 +1569,7 @@ function peg$parse(input, options) {
                 s1 = peg$parseaddr();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c39(s1);
+                  s1 = peg$c38(s1);
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -1590,7 +1577,7 @@ function peg$parse(input, options) {
                   s1 = peg$parsesdouble();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c40(s1);
+                    s1 = peg$c39(s1);
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
@@ -1609,7 +1596,7 @@ function peg$parse(input, options) {
                       }
                       if (s2 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c41(s1);
+                        s1 = peg$c40(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1649,7 +1636,7 @@ function peg$parse(input, options) {
                         s2 = peg$parsebooleanLiteral();
                         if (s2 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c42(s2);
+                          s1 = peg$c41(s2);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -1689,7 +1676,7 @@ function peg$parse(input, options) {
                           s2 = peg$parseunsetLiteral();
                           if (s2 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c42(s2);
+                            s1 = peg$c41(s2);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -1729,7 +1716,7 @@ function peg$parse(input, options) {
                             s2 = peg$parseboomWord();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c43(s2);
+                              s1 = peg$c42(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -1772,30 +1759,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c44) {
-      s1 = peg$c44;
+    if (input.substr(peg$currPos, 4) === peg$c43) {
+      s1 = peg$c43;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c45); }
+      if (peg$silentFails === 0) { peg$fail(peg$c44); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c46();
+      s1 = peg$c45();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c47) {
-        s1 = peg$c47;
+      if (input.substr(peg$currPos, 5) === peg$c46) {
+        s1 = peg$c46;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c49();
+        s1 = peg$c48();
       }
       s0 = s1;
     }
@@ -1807,16 +1794,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c50) {
-      s1 = peg$c50;
+    if (input.substr(peg$currPos, 3) === peg$c49) {
+      s1 = peg$c49;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c50); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c52();
+      s1 = peg$c51();
     }
     s0 = s1;
 
@@ -1837,7 +1824,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c53(s1, s2);
+        s1 = peg$c52(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1861,11 +1848,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c54;
+        s2 = peg$c53;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c54); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -1876,7 +1863,7 @@ function peg$parse(input, options) {
           s4 = peg$parseprocChain();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c56(s4);
+            s1 = peg$c55(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1935,7 +1922,7 @@ function peg$parse(input, options) {
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c57(s3);
+                  s1 = peg$c56(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1967,12 +1954,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c57) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c59); }
+      if (peg$silentFails === 0) { peg$fail(peg$c58); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1980,7 +1967,7 @@ function peg$parse(input, options) {
         s3 = peg$parsefieldExprList();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c60(s3);
+          s1 = peg$c59(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2002,12 +1989,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c60) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c61); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2015,7 +2002,7 @@ function peg$parse(input, options) {
         s3 = peg$parseduration();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c63(s3);
+          s1 = peg$c62(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2038,85 +2025,85 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c64;
+      s1 = peg$c63;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c64); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c65();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c67) {
-        s1 = peg$c67;
+      if (input.substr(peg$currPos, 2) === peg$c66) {
+        s1 = peg$c66;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c67); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c69();
+        s1 = peg$c68();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c70) {
-          s1 = peg$c70;
+        if (input.substr(peg$currPos, 2) === peg$c69) {
+          s1 = peg$c69;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c71); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c72();
+          s1 = peg$c71();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c73) {
-            s1 = peg$c73;
+          if (input.substr(peg$currPos, 2) === peg$c72) {
+            s1 = peg$c72;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c75();
+            s1 = peg$c74();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 60) {
-              s1 = peg$c76;
+              s1 = peg$c75;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c77); }
+              if (peg$silentFails === 0) { peg$fail(peg$c76); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c78();
+              s1 = peg$c77();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 62) {
-                s1 = peg$c79;
+                s1 = peg$c78;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c80); }
+                if (peg$silentFails === 0) { peg$fail(peg$c79); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c81();
+                s1 = peg$c80();
               }
               s0 = s1;
             }
@@ -2131,68 +2118,68 @@ function peg$parse(input, options) {
   function peg$parsetypes() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c82) {
-      s0 = peg$c82;
+    if (input.substr(peg$currPos, 4) === peg$c81) {
+      s0 = peg$c81;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+      if (peg$silentFails === 0) { peg$fail(peg$c82); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c84) {
-        s0 = peg$c84;
+      if (input.substr(peg$currPos, 3) === peg$c83) {
+        s0 = peg$c83;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c86) {
-          s0 = peg$c86;
+        if (input.substr(peg$currPos, 5) === peg$c85) {
+          s0 = peg$c85;
           peg$currPos += 5;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c87); }
+          if (peg$silentFails === 0) { peg$fail(peg$c86); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c88) {
-            s0 = peg$c88;
+          if (input.substr(peg$currPos, 6) === peg$c87) {
+            s0 = peg$c87;
             peg$currPos += 6;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c89); }
+            if (peg$silentFails === 0) { peg$fail(peg$c88); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c90) {
-              s0 = peg$c90;
+            if (input.substr(peg$currPos, 6) === peg$c89) {
+              s0 = peg$c89;
               peg$currPos += 6;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c91); }
+              if (peg$silentFails === 0) { peg$fail(peg$c90); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c92) {
-                s0 = peg$c92;
+              if (input.substr(peg$currPos, 4) === peg$c91) {
+                s0 = peg$c91;
                 peg$currPos += 4;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c93); }
+                if (peg$silentFails === 0) { peg$fail(peg$c92); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 6) === peg$c94) {
-                  s0 = peg$c94;
+                if (input.substr(peg$currPos, 6) === peg$c93) {
+                  s0 = peg$c93;
                   peg$currPos += 6;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c95); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c94); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 4) === peg$c96) {
-                    s0 = peg$c96;
+                  if (input.substr(peg$currPos, 4) === peg$c95) {
+                    s0 = peg$c95;
                     peg$currPos += 4;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c97); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c96); }
                   }
                 }
               }
@@ -2217,28 +2204,28 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 8212) {
-        s0 = peg$c98;
+        s0 = peg$c97;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c98); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 8211) {
-          s0 = peg$c100;
+          s0 = peg$c99;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c100); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c102) {
-            s1 = peg$c102;
+          if (input.substr(peg$currPos, 2) === peg$c101) {
+            s1 = peg$c101;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c103); }
+            if (peg$silentFails === 0) { peg$fail(peg$c102); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$currPos;
@@ -2272,12 +2259,12 @@ function peg$parse(input, options) {
   function peg$parseandToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c104) {
-      s0 = peg$c104;
+    if (input.substr(peg$currPos, 3) === peg$c103) {
+      s0 = peg$c103;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+      if (peg$silentFails === 0) { peg$fail(peg$c104); }
     }
 
     return s0;
@@ -2286,12 +2273,12 @@ function peg$parse(input, options) {
   function peg$parseorToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c106) {
-      s0 = peg$c106;
+    if (input.substr(peg$currPos, 2) === peg$c105) {
+      s0 = peg$c105;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c107); }
+      if (peg$silentFails === 0) { peg$fail(peg$c106); }
     }
 
     return s0;
@@ -2300,12 +2287,12 @@ function peg$parse(input, options) {
   function peg$parseinToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c108) {
-      s0 = peg$c108;
+    if (input.substr(peg$currPos, 2) === peg$c107) {
+      s0 = peg$c107;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c109); }
+      if (peg$silentFails === 0) { peg$fail(peg$c108); }
     }
 
     return s0;
@@ -2314,12 +2301,12 @@ function peg$parse(input, options) {
   function peg$parsenotToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c110) {
-      s0 = peg$c110;
+    if (input.substr(peg$currPos, 3) === peg$c109) {
+      s0 = peg$c109;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      if (peg$silentFails === 0) { peg$fail(peg$c110); }
     }
 
     return s0;
@@ -2339,7 +2326,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112();
+        s1 = peg$c111();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2356,12 +2343,12 @@ function peg$parse(input, options) {
   function peg$parsefieldNameStart() {
     var s0;
 
-    if (peg$c113.test(input.charAt(peg$currPos))) {
+    if (peg$c112.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+      if (peg$silentFails === 0) { peg$fail(peg$c113); }
     }
 
     return s0;
@@ -2372,12 +2359,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parsefieldNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c115.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c116); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
     }
 
@@ -2393,17 +2380,17 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c117;
+        s4 = peg$c116;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c119(s1, s5);
+          s4 = peg$c118(s1, s5);
           s3 = s4;
         } else {
           peg$currPos = s3;
@@ -2416,25 +2403,25 @@ function peg$parse(input, options) {
       if (s3 === peg$FAILED) {
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s4 = peg$c120;
+          s4 = peg$c119;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c120); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsesinteger();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s6 = peg$c122;
+              s6 = peg$c121;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c123); }
+              if (peg$silentFails === 0) { peg$fail(peg$c122); }
             }
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c124(s1, s5);
+              s4 = peg$c123(s1, s5);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2453,17 +2440,17 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c117;
+          s4 = peg$c116;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c118); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c119(s1, s5);
+            s4 = peg$c118(s1, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2476,25 +2463,25 @@ function peg$parse(input, options) {
         if (s3 === peg$FAILED) {
           s3 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s4 = peg$c120;
+            s4 = peg$c119;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c120); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsesinteger();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s6 = peg$c122;
+                s6 = peg$c121;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c123); }
+                if (peg$silentFails === 0) { peg$fail(peg$c122); }
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c124(s1, s5);
+                s4 = peg$c123(s1, s5);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2512,7 +2499,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c125(s1, s2);
+        s1 = peg$c124(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2566,7 +2553,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c126(s1, s5);
+                  s1 = peg$c125(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2607,16 +2594,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c127) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c126) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c128); }
+      if (peg$silentFails === 0) { peg$fail(peg$c127); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c129();
+      s1 = peg$c128();
     }
     s0 = s1;
 
@@ -2637,11 +2624,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c130;
+          s5 = peg$c129;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c131); }
+          if (peg$silentFails === 0) { peg$fail(peg$c130); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -2678,11 +2665,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c130;
+            s5 = peg$c129;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c131); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2713,7 +2700,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c132(s1, s2);
+        s1 = peg$c131(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2736,17 +2723,17 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c117;
+        s4 = peg$c116;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c119(s1, s5);
+          s4 = peg$c118(s1, s5);
           s3 = s4;
         } else {
           peg$currPos = s3;
@@ -2760,17 +2747,17 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c117;
+          s4 = peg$c116;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c118); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c119(s1, s5);
+            s4 = peg$c118(s1, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2783,7 +2770,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c133(s1, s2);
+        s1 = peg$c132(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2811,11 +2798,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c130;
+          s5 = peg$c129;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c131); }
+          if (peg$silentFails === 0) { peg$fail(peg$c130); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -2826,7 +2813,7 @@ function peg$parse(input, options) {
             s7 = peg$parsefieldRefDotOnly();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c134(s1, s7);
+              s4 = peg$c133(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2853,11 +2840,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c130;
+            s5 = peg$c129;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c131); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2868,7 +2855,7 @@ function peg$parse(input, options) {
               s7 = peg$parsefieldRefDotOnly();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c134(s1, s7);
+                s4 = peg$c133(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2889,7 +2876,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c135(s1, s2);
+        s1 = peg$c134(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2917,11 +2904,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c130;
+          s5 = peg$c129;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c131); }
+          if (peg$silentFails === 0) { peg$fail(peg$c130); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -2958,11 +2945,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c130;
+            s5 = peg$c129;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c131); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2993,7 +2980,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c136(s1, s2);
+        s1 = peg$c135(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3011,16 +2998,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c86) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c85) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      if (peg$silentFails === 0) { peg$fail(peg$c136); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c138();
+      s1 = peg$c137();
     }
     s0 = s1;
 
@@ -3031,156 +3018,156 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c139) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c138) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c139); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c141();
+      s1 = peg$c140();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c142) {
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c141) {
         s1 = input.substr(peg$currPos, 3);
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c144();
+        s1 = peg$c143();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c145) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c144) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c146); }
+          if (peg$silentFails === 0) { peg$fail(peg$c145); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c147();
+          s1 = peg$c146();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c148) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c147) {
             s1 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c149); }
+            if (peg$silentFails === 0) { peg$fail(peg$c148); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c147();
+            s1 = peg$c146();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c150) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c149) {
               s1 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c151); }
+              if (peg$silentFails === 0) { peg$fail(peg$c150); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c152();
+              s1 = peg$c151();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c153) {
+              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c152) {
                 s1 = input.substr(peg$currPos, 7);
                 peg$currPos += 7;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c154); }
+                if (peg$silentFails === 0) { peg$fail(peg$c153); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c155();
+                s1 = peg$c154();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
+                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c155) {
                   s1 = input.substr(peg$currPos, 3);
                   peg$currPos += 3;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c157); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c156); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c158();
+                  s1 = peg$c157();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c159) {
+                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c158) {
                     s1 = input.substr(peg$currPos, 3);
                     peg$currPos += 3;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c160); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c159); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c161();
+                    s1 = peg$c160();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c162) {
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c161) {
                       s1 = input.substr(peg$currPos, 5);
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c162); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c164();
+                      s1 = peg$c163();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c165) {
+                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c164) {
                         s1 = input.substr(peg$currPos, 4);
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c166); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c165); }
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c167();
+                        s1 = peg$c166();
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c168) {
+                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c167) {
                           s1 = input.substr(peg$currPos, 13);
                           peg$currPos += 13;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c168); }
                         }
                         if (s1 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c170();
+                          s1 = peg$c169();
                         }
                         s0 = s1;
                       }
@@ -3214,7 +3201,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c171(s2);
+          s1 = peg$c170(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3270,7 +3257,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c172(s1, s4);
+                s1 = peg$c171(s1, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3340,7 +3327,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c173(s1, s5);
+                  s1 = peg$c172(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3424,7 +3411,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1, s2, s3, s4);
+            s1 = peg$c173(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3450,12 +3437,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c175) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c174) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c176); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3463,7 +3450,7 @@ function peg$parse(input, options) {
         s3 = peg$parsefieldName();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c42(s3);
+          s1 = peg$c41(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3493,11 +3480,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c64;
+          s3 = peg$c63;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c64); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3508,7 +3495,7 @@ function peg$parse(input, options) {
             s5 = peg$parsereducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c177(s1, s5);
+              s1 = peg$c176(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3539,7 +3526,7 @@ function peg$parse(input, options) {
           s3 = peg$parseasClause();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c178(s1, s3);
+            s1 = peg$c177(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3586,11 +3573,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c130;
+          s5 = peg$c129;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c131); }
+          if (peg$silentFails === 0) { peg$fail(peg$c130); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -3627,11 +3614,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c130;
+            s5 = peg$c129;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c131); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -3662,7 +3649,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c179(s1, s2);
+        s1 = peg$c178(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3706,23 +3693,23 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c179) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c180); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c182) {
-          s4 = peg$c182;
+        if (input.substr(peg$currPos, 2) === peg$c181) {
+          s4 = peg$c181;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c183); }
+          if (peg$silentFails === 0) { peg$fail(peg$c182); }
         }
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
@@ -3751,12 +3738,12 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$currPos;
             peg$silentFails++;
-            if (input.substr(peg$currPos, 2) === peg$c182) {
-              s6 = peg$c182;
+            if (input.substr(peg$currPos, 2) === peg$c181) {
+              s6 = peg$c181;
               peg$currPos += 2;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c183); }
+              if (peg$silentFails === 0) { peg$fail(peg$c182); }
             }
             peg$silentFails--;
             if (s6 === peg$FAILED) {
@@ -3772,7 +3759,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c184(s2, s3, s6);
+                s1 = peg$c183(s2, s3, s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3800,12 +3787,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c179) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c180); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseprocLimitArg();
@@ -3816,12 +3803,12 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c182) {
-              s5 = peg$c182;
+            if (input.substr(peg$currPos, 2) === peg$c181) {
+              s5 = peg$c181;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c183); }
+              if (peg$silentFails === 0) { peg$fail(peg$c182); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -3849,7 +3836,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c185(s2, s3, s5);
+                s1 = peg$c184(s2, s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3880,12 +3867,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c186) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c185) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c187); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseprocLimitArg();
@@ -3896,12 +3883,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c188) {
-            s5 = peg$c188;
+          if (input.substr(peg$currPos, 6) === peg$c187) {
+            s5 = peg$c187;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c189); }
+            if (peg$silentFails === 0) { peg$fail(peg$c188); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3929,7 +3916,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c190(s2, s3, s5);
+              s1 = peg$c189(s2, s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3961,12 +3948,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c191) {
-        s2 = peg$c191;
+      if (input.substr(peg$currPos, 6) === peg$c190) {
+        s2 = peg$c190;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c192); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3974,7 +3961,7 @@ function peg$parse(input, options) {
           s4 = peg$parseinteger();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c193(s4);
+            s1 = peg$c192(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4000,12 +3987,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c194) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c193) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4013,7 +4000,7 @@ function peg$parse(input, options) {
         s3 = peg$parsefieldRefDotOnlyList();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c196(s3);
+          s1 = peg$c195(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4035,12 +4022,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c197) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c196) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c198); }
+      if (peg$silentFails === 0) { peg$fail(peg$c197); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4048,7 +4035,7 @@ function peg$parse(input, options) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c199(s3);
+          s1 = peg$c198(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4064,16 +4051,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c197) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c196) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c197); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c200();
+        s1 = peg$c199();
       }
       s0 = s1;
     }
@@ -4085,12 +4072,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c201) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c200) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c202); }
+      if (peg$silentFails === 0) { peg$fail(peg$c201); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4098,7 +4085,7 @@ function peg$parse(input, options) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c203(s3);
+          s1 = peg$c202(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4114,16 +4101,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c201) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c200) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c202); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c204();
+        s1 = peg$c203();
       }
       s0 = s1;
     }
@@ -4135,12 +4122,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c205) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c204) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c206); }
+      if (peg$silentFails === 0) { peg$fail(peg$c205); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4170,26 +4157,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c207) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c209) {
-          s3 = peg$c209;
+        if (input.substr(peg$currPos, 2) === peg$c208) {
+          s3 = peg$c208;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c210); }
+          if (peg$silentFails === 0) { peg$fail(peg$c209); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c211();
+          s1 = peg$c210();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4205,16 +4192,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c207) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c208); }
+        if (peg$silentFails === 0) { peg$fail(peg$c207); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c212();
+        s1 = peg$c211();
       }
       s0 = s1;
     }
@@ -4236,12 +4223,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c104) {
-                s3 = peg$c104;
+              if (input.substr(peg$currPos, 3) === peg$c103) {
+                s3 = peg$c103;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                if (peg$silentFails === 0) { peg$fail(peg$c104); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -4286,44 +4273,44 @@ function peg$parse(input, options) {
   function peg$parsesec_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c213) {
-      s0 = peg$c213;
+    if (input.substr(peg$currPos, 7) === peg$c212) {
+      s0 = peg$c212;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c213); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c215) {
-        s0 = peg$c215;
+      if (input.substr(peg$currPos, 6) === peg$c214) {
+        s0 = peg$c214;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+        if (peg$silentFails === 0) { peg$fail(peg$c215); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c217) {
-          s0 = peg$c217;
+        if (input.substr(peg$currPos, 4) === peg$c216) {
+          s0 = peg$c216;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c218); }
+          if (peg$silentFails === 0) { peg$fail(peg$c217); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c219) {
-            s0 = peg$c219;
+          if (input.substr(peg$currPos, 3) === peg$c218) {
+            s0 = peg$c218;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c220); }
+            if (peg$silentFails === 0) { peg$fail(peg$c219); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c221;
+              s0 = peg$c220;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c222); }
+              if (peg$silentFails === 0) { peg$fail(peg$c221); }
             }
           }
         }
@@ -4336,44 +4323,44 @@ function peg$parse(input, options) {
   function peg$parsemin_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c223) {
-      s0 = peg$c223;
+    if (input.substr(peg$currPos, 7) === peg$c222) {
+      s0 = peg$c222;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c224); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c225) {
-        s0 = peg$c225;
+      if (input.substr(peg$currPos, 6) === peg$c224) {
+        s0 = peg$c224;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c226); }
+        if (peg$silentFails === 0) { peg$fail(peg$c225); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c227) {
-          s0 = peg$c227;
+        if (input.substr(peg$currPos, 4) === peg$c226) {
+          s0 = peg$c226;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c227); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c156) {
-            s0 = peg$c156;
+          if (input.substr(peg$currPos, 3) === peg$c155) {
+            s0 = peg$c155;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c229); }
+            if (peg$silentFails === 0) { peg$fail(peg$c228); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c230;
+              s0 = peg$c229;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c231); }
+              if (peg$silentFails === 0) { peg$fail(peg$c230); }
             }
           }
         }
@@ -4386,44 +4373,44 @@ function peg$parse(input, options) {
   function peg$parsehour_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c232) {
-      s0 = peg$c232;
+    if (input.substr(peg$currPos, 5) === peg$c231) {
+      s0 = peg$c231;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c234) {
-        s0 = peg$c234;
+      if (input.substr(peg$currPos, 3) === peg$c233) {
+        s0 = peg$c233;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c235); }
+        if (peg$silentFails === 0) { peg$fail(peg$c234); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c236) {
-          s0 = peg$c236;
+        if (input.substr(peg$currPos, 2) === peg$c235) {
+          s0 = peg$c235;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c237); }
+          if (peg$silentFails === 0) { peg$fail(peg$c236); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c238;
+            s0 = peg$c237;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c239); }
+            if (peg$silentFails === 0) { peg$fail(peg$c238); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c240) {
-              s0 = peg$c240;
+            if (input.substr(peg$currPos, 4) === peg$c239) {
+              s0 = peg$c239;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c241); }
+              if (peg$silentFails === 0) { peg$fail(peg$c240); }
             }
           }
         }
@@ -4436,28 +4423,28 @@ function peg$parse(input, options) {
   function peg$parseday_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c242) {
-      s0 = peg$c242;
+    if (input.substr(peg$currPos, 4) === peg$c241) {
+      s0 = peg$c241;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c243); }
+      if (peg$silentFails === 0) { peg$fail(peg$c242); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c244) {
-        s0 = peg$c244;
+      if (input.substr(peg$currPos, 3) === peg$c243) {
+        s0 = peg$c243;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c245); }
+        if (peg$silentFails === 0) { peg$fail(peg$c244); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c246;
+          s0 = peg$c245;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+          if (peg$silentFails === 0) { peg$fail(peg$c246); }
         }
       }
     }
@@ -4468,44 +4455,44 @@ function peg$parse(input, options) {
   function peg$parseweek_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c248) {
-      s0 = peg$c248;
+    if (input.substr(peg$currPos, 5) === peg$c247) {
+      s0 = peg$c247;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c250) {
-        s0 = peg$c250;
+      if (input.substr(peg$currPos, 4) === peg$c249) {
+        s0 = peg$c249;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c251); }
+        if (peg$silentFails === 0) { peg$fail(peg$c250); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c252) {
-          s0 = peg$c252;
+        if (input.substr(peg$currPos, 3) === peg$c251) {
+          s0 = peg$c251;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c253); }
+          if (peg$silentFails === 0) { peg$fail(peg$c252); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c254) {
-            s0 = peg$c254;
+          if (input.substr(peg$currPos, 2) === peg$c253) {
+            s0 = peg$c253;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c255); }
+            if (peg$silentFails === 0) { peg$fail(peg$c254); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c256;
+              s0 = peg$c255;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c257); }
+              if (peg$silentFails === 0) { peg$fail(peg$c256); }
             }
           }
         }
@@ -4519,16 +4506,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c215) {
-      s1 = peg$c215;
+    if (input.substr(peg$currPos, 6) === peg$c214) {
+      s1 = peg$c214;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c216); }
+      if (peg$silentFails === 0) { peg$fail(peg$c215); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c258();
+      s1 = peg$c257();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4543,7 +4530,7 @@ function peg$parse(input, options) {
           s3 = peg$parsesec_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c259(s1);
+            s1 = peg$c258(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4566,16 +4553,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c225) {
-      s1 = peg$c225;
+    if (input.substr(peg$currPos, 6) === peg$c224) {
+      s1 = peg$c224;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c225); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c260();
+      s1 = peg$c259();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4590,7 +4577,7 @@ function peg$parse(input, options) {
           s3 = peg$parsemin_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c261(s1);
+            s1 = peg$c260(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4613,16 +4600,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c240) {
-      s1 = peg$c240;
+    if (input.substr(peg$currPos, 4) === peg$c239) {
+      s1 = peg$c239;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c262();
+      s1 = peg$c261();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4637,7 +4624,7 @@ function peg$parse(input, options) {
           s3 = peg$parsehour_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c263(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4660,16 +4647,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c244) {
-      s1 = peg$c244;
+    if (input.substr(peg$currPos, 3) === peg$c243) {
+      s1 = peg$c243;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c245); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c264();
+      s1 = peg$c263();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4684,7 +4671,7 @@ function peg$parse(input, options) {
           s3 = peg$parseday_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c265(s1);
+            s1 = peg$c264(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4717,7 +4704,7 @@ function peg$parse(input, options) {
         s3 = peg$parseweek_abbrev();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c266(s1);
+          s1 = peg$c265(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4743,31 +4730,31 @@ function peg$parse(input, options) {
     s2 = peg$parseinteger();
     if (s2 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c117;
+        s3 = peg$c116;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseinteger();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c117;
+            s5 = peg$c116;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c118); }
+            if (peg$silentFails === 0) { peg$fail(peg$c117); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parseinteger();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c117;
+                s7 = peg$c116;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c118); }
+                if (peg$silentFails === 0) { peg$fail(peg$c117); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parseinteger();
@@ -4804,7 +4791,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c267(s1);
+      s1 = peg$c266(s1);
     }
     s0 = s1;
 
@@ -4816,17 +4803,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c268;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c269); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s2);
+        s1 = peg$c41(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4858,7 +4845,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c270(s1, s2);
+        s1 = peg$c269(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4879,12 +4866,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c271) {
-            s3 = peg$c271;
+          if (input.substr(peg$currPos, 2) === peg$c270) {
+            s3 = peg$c270;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c272); }
+            if (peg$silentFails === 0) { peg$fail(peg$c271); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -4897,7 +4884,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c273(s1, s2, s4, s5);
+                s1 = peg$c272(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4921,12 +4908,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c271) {
-          s1 = peg$c271;
+        if (input.substr(peg$currPos, 2) === peg$c270) {
+          s1 = peg$c270;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c272); }
+          if (peg$silentFails === 0) { peg$fail(peg$c271); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -4939,7 +4926,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c274(s2, s3);
+              s1 = peg$c273(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4964,16 +4951,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c271) {
-                s3 = peg$c271;
+              if (input.substr(peg$currPos, 2) === peg$c270) {
+                s3 = peg$c270;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c272); }
+                if (peg$silentFails === 0) { peg$fail(peg$c271); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c275(s1, s2);
+                s1 = peg$c274(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4989,16 +4976,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c271) {
-              s1 = peg$c271;
+            if (input.substr(peg$currPos, 2) === peg$c270) {
+              s1 = peg$c270;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c272); }
+              if (peg$silentFails === 0) { peg$fail(peg$c271); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c276();
+              s1 = peg$c275();
             }
             s0 = s1;
           }
@@ -5025,17 +5012,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c268;
+      s1 = peg$c267;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c269); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c277(s2);
+        s1 = peg$c276(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5056,15 +5043,15 @@ function peg$parse(input, options) {
     s1 = peg$parseh16();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c268;
+        s2 = peg$c267;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c269); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c278(s1);
+        s1 = peg$c277(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5088,21 +5075,21 @@ function peg$parse(input, options) {
       s2 = peg$parseinteger();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c117;
+          s3 = peg$c116;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c118); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseinteger();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 46) {
-              s5 = peg$c117;
+              s5 = peg$c116;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c118); }
+              if (peg$silentFails === 0) { peg$fail(peg$c117); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parseinteger();
@@ -5131,7 +5118,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c279(s1);
+        s1 = peg$c278(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -5140,11 +5127,11 @@ function peg$parse(input, options) {
         s2 = peg$parseinteger();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c117;
+            s3 = peg$c116;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c118); }
+            if (peg$silentFails === 0) { peg$fail(peg$c117); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parseinteger();
@@ -5165,7 +5152,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c280(s1);
+          s1 = peg$c279(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -5173,7 +5160,7 @@ function peg$parse(input, options) {
           s1 = peg$parseinteger();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c281(s1);
+            s1 = peg$c280(s1);
           }
           s0 = s1;
         }
@@ -5190,17 +5177,17 @@ function peg$parse(input, options) {
     s1 = peg$parsesub_addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c282;
+        s2 = peg$c281;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c283); }
+        if (peg$silentFails === 0) { peg$fail(peg$c282); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c284(s1, s3);
+          s1 = peg$c283(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5225,17 +5212,17 @@ function peg$parse(input, options) {
     s1 = peg$parseip6addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c282;
+        s2 = peg$c281;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c283); }
+        if (peg$silentFails === 0) { peg$fail(peg$c282); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseinteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c285(s1, s3);
+          s1 = peg$c284(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5260,7 +5247,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesinteger();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c286(s1);
+      s1 = peg$c285(s1);
     }
     s0 = s1;
 
@@ -5272,22 +5259,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c115.test(input.charAt(peg$currPos))) {
+    if (peg$c114.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      if (peg$silentFails === 0) { peg$fail(peg$c115); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c115.test(input.charAt(peg$currPos))) {
+        if (peg$c114.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c116); }
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
         }
       }
     } else {
@@ -5295,7 +5282,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c287(s1);
+      s1 = peg$c286(s1);
     }
     s0 = s1;
 
@@ -5309,7 +5296,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesdouble();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c288(s1);
+      s1 = peg$c287(s1);
     }
     s0 = s1;
 
@@ -5332,11 +5319,11 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c117;
+        s2 = peg$c116;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -5356,7 +5343,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c289();
+            s1 = peg$c288();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5377,11 +5364,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c117;
+        s1 = peg$c116;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -5401,7 +5388,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c289();
+            s1 = peg$c288();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5424,38 +5411,38 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c290;
+      s0 = peg$c289;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c292.test(input.charAt(peg$currPos))) {
+      if (peg$c291.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c293); }
+        if (peg$silentFails === 0) { peg$fail(peg$c292); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c115.test(input.charAt(peg$currPos))) {
+        if (peg$c114.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c116); }
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c115.test(input.charAt(peg$currPos))) {
+          if (peg$c114.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c116); }
+            if (peg$silentFails === 0) { peg$fail(peg$c115); }
           }
         }
         if (s2 !== peg$FAILED) {
@@ -5477,12 +5464,12 @@ function peg$parse(input, options) {
   function peg$parsedoubleDigit() {
     var s0;
 
-    if (peg$c115.test(input.charAt(peg$currPos))) {
+    if (peg$c114.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      if (peg$silentFails === 0) { peg$fail(peg$c115); }
     }
 
     return s0;
@@ -5492,12 +5479,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (peg$c294.test(input.charAt(peg$currPos))) {
+    if (peg$c293.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c295); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -5532,12 +5519,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c296) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c295) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c297); }
+      if (peg$silentFails === 0) { peg$fail(peg$c296); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesignedInteger();
@@ -5572,7 +5559,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c298(s1);
+      s1 = peg$c297(s1);
     }
     s0 = s1;
 
@@ -5582,12 +5569,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c299.test(input.charAt(peg$currPos))) {
+    if (peg$c298.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c299); }
     }
 
     return s0;
@@ -5610,13 +5597,13 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c302(s1);
+      s1 = peg$c301(s1);
     }
     s0 = s1;
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
+      if (peg$silentFails === 0) { peg$fail(peg$c300); }
     }
 
     return s0;
@@ -5627,11 +5614,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c303;
+      s1 = peg$c302;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c304); }
+      if (peg$silentFails === 0) { peg$fail(peg$c303); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -5651,12 +5638,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c305.test(input.charAt(peg$currPos))) {
+      if (peg$c304.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c306); }
+        if (peg$silentFails === 0) { peg$fail(peg$c305); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -5674,11 +5661,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c306); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c112();
+          s1 = peg$c111();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5698,11 +5685,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c308;
+      s1 = peg$c307;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+      if (peg$silentFails === 0) { peg$fail(peg$c308); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -5713,15 +5700,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c308;
+          s3 = peg$c307;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c309); }
+          if (peg$silentFails === 0) { peg$fail(peg$c308); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c310(s2);
+          s1 = peg$c309(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5738,11 +5725,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c311;
+        s1 = peg$c310;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c312); }
+        if (peg$silentFails === 0) { peg$fail(peg$c311); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -5753,15 +5740,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c311;
+            s3 = peg$c310;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c312); }
+            if (peg$silentFails === 0) { peg$fail(peg$c311); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c310(s2);
+            s1 = peg$c309(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5787,11 +5774,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c308;
+      s2 = peg$c307;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c309); }
+      if (peg$silentFails === 0) { peg$fail(peg$c308); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -5809,11 +5796,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c307); }
+        if (peg$silentFails === 0) { peg$fail(peg$c306); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112();
+        s1 = peg$c111();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5826,11 +5813,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c303;
+        s1 = peg$c302;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c304); }
+        if (peg$silentFails === 0) { peg$fail(peg$c303); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -5858,11 +5845,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c311;
+      s2 = peg$c310;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c311); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -5880,11 +5867,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c307); }
+        if (peg$silentFails === 0) { peg$fail(peg$c306); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112();
+        s1 = peg$c111();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5897,11 +5884,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c303;
+        s1 = peg$c302;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c304); }
+        if (peg$silentFails === 0) { peg$fail(peg$c303); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -5927,11 +5914,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c313;
+      s1 = peg$c312;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c314); }
+      if (peg$silentFails === 0) { peg$fail(peg$c313); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -5939,7 +5926,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c315();
+          s1 = peg$c314();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5967,110 +5954,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c311;
+      s0 = peg$c310;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c311); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c308;
+        s0 = peg$c307;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c309); }
+        if (peg$silentFails === 0) { peg$fail(peg$c308); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c303;
+          s0 = peg$c302;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c304); }
+          if (peg$silentFails === 0) { peg$fail(peg$c303); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c316;
+            s1 = peg$c315;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c317); }
+            if (peg$silentFails === 0) { peg$fail(peg$c316); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c318();
+            s1 = peg$c317();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c319;
+              s1 = peg$c318;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c320); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c321();
+              s1 = peg$c320();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c322;
+                s1 = peg$c321;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                if (peg$silentFails === 0) { peg$fail(peg$c322); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c324();
+                s1 = peg$c323();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c325;
+                  s1 = peg$c324;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c326); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c325); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c327();
+                  s1 = peg$c326();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c328;
+                    s1 = peg$c327;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c328); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c330();
+                    s1 = peg$c329();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c331;
+                      s1 = peg$c330;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c332); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c331); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c333();
+                      s1 = peg$c332();
                     }
                     s0 = s1;
                   }
@@ -6090,11 +6077,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c334;
+      s1 = peg$c333;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -6136,25 +6123,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c282;
+      s1 = peg$c281;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c282;
+          s3 = peg$c281;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c282); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c42(s2);
+          s1 = peg$c41(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6177,39 +6164,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c336.test(input.charAt(peg$currPos))) {
+    if (peg$c335.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c336); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c338) {
-        s2 = peg$c338;
+      if (input.substr(peg$currPos, 2) === peg$c337) {
+        s2 = peg$c337;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c339); }
+        if (peg$silentFails === 0) { peg$fail(peg$c338); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c336.test(input.charAt(peg$currPos))) {
+        if (peg$c335.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c337); }
+          if (peg$silentFails === 0) { peg$fail(peg$c336); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c338) {
-            s2 = peg$c338;
+          if (input.substr(peg$currPos, 2) === peg$c337) {
+            s2 = peg$c337;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c339); }
+            if (peg$silentFails === 0) { peg$fail(peg$c338); }
           }
         }
       }
@@ -6218,7 +6205,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c112();
+      s1 = peg$c111();
     }
     s0 = s1;
 
@@ -6228,12 +6215,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c340.test(input.charAt(peg$currPos))) {
+    if (peg$c339.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
 
     return s0;
@@ -6243,51 +6230,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c342;
+      s0 = peg$c341;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c344;
+        s0 = peg$c343;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c345); }
+        if (peg$silentFails === 0) { peg$fail(peg$c344); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c346;
+          s0 = peg$c345;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c347); }
+          if (peg$silentFails === 0) { peg$fail(peg$c346); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c348;
+            s0 = peg$c347;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c349); }
+            if (peg$silentFails === 0) { peg$fail(peg$c348); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c350;
+              s0 = peg$c349;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c351); }
+              if (peg$silentFails === 0) { peg$fail(peg$c350); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c352;
+                s0 = peg$c351;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c353); }
+                if (peg$silentFails === 0) { peg$fail(peg$c352); }
               }
             }
           }
@@ -6315,7 +6302,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
 
     return s0;
@@ -6331,7 +6318,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c306); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -105,9 +105,6 @@ searchPred
   / "**" _? fieldComparator:equalityToken _? v:searchValue {
       RETURN(makeCompareAny(fieldComparator, true, v))
     }
-  / "*" {
-      RETURN(makeBooleanLiteral(true))
-    }
   / f:fieldExpr _? fieldComparator:equalityToken _? v:searchValue {
       RETURN(makeCompareField(fieldComparator, f, v))
     }
@@ -118,12 +115,17 @@ searchPred
       RETURN(makeCompareField("in", f, v))
     }
   / v:searchValue {
-      INIT_ASSIGN_VAR(ss, makeCompareAny("search", true, v))
       IF(getValueType(v) == "string") {
-        RETURN(makeOrChain(ss, ARRAY(makeCompareAny("searchin", true, v))))
+        RETURN(makeOrChain(makeCompareAny("search", true, v), ARRAY(makeCompareAny("searchin", true, v))))
       }
-      ss = makeCompareAny("search", true, makeTypedValue("string", TEXT))
-      RETURN(makeOrChain(ss, ARRAY(makeCompareAny("searchin", true, makeTypedValue("string", TEXT)), makeCompareAny("eql", true, v), makeCompareAny("in", true, v))))
+      IF(getValueType(v) == "regexp") {
+        IF(TEXT == "*") {
+          RETURN(makeBooleanLiteral(true))
+        }
+        RETURN(makeOrChain(makeCompareAny("eql", true, v), ARRAY(makeCompareAny("in", true, v))))
+      }
+
+      RETURN(makeOrChain(makeCompareAny("search", true, makeTypedValue("string", TEXT)), ARRAY(makeCompareAny("searchin", true, makeTypedValue("string", TEXT)), makeCompareAny("eql", true, v), makeCompareAny("in", true, v))))
     }
 
 searchValue


### PR DESCRIPTION
Make a search like "foo*bar" or "*something" work again.
The tests here are rudimentary, it just tests that certain queries
compile, ideally we would also check the semantics of the parsed AST.