### PR TITLE
Escape clarifications

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -602,7 +602,7 @@ This allows binary data that does not conform to a valid UTF-8 character encodin
 to be embedded in the `bstring` data type.
 
 These special characters must be hex escaped if they appear within a `bstring`
-or a `string` type:
+type:
 ```
 ; \n \\
 ```
@@ -618,7 +618,7 @@ to `-` as opposed to representing an unset value.
 
 > `\x` followed by anything other than two hexadecimal digits is not a valid
 > escape sequence. The behavior of an implementation that encounters such
-> invalid sequences in a `bstring` or `string` type is undefined.
+> invalid sequences in a `bstring` type is undefined.
 
 #### 3.2.2 Value Syntax
 

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -412,7 +412,7 @@ Following the tag encoding is the value encoded in N bytes as described above.
 The ZNG text format is a human-readable form that follows directly from the BZNG
 binary format.  A stream of control messages and values messages is represented
 as a sequence of UTF-8 lines each terminated by a newline.  Any newlines embedded
-in values must be escaped, i.e., via `\n`.
+in values must be escaped, i.e., via `\x0a`.
 
 A line that begins with `#` is a control message.
 
@@ -615,6 +615,10 @@ of a value:
 ```
 In addition, `-` must be escaped if representing the single ASCII byte equal
 to `-` as opposed to representing an unset value.
+
+> `\x` followed by anything other than two hexadecimal digits is not a valid
+> escape sequence. The behavior of an implementation that encounters such
+> invalid sequences in a `bstring` or `string` type is undefined.
 
 #### 3.2.2 Value Syntax
 


### PR DESCRIPTION
I'm attempting two clarifications here:

1. The spec had implied that escaped newlines were handled via `\n`. However, checking in on how Zeek handles them, a Zeek script that logs a string "`\n`" lands it in the TSV output as `\x0a`. Also, how the `zq` implementation of ZNG currently behaves:
      ```
      $ cat newline.zng 
      #0:record[newline_escape:string]
      0:[\n;]
      
      $ zq newline.zng 
      #0:record[newline_escape:string]
      0:[n;]
      ```
   Conclusion: It looks like `zq` is _not_ recognizing `\n` as a special escape sequence, so changing the spec to match that.

2. We've discussed whether we should try to advise how an implementation would deal with invalid escape sequences. Current consensus is to leave it undefined, so I've changed the spec to reflect that.