### PR TITLE
Use \u escapes in json where possible

### DIFF
--- a/tests/suite.go
+++ b/tests/suite.go
@@ -21,6 +21,7 @@ var internals = []test.Internal{
 	cut.Internal,
 	format.Internal,
 	format.JsonTypes,
+	format.JsonString,
 	input.JSON,
 	input.Backslash,
 	errors.DuplicateFields,

--- a/tests/suite/format/json.go
+++ b/tests/suite/format/json.go
@@ -21,3 +21,21 @@ const jsonInput = `
 const jsonExpected = `
 {"a":"10.1.1.1","a2":"fe80::eef4:bbff:fe51:89ec","b":true,"c":517,"d":3.14159,"e":"foo","i":18,"interval":60000000000,"p":443,"s":"Hello, world!","t":1578407783487000000}
 `
+
+// Test that non-printable unicode characters are properly escaped.
+const stringIn = `
+#0:record[s:string]
+0:[\x03;]
+`
+
+const stringExpected = `
+{"s":"\u0003"}
+`
+
+var JsonString = test.Internal{
+	Name:         "json string formatting",
+	Query:        "*",
+	Input:        test.Trim(stringIn),
+	OutputFormat: "ndjson",
+	Expected:     test.Trim(stringExpected),
+}

--- a/zbuf/zval.go
+++ b/zbuf/zval.go
@@ -47,7 +47,7 @@ func appendZvalFromZeek(dst zcode.Bytes, typ zng.Type, val []byte) zcode.Bytes {
 
 func escape(s string, utf8 bool) string {
 	if utf8 {
-		return zng.EscapeUTF8([]byte(s))
+		return zng.EscapeUTF8([]byte(s), false)
 	}
 	return zng.Escape([]byte(s))
 }

--- a/zng/escape.go
+++ b/zng/escape.go
@@ -29,7 +29,7 @@ func Escape(data []byte) string {
 
 // EscapeUTF8 does the same non-standard formatting of mixed-binary strings
 // that zeek does.  There is no way to disambiguate between random binary data
-// and a deliberate utf-8 string so it's left to the "presenation layer" to
+// and a deliberate utf-8 string so it's left to the "presentation layer" to
 // decide how to format the data.  This is not an issue for the ZNG types
 // "string" (which must always be valid UTF-8) and "bytes" (which is defined
 // to be an anonymous buffer of bytes and hence not treated as text).  But

--- a/zng/string.go
+++ b/zng/string.go
@@ -43,5 +43,5 @@ func (t *TypeOfString) StringOf(zv zcode.Bytes) string {
 
 func (t *TypeOfString) Marshal(zv zcode.Bytes) (interface{}, error) {
 	// XXX this should be done by ZNG bstring, not string
-	return EscapeUTF8(zv), nil
+	return EscapeUTF8(zv, true), nil
 }


### PR DESCRIPTION
Don't use \x to escape valid non-printable unicode code points in
json output.