### PR TITLE
Adjust URL to plugin repo

### DIFF
--- a/zng/docs/zng-over-http.md
+++ b/zng/docs/zng-over-http.md
@@ -63,5 +63,5 @@ curl -X POST "http://localhost:8080/logs" --data-binary @conn.bzng
 
 ## Reference Implementations
 
-* production client - [zson-http-plugin](https://github.com/looky-cloud/zson-http-plugin)
+* production client - [zeek-tsv-http-plugin](https://github.com/looky-cloud/zeek-tsv-http-plugin)
 * toy server - [zsond](https://github.com/mccanne/zsond)


### PR DESCRIPTION
GitHub is redirecting old URLs, but we might as well point to the official one.