### PR TITLE
Encode port with little-endian byte ordering

### DIFF
--- a/zng/port.go
+++ b/zng/port.go
@@ -9,18 +9,18 @@ import (
 
 type TypeOfPort struct{}
 
-func NewPort(p uint32) Value {
+func NewPort(p uint16) Value {
 	return Value{TypePort, EncodePort(p)}
 }
 
-func EncodePort(p uint32) zcode.Bytes {
+func EncodePort(p uint16) zcode.Bytes {
 	var b [2]byte
-	b[0] = byte(p >> 8)
-	b[1] = byte(p)
+	b[0] = byte(p)
+	b[1] = byte(p >> 8)
 	return b[:]
 }
 
-func DecodePort(zv zcode.Bytes) (uint32, error) {
+func DecodePort(zv zcode.Bytes) (uint16, error) {
 	if zv == nil {
 		return 0, ErrUnset
 	}
@@ -28,11 +28,11 @@ func DecodePort(zv zcode.Bytes) (uint32, error) {
 		return 0, errors.New("port encoding must be 2 bytes")
 
 	}
-	return uint32(zv[0])<<8 | uint32(zv[1]), nil
+	return uint16(zv[0]) | uint16(zv[1])<<8, nil
 }
 
 func (t *TypeOfPort) Parse(in []byte) (zcode.Bytes, error) {
-	i, err := UnsafeParseUint32(in)
+	i, err := UnsafeParseUint16(in)
 	if err != nil {
 		return nil, err
 	}

--- a/zng/unsafe.go
+++ b/zng/unsafe.go
@@ -42,6 +42,11 @@ func UnsafeParseFloat64(b []byte) (float64, error) {
 	return strconv.ParseFloat(ustring(b), 10)
 }
 
+func UnsafeParseUint16(b []byte) (uint16, error) {
+	v, err := strconv.ParseUint(ustring(b), 10, 16)
+	return uint16(v), err
+}
+
 func UnsafeParseUint32(b []byte) (uint32, error) {
 	v, err := strconv.ParseUint(ustring(b), 10, 32)
 	return uint32(v), err

--- a/zx/coerce.go
+++ b/zx/coerce.go
@@ -33,7 +33,7 @@ func CoerceToDouble(in zng.Value) (float64, bool) {
 		v, err = zng.DecodeCount(in.Bytes)
 		out = float64(v)
 	case *zng.TypeOfPort:
-		var v uint32
+		var v uint16
 		v, err = zng.DecodePort(in.Bytes)
 		out = float64(v)
 	case *zng.TypeOfTime:
@@ -75,7 +75,7 @@ func CoerceToInt(in zng.Value) (int64, bool) {
 		}
 		out = int64(v)
 	case *zng.TypeOfPort:
-		var v uint32
+		var v uint16
 		v, err = zng.DecodePort(body)
 		out = int64(v)
 	case *zng.TypeOfDouble:


### PR DESCRIPTION
It appears that the rest of zq uses little-ending byte ordering, but
port does not. Fix that.

Also, that native format of a port should be uint16 instead of uint32, so fix
that.