### PR TITLE
Show hex code for escaped hyphen

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -583,7 +583,7 @@ Any value can be specified as "unset" with the ASCII character `-`.
 This is typically used to represent columns of records where not all
 columns have been set in a given record value, though any type can be
 validly unset.  A value that is not to be interpreted as "unset"
-but is the single-character string `-`, must be escaped (e.g., `\-`).
+but is the single-character string `-`, must be escaped (e.g., `\x2d`).
 
 Note that this syntax can be scanned and parsed independent of the
 actual type definition indicated by the descriptor.  It is a semantic error


### PR DESCRIPTION
The `zq` implementation currently outputs ZNG that uses hex codes for escaping the hyphen to disambiguate from "unset":

```
# echo '{"foo": "-"}' | zq -
#0:record[foo:string]
0:[\x2d;]
```

This PR syncs the spec up with that.