### PR TITLE
Coerce ints as seconds

### DIFF
--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -66,7 +66,7 @@ const zngsrc = `
 #7:record[nested:vector[record[field:int]]]
 #8:record[nested:record[vec:vector[int]]]
 #9:record[s:string]
-#10:record[ts:time]
+#10:record[ts:time,ts2:time]
 #11:record[s:string,srec:record[svec:vector[string]]]
 0:[[abc;xyz;]]
 1:[[abc;xyz;]]
@@ -79,7 +79,7 @@ const zngsrc = `
 7:[[[1;][2;]]]
 8:[[[1;2;3;]]]
 9:[begin\x01\x02\xffend;]
-10:[1.001;]
+10:[1.001;1578411532.0;]
 11:[hello;[[world;worldz;1.1.1.1;]]]
 `
 
@@ -161,9 +161,8 @@ func TestFilters(t *testing.T) {
 		{"begin\\x01\\x02\\xffend", records[10], true},
 		{"s=begin\\x01\\x02\\xffend", records[10], true},
 
-		{"ts<2", records[11], false},
-		{"ts=1001000000", records[11], true},
-		{"ts<1002000000", records[11], true},
+		{"ts<2", records[11], true},
+		{"ts2=1578411532", records[11], true},
 		{"T", records[11], false}, // 0x54 matches binary encoding of 1.001 but naked string search shouldn't
 
 		{"ts=1.001", records[11], true},

--- a/pkg/zeek/int.go
+++ b/pkg/zeek/int.go
@@ -125,12 +125,12 @@ func (i Int) Comparison(op string) (Predicate, error) {
 		case *TypeOfTime:
 			ts, err := DecodeTime(val)
 			if err == nil {
-				return CompareInt(int64(ts), pattern)
+				return CompareInt(int64(ts)/1e9, pattern)
 			}
 		case *TypeOfInterval:
 			v, err := DecodeInt(val)
 			if err == nil {
-				return CompareInt(int64(v), pattern)
+				return CompareInt(int64(v)/1e9, pattern)
 			}
 		}
 		return false
@@ -148,9 +148,9 @@ func (i Int) Coerce(typ Type) Value {
 	case *TypeOfPort:
 		return NewPort(uint32(i))
 	case *TypeOfTime:
-		return NewTime(nano.Ts(i))
+		return NewTime(nano.Ts(i * 1e9))
 	case *TypeOfInterval:
-		return NewInterval(int64(i))
+		return NewInterval(int64(i * 1e9))
 	}
 	return nil
 }

--- a/pkg/zeek/interval.go
+++ b/pkg/zeek/interval.go
@@ -73,20 +73,21 @@ func (i *Interval) Coerce(typ Type) Value {
 }
 
 // CoerceToInterval attempts to convert a value to an interval.  Int
-// is converted as nanoseconds and Double is converted as seconds. The
-// resulting coerced value is written to out, and true is returned. If
-// the value cannot be coerced, then false is returned.
+// and Double are converted as seconds. The resulting coerced value is
+// written to out, and true is returned. If the value cannot be
+// coerced, then false is returned.
 func CoerceToInterval(in Value, out *Interval) bool {
 	switch v := in.(type) {
 	case *Interval:
 		*out = *v
 		return true
 	case *Int:
-		*out = Interval(int64(*v))
+		s := *v * 1e9
+		*out = Interval(s)
 		return true
 	case *Double:
 		s := *v * 1e9
-		*out = Interval(int64(s))
+		*out = Interval(s)
 		return true
 	}
 	return false

--- a/pkg/zeek/time.go
+++ b/pkg/zeek/time.go
@@ -81,17 +81,18 @@ func (t *Time) Coerce(typ Type) Value {
 	return nil
 }
 
-// CoerceToTime attempts to convert a value to a time. Int is
-// converted as nanoseconds and Double is converted as seconds. The
-// resulting coerced value is written to out, and true is returned. If
-// the value cannot be coerced, then false is returned.
+// CoerceToTime attempts to convert a value to a time. Int and Double
+// are converted as seconds. The resulting coerced value is written to
+// out, and true is returned. If the value cannot be coerced, then
+// false is returned.
 func CoerceToTime(in Value, out *Time) bool {
 	switch v := in.(type) {
 	case *Time:
 		*out = *v
 		return true
 	case *Int:
-		*out = Time(*v)
+		s := *v * 1e9
+		*out = Time(s)
 		return true
 	case *Double:
 		s := *v * 1e9


### PR DESCRIPTION
This changes ints to be coerced into time/interval as seconds, like doubles.

(Previously they were coerced as nanoseconds, which lead to
head-scratching such as when doing `ts<1578411532` followed by
`ts<1578411532.1`).