### PR TITLE
replace CI module cache with "go mod download"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,7 @@ jobs:
     steps:
       - log_date
       - checkout
-      - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+      - run: go mod download
       - run:
           name: Go vet
           command: 'make vet'
@@ -37,10 +36,6 @@ jobs:
       - run:
           name: Build
           command: 'make build'
-      - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - /go/pkg/mod
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
I've seen reports that for some folks "go mod download" is now faster than restore_cache. Let's see if it is here.