### PR TITLE
More zng spec updates

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -278,7 +278,7 @@ with the following structure:
 A union type consists of an ordered set of types
 encoded as a count of the number of types, i.e., `<ntypes>` from above,
 followed by the type IDs comprising the types of the union.
-The type Ids of a union must be unique.
+The type IDs of a union must be unique.
 
 The `<ntypes>` and the type IDs are all encoded as `uvarint`.
 


### PR DESCRIPTION
This commit backs out the misguided attempt to have the text format
follow the fine-grained approach to the type system defined in the
binary format.  Instead, composite string types are used and an
implementation would map these string types to underlying typedefs.
In this model, the integer type codes in the ZNG text format are
now generic integer tags that do share the same "numerical space"
as the under BZNG type codes.

We also add a "union" type so we can support mixed-type JSON arrays
since we got rid of type "any" (the problem with type "any" was that
the idea was the value we include a type ID but that we entail mapping
"any" values between type contexts but union values do not suffer
this problem.

The syntax for aliases is simplified in the text format.

Next steps are to implement aliases and unions and take the zeek specific
names out of the type system.