### PR TITLE
Fix close without date

### DIFF
--- a/tests/formats/zeek/close-date.in.log
+++ b/tests/formats/zeek/close-date.in.log
@@ -1,0 +1,9 @@
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	a
+#fields	ts	d
+#types	time	double
+10.000000	1
+#close  2019-10-10-08-30-35

--- a/tests/formats/zeek/close-date.out.zng
+++ b/tests/formats/zeek/close-date.out.zng
@@ -1,0 +1,2 @@
+#0:record[_path:string,ts:time,d:double]
+0:[a;10;1;]

--- a/tests/formats/zeek/close-nodate.in.log
+++ b/tests/formats/zeek/close-nodate.in.log
@@ -1,0 +1,9 @@
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	a
+#fields	ts	d
+#types	time	double
+10.000000	1
+#close

--- a/tests/formats/zeek/close-nodate.out.zng
+++ b/tests/formats/zeek/close-nodate.out.zng
@@ -1,0 +1,2 @@
+#0:record[_path:string,ts:time,d:double]
+0:[a;10;1;]

--- a/tests/formats/zeek/multizeek.in.log
+++ b/tests/formats/zeek/multizeek.in.log
@@ -1,0 +1,11 @@
+#separator \x09
+#empty_field	(empty)
+#unset_field	-
+#path	a
+#fields	ts	d
+#types	time	double
+10.0	1.0
+#path	b
+#fields	ts	d
+#types	time	int
+11.0	1

--- a/tests/formats/zeek/multizeek.out.zng
+++ b/tests/formats/zeek/multizeek.out.zng
@@ -1,0 +1,4 @@
+#0:record[_path:string,ts:time,d:double]
+0:[a;10;1;]
+#1:record[_path:string,ts:time,d:int]
+1:[b;11;1;]

--- a/tests/formats/zeek/multizng.in.zng
+++ b/tests/formats/zeek/multizng.in.zng
@@ -1,0 +1,4 @@
+#0:record[_path:string,ts:time,d:double]
+0:[a;10;1;]
+#1:record[_path:string,ts:time,d:int]
+1:[b;11;1;]

--- a/tests/formats/zeek/multizng.out.log
+++ b/tests/formats/zeek/multizng.out.log
@@ -1,0 +1,12 @@
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	a
+#fields	ts	d
+#types	time	double
+10.000000	1
+#path	b
+#fields	ts	d
+#types	time	int
+11.000000	1

--- a/zio/zeekio/parser.go
+++ b/zio/zeekio/parser.go
@@ -132,10 +132,15 @@ func (p *Parser) ParseDirective(line []byte) error {
 		}
 		p.open = tokens[1]
 	case "close":
-		if len(tokens) != 2 {
+		if len(tokens) > 2 {
 			return badfield("close")
 		}
-		p.close = tokens[1]
+		if len(tokens) == 1 {
+			p.close = ""
+		} else {
+			p.close = tokens[1]
+		}
+
 	case "fields":
 		if len(tokens) < 2 {
 			return badfield("fields")


### PR DESCRIPTION
Some zeek logs have a bare `#close`, some have a `#close` with a date. Handle both.