### PR TITLE
fix data race in resolver.Translator

### DIFF
--- a/zng/resolver/translator.go
+++ b/zng/resolver/translator.go
@@ -1,10 +1,13 @@
 package resolver
 
 import (
+	"sync"
+
 	"github.com/mccanne/zq/zng"
 )
 
 type Translator struct {
+	mu sync.Mutex
 	Slice
 	inputCtx  *Context
 	outputCtx *Context
@@ -19,6 +22,8 @@ func NewTranslator(in, out *Context) *Translator {
 
 // Lookup implements zng.Resolver
 func (t *Translator) Lookup(id int) *zng.TypeRecord {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	outputType := t.lookup(id)
 	if outputType == nil {
 		inputType := t.inputCtx.Lookup(id)


### PR DESCRIPTION
This commit fixes a data race in resolver.Translator where multiple
threads simultaneously try to create the same mapping. The solution
is to wrap a mutex around Lookup and rely on a resolver.Cache to
make put a lock-free layer above.