### PR TITLE
add back regexp comparisons

### DIFF
--- a/tests/suite.go
+++ b/tests/suite.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mccanne/zq/tests/suite/errors"
 	"github.com/mccanne/zq/tests/suite/format"
 	"github.com/mccanne/zq/tests/suite/input"
+	"github.com/mccanne/zq/tests/suite/regexp"
 	"github.com/mccanne/zq/tests/suite/sort"
 	"github.com/mccanne/zq/tests/suite/utf8"
 )
@@ -27,6 +28,7 @@ var internals = []test.Internal{
 	errors.ErrNotContainerZJSON,
 	errors.ErrMissingField,
 	errors.ErrExtraField,
+	regexp.Internal,
 	sort.Internal1,
 	sort.Internal2,
 	sort.Internal3,

--- a/tests/suite/regexp/test.go
+++ b/tests/suite/regexp/test.go
@@ -1,0 +1,28 @@
+package regexp
+
+import (
+	"github.com/mccanne/zq/pkg/test"
+)
+
+var Internal = test.Internal{
+	Name:         "regexp",
+	Query:        "foo*",
+	Input:        test.Trim(input),
+	OutputFormat: "zng",
+	Expected:     test.Trim(expected),
+}
+
+const input = `
+#0:record[a:string,b:string]
+0:[hello;there;]
+0:[foox;there;]
+0:[hello;foox;]
+0:[;foo;]
+`
+
+const expected = `
+#0:record[a:string,b:string]
+0:[foox;there;]
+0:[hello;foox;]
+0:[;foo;]
+`

--- a/zx/compare.go
+++ b/zx/compare.go
@@ -436,6 +436,9 @@ func Contains(compare Predicate) Predicate {
 // of this method as some types limit the operand to equality and
 // the various types handle coercion in different ways.
 func Comparison(op string, literal ast.Literal) (Predicate, error) {
+	if literal.Type == "regexp" {
+		return CompareRegexp(op, literal.Value)
+	}
 	v, err := zng.ParseLiteral(literal)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit also adds a test using regexp since this bug was
introduced without being caught.