### PR TITLE
fix bugs with marshaling zng.Context

### DIFF
--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -87,7 +87,7 @@ func (d *Dir) filename(r *zng.Record) (string, string) {
 	if err == nil {
 		path = base
 	} else {
-		base = strconv.Itoa(r.Type.ID)
+		base = strconv.Itoa(r.Type.ID())
 	}
 	name := d.prefix + base + d.ext
 	return filepath.Join(d.dir, name), path

--- a/proc/cut.go
+++ b/proc/cut.go
@@ -49,7 +49,7 @@ func CompileCutProc(c *Context, parent Proc, node *ast.CutProc) (*Cut, error) {
 func (c *Cut) cut(in *zng.Record) *zng.Record {
 	// Check if we already have an output descriptor for this
 	// input type
-	typ, ok := c.cutmap[in.Type.ID]
+	typ, ok := c.cutmap[in.Type.ID()]
 	if ok && typ == nil {
 		// One or more cut fields isn't present in this type of
 		// input record, drop it now.
@@ -70,7 +70,7 @@ func (c *Cut) cut(in *zng.Record) *zng.Record {
 		if typ == nil {
 			if val.Type == nil {
 				// a field is missing... block this descriptor
-				c.cutmap[in.Type.ID] = nil
+				c.cutmap[in.Type.ID()] = nil
 				c.nblocked++
 				return nil
 			}
@@ -81,7 +81,7 @@ func (c *Cut) cut(in *zng.Record) *zng.Record {
 	if typ == nil {
 		cols := c.builder.TypedColumns(types)
 		typ = c.TypeContext.LookupByColumns(cols)
-		c.cutmap[in.Type.ID] = typ
+		c.cutmap[in.Type.ID()] = typ
 	}
 
 	zv, err := c.builder.Encode()

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -226,9 +226,9 @@ var blocked = &zng.TypeRecord{}
 func (g *GroupByAggregator) Consume(r *zng.Record) error {
 	// First check if we've seen this descriptor before and if not
 	// build an entry for it.
-	keysType := g.keysMap.Map(r.Type.ID)
+	keysType := g.keysMap.Map(r.Type.ID())
 	if keysType == nil {
-		id := r.Type.ID
+		id := r.Type.ID()
 		recType := keysTypeRecord(g.kctx, r, g.keys)
 		if recType == nil {
 			g.keysMap.EnterDescriptor(id, blocked)
@@ -259,7 +259,7 @@ func (g *GroupByAggregator) Consume(r *zng.Record) error {
 	} else {
 		keyBytes = make(zcode.Bytes, 4, 128)
 	}
-	binary.BigEndian.PutUint32(keyBytes, uint32(keysType.ID))
+	binary.BigEndian.PutUint32(keyBytes, uint32(keysType.ID()))
 	g.builder.Reset()
 	for _, key := range g.keys {
 		keyVal := key.resolver(r)

--- a/zio/bzngio/writer.go
+++ b/zio/bzngio/writer.go
@@ -20,7 +20,7 @@ func NewWriter(w io.Writer) *Writer {
 }
 
 func (w *Writer) Write(r *zng.Record) error {
-	id := r.Type.ID
+	id := r.Type.ID()
 	if !w.tracker.Seen(id) {
 		b := []byte(r.Type.String())
 		if err := w.encode(TypeDescriptor, id, b); err != nil {

--- a/zio/ndjsonio/parser.go
+++ b/zio/ndjsonio/parser.go
@@ -77,7 +77,7 @@ func (*stubTypeOf) Coerce(zv zcode.Bytes, typ zng.Type) zcode.Bytes {
 	return nil
 }
 
-func (*stubTypeOf) Id() int {
+func (*stubTypeOf) ID() int {
 	return -1
 }
 

--- a/zio/ndjsonio/parser.go
+++ b/zio/ndjsonio/parser.go
@@ -77,6 +77,10 @@ func (*stubTypeOf) Coerce(zv zcode.Bytes, typ zng.Type) zcode.Bytes {
 	return nil
 }
 
+func (*stubTypeOf) Id() int {
+	return -1
+}
+
 func (p *Parser) jsonParseObject(b []byte) (zng.Type, error) {
 	type kv struct {
 		key   []byte

--- a/zio/zeekio/flatten.go
+++ b/zio/zeekio/flatten.go
@@ -51,7 +51,7 @@ func recode(dst zcode.Bytes, typ *zng.TypeRecord, in zcode.Bytes) (zcode.Bytes, 
 }
 
 func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
-	id := r.Type.ID
+	id := r.Type.ID()
 	outputType := f.mapper.Map(id)
 	if outputType == nil {
 		cols := flattenColumns(r.Type.Columns)

--- a/zio/zjsonio/stream.go
+++ b/zio/zjsonio/stream.go
@@ -20,7 +20,7 @@ func NewStream() *Stream {
 }
 
 func (s *Stream) Transform(r *zng.Record) (*Record, error) {
-	id := r.Type.ID
+	id := r.Type.ID()
 	var typ []interface{}
 	if !s.tracker.Seen(id) {
 		var err error

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -31,7 +31,7 @@ func (w *Writer) WriteControl(b []byte) error {
 }
 
 func (w *Writer) Write(r *zng.Record) error {
-	inId := r.Type.ID
+	inId := r.Type.ID()
 	outId, ok := w.tracker[inId]
 	if !ok {
 		outId = len(w.tracker)

--- a/zng/addr.go
+++ b/zng/addr.go
@@ -40,6 +40,10 @@ func (t *TypeOfAddr) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeAddr(ip), nil
 }
 
+func (t *TypeOfAddr) Id() int {
+	return IdIP
+}
+
 func (t *TypeOfAddr) String() string {
 	return "addr"
 }

--- a/zng/addr.go
+++ b/zng/addr.go
@@ -40,7 +40,7 @@ func (t *TypeOfAddr) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeAddr(ip), nil
 }
 
-func (t *TypeOfAddr) Id() int {
+func (t *TypeOfAddr) ID() int {
 	return IdIP
 }
 

--- a/zng/bool.go
+++ b/zng/bool.go
@@ -36,6 +36,10 @@ func (t *TypeOfBool) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeBool(b), nil
 }
 
+func (t *TypeOfBool) Id() int {
+	return IdBool
+}
+
 func (t *TypeOfBool) String() string {
 	return "bool"
 }

--- a/zng/bool.go
+++ b/zng/bool.go
@@ -36,7 +36,7 @@ func (t *TypeOfBool) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeBool(b), nil
 }
 
-func (t *TypeOfBool) Id() int {
+func (t *TypeOfBool) ID() int {
 	return IdBool
 }
 

--- a/zng/column.go
+++ b/zng/column.go
@@ -1,59 +1,21 @@
 package zng
 
 import (
-	"encoding/json"
 	"strings"
 )
 
-type ColumnProto struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-}
-
 // Column defines the field name and type of a column in a record type.
 type Column struct {
-	ColumnProto
+	Name string
 	Type Type
 }
 
 func NewColumn(name string, typ Type) Column {
-	c := Column{}
-	c.Name = name
-	c.Type = typ
-	return c
+	return Column{name, typ}
 }
 
 func (c *Column) String() string {
 	return c.Name + ":" + c.Type.String()
-}
-
-func (c *Column) MarshalJSON() ([]byte, error) {
-	if c.ColumnProto.Type == "" {
-		c.ColumnProto.Type = c.Type.String()
-	}
-	return json.Marshal(c.ColumnProto)
-}
-
-// Typify fills in the native Type value for each column given a type context.
-// If the context  is nil, then types are looked up as primitive types.
-func Typify(c Context, columns []Column) error {
-	for k := range columns {
-		if columns[k].Type == nil {
-			typeName := columns[k].ColumnProto.Type
-			var typ Type
-			if c != nil {
-				var err error
-				typ, err = c.LookupByName(typeName)
-				if err != nil {
-					return err
-				}
-			} else {
-				typ = LookupPrimitive(typeName)
-			}
-			columns[k].Type = typ
-		}
-	}
-	return nil
 }
 
 func ColumnString(prefix string, columns []Column, suffix string) string {

--- a/zng/count.go
+++ b/zng/count.go
@@ -33,6 +33,10 @@ func (t *TypeOfCount) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeCount(c), nil
 }
 
+func (t *TypeOfCount) Id() int {
+	return IdUint64
+}
+
 func (t *TypeOfCount) String() string {
 	return "count"
 }

--- a/zng/count.go
+++ b/zng/count.go
@@ -33,7 +33,7 @@ func (t *TypeOfCount) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeCount(c), nil
 }
 
-func (t *TypeOfCount) Id() int {
+func (t *TypeOfCount) ID() int {
 	return IdUint64
 }
 

--- a/zng/double.go
+++ b/zng/double.go
@@ -46,6 +46,10 @@ func (t *TypeOfDouble) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeDouble(d), nil
 }
 
+func (t *TypeOfDouble) Id() int {
+	return IdFloat64
+}
+
 func (t *TypeOfDouble) String() string {
 	return "double"
 }

--- a/zng/double.go
+++ b/zng/double.go
@@ -46,7 +46,7 @@ func (t *TypeOfDouble) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeDouble(d), nil
 }
 
-func (t *TypeOfDouble) Id() int {
+func (t *TypeOfDouble) ID() int {
 	return IdFloat64
 }
 

--- a/zng/enum.go
+++ b/zng/enum.go
@@ -25,7 +25,7 @@ func (t *TypeOfEnum) Parse(in []byte) (zcode.Bytes, error) {
 	return in, nil
 }
 
-func (t *TypeOfEnum) Id() int {
+func (t *TypeOfEnum) ID() int {
 	return IdEnum
 }
 

--- a/zng/enum.go
+++ b/zng/enum.go
@@ -25,6 +25,10 @@ func (t *TypeOfEnum) Parse(in []byte) (zcode.Bytes, error) {
 	return in, nil
 }
 
+func (t *TypeOfEnum) Id() int {
+	return IdEnum
+}
+
 func (t *TypeOfEnum) String() string {
 	return "enum"
 }

--- a/zng/int.go
+++ b/zng/int.go
@@ -41,6 +41,10 @@ func (t *TypeOfInt) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeInt(i), nil
 }
 
+func (t *TypeOfInt) Id() int {
+	return IdInt64
+}
+
 func (t *TypeOfInt) String() string {
 	return "int"
 }

--- a/zng/int.go
+++ b/zng/int.go
@@ -41,7 +41,7 @@ func (t *TypeOfInt) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeInt(i), nil
 }
 
-func (t *TypeOfInt) Id() int {
+func (t *TypeOfInt) ID() int {
 	return IdInt64
 }
 

--- a/zng/interval.go
+++ b/zng/interval.go
@@ -27,7 +27,7 @@ func (t *TypeOfInterval) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeInterval(int64(dur)), nil
 }
 
-func (t *TypeOfInterval) Id() int {
+func (t *TypeOfInterval) ID() int {
 	return IdDuration
 }
 

--- a/zng/interval.go
+++ b/zng/interval.go
@@ -27,6 +27,10 @@ func (t *TypeOfInterval) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeInterval(int64(dur)), nil
 }
 
+func (t *TypeOfInterval) Id() int {
+	return IdDuration
+}
+
 func (t *TypeOfInterval) String() string {
 	return "interval"
 }

--- a/zng/port.go
+++ b/zng/port.go
@@ -39,7 +39,7 @@ func (t *TypeOfPort) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodePort(i), nil
 }
 
-func (t *TypeOfPort) Id() int {
+func (t *TypeOfPort) ID() int {
 	return IdPort
 }
 

--- a/zng/port.go
+++ b/zng/port.go
@@ -39,6 +39,10 @@ func (t *TypeOfPort) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodePort(i), nil
 }
 
+func (t *TypeOfPort) Id() int {
+	return IdPort
+}
+
 func (t *TypeOfPort) String() string {
 	return "port"
 }

--- a/zng/record.go
+++ b/zng/record.go
@@ -1,7 +1,6 @@
 package zng
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/mccanne/zq/zcode"
@@ -42,20 +41,12 @@ func TypeRecordString(columns []Column) string {
 	return ColumnString("record[", columns, "]")
 }
 
+func (t *TypeRecord) Id() int {
+	return t.ID
+}
+
 func (t *TypeRecord) String() string {
 	return ColumnString("record[", t.Columns, "]")
-}
-
-func (t TypeRecord) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Columns)
-}
-
-func (t *TypeRecord) UnmarshalJSON(data []byte) error {
-	if err := json.Unmarshal(data, &t.Columns); err != nil {
-		return err
-	}
-	Typify(t.Context, t.Columns)
-	return nil
 }
 
 //XXX we shouldn't need this... tests are using it

--- a/zng/record.go
+++ b/zng/record.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TypeRecord struct {
-	ID      int
+	id      int
 	Columns []Column
 	LUT     map[string]int
 	TsCol   int
@@ -26,7 +26,7 @@ func CopyTypeRecord(id int, r *TypeRecord) *TypeRecord {
 
 func NewTypeRecord(id int, columns []Column) *TypeRecord {
 	r := &TypeRecord{
-		ID:      id,
+		id:      id,
 		Columns: columns,
 		TsCol:   -1,
 		Key:     ColumnString("", columns, ""), //XXX
@@ -40,8 +40,13 @@ func TypeRecordString(columns []Column) string {
 	return ColumnString("record[", columns, "]")
 }
 
-func (t *TypeRecord) Id() int {
-	return t.ID
+func (t *TypeRecord) ID() int {
+	return t.id
+}
+
+//XXX get rid of this when we implement full ZNG
+func (t *TypeRecord) SetID(id int) {
+	t.id = id
 }
 
 func (t *TypeRecord) String() string {

--- a/zng/record.go
+++ b/zng/record.go
@@ -7,7 +7,6 @@ import (
 )
 
 type TypeRecord struct {
-	Context
 	ID      int
 	Columns []Column
 	LUT     map[string]int

--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -93,7 +93,7 @@ func (c *Context) makeSetType(id int, aliases []Alias) (*zng.TypeSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &zng.TypeSet{Context: c, ID: id, InnerType: typ}, nil
+	return &zng.TypeSet{ID: id, InnerType: typ}, nil
 }
 
 func (c *Context) makeVectorType(id int, aliases []Alias) (*zng.TypeVector, error) {
@@ -102,7 +102,7 @@ func (c *Context) makeVectorType(id int, aliases []Alias) (*zng.TypeVector, erro
 	if err != nil {
 		return nil, err
 	}
-	return &zng.TypeVector{Context: c, ID: id, Type: typ}, nil
+	return &zng.TypeVector{ID: id, Type: typ}, nil
 }
 
 func (c *Context) makeRecordType(id int, aliases []Alias) (*zng.TypeRecord, error) {

--- a/zng/resolver/context_test.go
+++ b/zng/resolver/context_test.go
@@ -41,5 +41,5 @@ func TestContextMarshaling(t *testing.T) {
 	require.NoError(t, err)
 	r2, err := ctx.LookupByName("record[a:int,b:int]")
 	require.NoError(t, err)
-	assert.EqualValues(t, r1.(*zng.TypeRecord).ID, r2.(*zng.TypeRecord).ID)
+	assert.EqualValues(t, r1.ID(), r2.ID())
 }

--- a/zng/resolver/context_test.go
+++ b/zng/resolver/context_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/mccanne/zq/pkg/nano"
@@ -10,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTableAddColumns(t *testing.T) {
+func TestContextAddColumns(t *testing.T) {
 	ctx := NewContext()
 	d := ctx.LookupByColumns([]zng.Column{zng.NewColumn("s1", zng.TypeString)})
 	r, err := zbuf.NewRecordZeekStrings(d, "S1")
@@ -25,4 +26,20 @@ func TestTableAddColumns(t *testing.T) {
 	assert.EqualValues(t, "S2", r.Value(2).String())
 	zv, _ := r.Slice(4)
 	assert.Nil(t, zv)
+}
+
+func TestContextMarshaling(t *testing.T) {
+	ctx := NewContext()
+	ctx.LookupByName("record[a:set[string],b:int]]")
+	ctx.LookupByName("record[a:vector[record[a:int,b:int]],b:int]]")
+	b, err := json.Marshal(ctx)
+	require.NoError(t, err)
+	var newCtx *Context
+	err = json.Unmarshal(b, &newCtx)
+	require.NoError(t, err)
+	r1, err := ctx.LookupByName("record[a:int,b:int]")
+	require.NoError(t, err)
+	r2, err := ctx.LookupByName("record[a:int,b:int]")
+	require.NoError(t, err)
+	assert.EqualValues(t, r1.(*zng.TypeRecord).ID, r2.(*zng.TypeRecord).ID)
 }

--- a/zng/resolver/file.go
+++ b/zng/resolver/file.go
@@ -23,7 +23,7 @@ func NewFile(path string) *File {
 	return &File{Context: NewContext(), path: path, nstored: -1}
 }
 
-// Save writes this descriptor table to disk.
+// Save writes this context table to disk.
 func (f *File) Save() error {
 	//XXX use jsonfile?  why 0755?
 	if err := os.MkdirAll(filepath.Dir(f.path), 0755); err != nil {

--- a/zng/resolver/filter.go
+++ b/zng/resolver/filter.go
@@ -20,7 +20,7 @@ func NewFilter(f Predicate) *Filter {
 }
 
 func (f *Filter) Match(d *zng.TypeRecord) bool {
-	td := d.ID
+	td := d.ID()
 	v := f.lookup(td)
 	if v == nil {
 		if f.filter(d) {

--- a/zng/set.go
+++ b/zng/set.go
@@ -7,13 +7,18 @@ import (
 )
 
 type TypeSet struct {
+	Context
+	ID        int
 	InnerType Type
+}
+
+func (t *TypeSet) Id() int {
+	return t.ID
 }
 
 func (t *TypeSet) String() string {
 	return fmt.Sprintf("set[%s]", t.InnerType)
 }
-
 func (t *TypeSet) Decode(zv zcode.Bytes) ([]Value, error) {
 	if zv == nil {
 		return nil, ErrUnset

--- a/zng/set.go
+++ b/zng/set.go
@@ -7,12 +7,21 @@ import (
 )
 
 type TypeSet struct {
-	ID        int
+	id        int
 	InnerType Type
 }
 
-func (t *TypeSet) Id() int {
-	return t.ID
+func NewTypeSet(id int, typ Type) *TypeSet {
+	return &TypeSet{id, typ}
+}
+
+func (t *TypeSet) ID() int {
+	return t.id
+}
+
+//XXX get rid of this when we implement full ZNG
+func (t *TypeSet) SetID(id int) {
+	t.id = id
 }
 
 func (t *TypeSet) String() string {

--- a/zng/set.go
+++ b/zng/set.go
@@ -7,7 +7,6 @@ import (
 )
 
 type TypeSet struct {
-	Context
 	ID        int
 	InnerType Type
 }

--- a/zng/string.go
+++ b/zng/string.go
@@ -27,7 +27,7 @@ func (t *TypeOfString) Parse(in []byte) (zcode.Bytes, error) {
 	return normalized, nil
 }
 
-func (t *TypeOfString) Id() int {
+func (t *TypeOfString) ID() int {
 	return IdBstring
 }
 

--- a/zng/string.go
+++ b/zng/string.go
@@ -27,6 +27,10 @@ func (t *TypeOfString) Parse(in []byte) (zcode.Bytes, error) {
 	return normalized, nil
 }
 
+func (t *TypeOfString) Id() int {
+	return IdBstring
+}
+
 func (t *TypeOfString) String() string {
 	return "string"
 }

--- a/zng/subnet.go
+++ b/zng/subnet.go
@@ -61,6 +61,10 @@ func (t *TypeOfSubnet) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeSubnet(subnet), nil
 }
 
+func (t *TypeOfSubnet) Id() int {
+	return IdNet
+}
+
 func (t *TypeOfSubnet) String() string {
 	return "subnet"
 }

--- a/zng/subnet.go
+++ b/zng/subnet.go
@@ -61,7 +61,7 @@ func (t *TypeOfSubnet) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeSubnet(subnet), nil
 }
 
-func (t *TypeOfSubnet) Id() int {
+func (t *TypeOfSubnet) ID() int {
 	return IdNet
 }
 

--- a/zng/time.go
+++ b/zng/time.go
@@ -32,7 +32,7 @@ func (t *TypeOfTime) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeTime(ts), nil
 }
 
-func (t *TypeOfTime) Id() int {
+func (t *TypeOfTime) ID() int {
 	return IdTime
 }
 

--- a/zng/time.go
+++ b/zng/time.go
@@ -32,6 +32,10 @@ func (t *TypeOfTime) Parse(in []byte) (zcode.Bytes, error) {
 	return EncodeTime(ts), nil
 }
 
+func (t *TypeOfTime) Id() int {
+	return IdTime
+}
+
 func (t *TypeOfTime) String() string {
 	return "time"
 }

--- a/zng/type.go
+++ b/zng/type.go
@@ -46,6 +46,7 @@ type Type interface {
 	// encoding.  The string input is provided as a byte slice for efficiency
 	// given the common use cases in the system.
 	Parse([]byte) (zcode.Bytes, error)
+	Id() int
 }
 
 var (
@@ -60,6 +61,28 @@ var (
 	TypeAddr     = &TypeOfAddr{}
 	TypeSubnet   = &TypeOfSubnet{}
 	TypeEnum     = &TypeOfEnum{}
+)
+
+const (
+	IdBool     = 0
+	IdByte     = 1
+	IdInt16    = 2
+	IdUint16   = 3
+	IdInt32    = 4
+	IdUint32   = 5
+	IdInt64    = 6
+	IdUint64   = 7
+	IdFloat64  = 8
+	IdString   = 9
+	IdBytes    = 10
+	IdBstring  = 11
+	IdEnum     = 12
+	IdIP       = 13
+	IdPort     = 14
+	IdNet      = 15
+	IdTime     = 16
+	IdDuration = 17
+	IdAny      = 18
 )
 
 func LookupPrimitive(name string) Type {
@@ -85,6 +108,34 @@ func LookupPrimitive(name string) Type {
 	case "subnet":
 		return TypeSubnet
 	case "enum":
+		return TypeEnum
+	}
+	return nil
+}
+
+func LookupPrimitiveById(id int) Type {
+	switch id {
+	case IdBool:
+		return TypeBool
+	case IdUint64:
+		return TypeCount
+	case IdInt64:
+		return TypeInt
+	case IdFloat64:
+		return TypeDouble
+	case IdTime:
+		return TypeTime
+	case IdDuration:
+		return TypeInterval
+	case IdBstring:
+		return TypeString
+	case IdPort:
+		return TypePort
+	case IdIP:
+		return TypeAddr
+	case IdNet:
+		return TypeSubnet
+	case IdEnum:
 		return TypeEnum
 	}
 	return nil

--- a/zng/type.go
+++ b/zng/type.go
@@ -46,7 +46,7 @@ type Type interface {
 	// encoding.  The string input is provided as a byte slice for efficiency
 	// given the common use cases in the system.
 	Parse([]byte) (zcode.Bytes, error)
-	Id() int
+	ID() int
 }
 
 var (

--- a/zng/vector.go
+++ b/zng/vector.go
@@ -7,7 +7,6 @@ import (
 )
 
 type TypeVector struct {
-	Context
 	ID   int
 	Type Type
 }

--- a/zng/vector.go
+++ b/zng/vector.go
@@ -7,12 +7,21 @@ import (
 )
 
 type TypeVector struct {
-	ID   int
+	id   int
 	Type Type
 }
 
-func (t *TypeVector) Id() int {
-	return t.ID
+func NewTypeVector(id int, typ Type) *TypeVector {
+	return &TypeVector{id, typ}
+}
+
+func (t *TypeVector) ID() int {
+	return t.id
+}
+
+//XXX get rid of this when we implement full ZNG
+func (t *TypeVector) SetID(id int) {
+	t.id = id
 }
 
 func (t *TypeVector) String() string {

--- a/zng/vector.go
+++ b/zng/vector.go
@@ -7,7 +7,13 @@ import (
 )
 
 type TypeVector struct {
+	Context
+	ID   int
 	Type Type
+}
+
+func (t *TypeVector) Id() int {
+	return t.ID
 }
 
 func (t *TypeVector) String() string {


### PR DESCRIPTION
This commit fixes bugs with the zng.Context and zng.Type marhaling
logic.  It also adds a test so marshaling problems may be detected
down the road since a regressions was previously missed.

Along the way here, we moved closer to supporting the latest ZNG spec
by introducing typedefs and type IDs.

Any external code that relies upon marshaling types will have to be
update as we are encouraging a model where you send a type as a
string conforming to the ZNG type system or you send ZNG directly
which embeds the type definitions, rather than marshaling the
Go type objects.

The marshaling logic for saving resolver.Contexts is a placeholder
until we get the ZNG implementation up to date.  At that point,
we will deprecate the marshal interface on resolver.Context and
replace this with methods to read and write contexts as BZNG
files that exclusively contain typedefs.