### PR TITLE
Fix group-by keys bug and make type record allocation more robust

### DIFF
--- a/zio/ndjsonio/parser.go
+++ b/zio/ndjsonio/parser.go
@@ -49,38 +49,6 @@ func (p *Parser) Parse(b []byte) (zcode.Bytes, zng.Type, error) {
 	return p.builder.Bytes(), ztyp, nil
 }
 
-type stubTypeOf struct{}
-
-var stubType = &stubTypeOf{}
-
-func (*stubTypeOf) String() string {
-	return "none"
-}
-
-func (*stubTypeOf) Parse(in []byte) (zcode.Bytes, error) {
-	return nil, nil
-}
-
-func (*stubTypeOf) Format(value []byte) (interface{}, error) {
-	return "none", nil
-}
-
-func (*stubTypeOf) StringOf(zv zcode.Bytes) string {
-	return "-"
-}
-
-func (*stubTypeOf) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return nil, nil
-}
-
-func (*stubTypeOf) Coerce(zv zcode.Bytes, typ zng.Type) zcode.Bytes {
-	return nil
-}
-
-func (*stubTypeOf) ID() int {
-	return -1
-}
-
 func (p *Parser) jsonParseObject(b []byte) (zng.Type, error) {
 	type kv struct {
 		key   []byte
@@ -105,7 +73,7 @@ func (p *Parser) jsonParseObject(b []byte) (zng.Type, error) {
 	// through Unflatten() to find nested records.
 	columns := make([]zng.Column, len(kvs))
 	for i, kv := range kvs {
-		columns[i] = zng.NewColumn(string(kv.key), stubType)
+		columns[i] = zng.NewColumn(string(kv.key), zng.TypeString)
 	}
 	columns, _ = zeekio.Unflatten(p.zctx, columns, false)
 

--- a/zng/record.go
+++ b/zng/record.go
@@ -50,7 +50,7 @@ func (t *TypeRecord) SetID(id int) {
 }
 
 func (t *TypeRecord) String() string {
-	return ColumnString("record[", t.Columns, "]")
+	return TypeRecordString(t.Columns)
 }
 
 //XXX we shouldn't need this... tests are using it


### PR DESCRIPTION
This commit fixes a group-by keys bug where a zero-length record
was illegaly put in the type context.  It also makes the creation
of new record types more robust by guaranteeing that the columns
of the newly created record have types (resurively speaking) that
all come from the context being called.  This way, LookupByColumns
cannot return a new record type that has columns with types that
point into othe contexts.

Along the way, we got rid of the stub type in ndjsonio, since any
old type would do (we changed it to string), when it calls unflatten
to find nested records.  With the change to LookupByColumns, the
stub type was no longer tolerated.

Finally, this commit also adds more friendly marshaling of
the type context table.  This code is all going away when we
switch to native BZNG files to represent type contexts, but it
was useful in debugging these problems here for now.