### PR TITLE
add "-f types" flag to dump ZNG types

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -93,7 +93,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	cwd, _ := os.Getwd()
 	c := &Command{zctx: resolver.NewContext()}
 	f.StringVar(&c.ifmt, "i", "auto", "format of input data [auto,bzng,ndjson,zeek,zjson,zng]")
-	f.StringVar(&c.ofmt, "f", "zng", "format for output data [bzng,ndjson,table,text,zeek,zjson,zng]")
+	f.StringVar(&c.ofmt, "f", "zng", "format for output data [bzng,ndjson,table,text,types,zeek,zjson,zng]")
 	f.StringVar(&c.path, "p", cwd, "path for input")
 	f.StringVar(&c.dir, "d", "", "directory for output data files")
 	f.StringVar(&c.outputFile, "o", "", "write data to output file")
@@ -188,6 +188,15 @@ func (c *Command) Run(args []string) error {
 		if err != nil {
 			return fmt.Errorf("parse error: %s", err)
 		}
+	}
+	if c.ofmt == "types" {
+		logger, err := emitter.NewTypeLogger(c.outputFile, c.verbose)
+		if err != nil {
+			return err
+		}
+		c.zctx.SetLogger(logger)
+		c.ofmt = "null"
+		defer logger.Close()
 	}
 	var reader zbuf.Reader
 	if reader, err = c.loadFiles(paths); err != nil {

--- a/emitter/types.go
+++ b/emitter/types.go
@@ -1,0 +1,69 @@
+package emitter
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/mccanne/zq/pkg/bufwriter"
+	"github.com/mccanne/zq/zng"
+)
+
+type TypeLogger struct {
+	io.WriteCloser
+	verbose bool
+}
+
+func NewTypeLogger(path string, verbose bool) (*TypeLogger, error) {
+	var f io.WriteCloser
+	if path == "" {
+		// Don't close stdout in case we live inside something
+		// here that runs multiple instances of this to stdout.
+		f = &noClose{os.Stdout}
+	} else {
+		var err error
+		flags := os.O_WRONLY | os.O_CREATE
+		file, err := os.OpenFile(path, flags, 0600)
+		if err != nil {
+			return nil, err
+		}
+		f = file
+	}
+	return &TypeLogger{bufwriter.New(f), verbose}, nil
+}
+
+func (t *TypeLogger) Close() error {
+	return t.WriteCloser.Close()
+
+}
+func (t *TypeLogger) TypeDef(id int, typ zng.Type) {
+	var s string
+	if t.verbose {
+		s = formatType(typ) + "\n"
+	} else {
+		s = fmt.Sprintf("#%d:%s\n", id, typ)
+	}
+	t.Write([]byte(s))
+}
+
+func formatType(typ zng.Type) string {
+	switch typ := typ.(type) {
+	case *zng.TypeSet:
+		return fmt.Sprintf("%d:set[<%d>]", typ.ID(), typ.InnerType.ID())
+	case *zng.TypeVector:
+		return fmt.Sprintf("%d:vector[<%d>]", typ.ID(), typ.Type.ID())
+	case *zng.TypeRecord:
+		s := fmt.Sprintf("%d:record[", typ.ID())
+		comma := ""
+		for _, col := range typ.Columns {
+			s += fmt.Sprintf("%s%s:<%d>", comma, col.Name, col.Type.ID())
+			comma = ","
+		}
+		s += "]"
+		return s
+	default:
+		// this shouldn't happen
+		return strconv.Itoa(typ.ID())
+	}
+}

--- a/tests/formats.go
+++ b/tests/formats.go
@@ -44,6 +44,8 @@ func match(subdir, name, direction string) (*filespec, error) {
 		format = "text"
 	case "tbl", "table":
 		format = "table"
+	case "types":
+		format = "types"
 	default:
 		return nil, fmt.Errorf("unknown extension %s (in %s)\n", ext, name)
 	}

--- a/tests/formats/types/1.in.zng
+++ b/tests/formats/types/1.in.zng
@@ -1,0 +1,3 @@
+#0:record[a:string,r:record[b:string,c:int]]
+0:[hello;[there;1;]]
+0:[foox;[there;2;]]

--- a/tests/formats/types/1.out.types
+++ b/tests/formats/types/1.out.types
@@ -1,0 +1,2 @@
+#23:record[b:string,c:int]
+#24:record[a:string,r:record[b:string,c:int]]

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -12,8 +12,15 @@ import (
 	"github.com/mccanne/zq/zio/zeekio"
 	"github.com/mccanne/zq/zio/zjsonio"
 	"github.com/mccanne/zq/zio/zngio"
+	"github.com/mccanne/zq/zng"
 	"github.com/mccanne/zq/zng/resolver"
 )
+
+type nullWriter struct{}
+
+func (*nullWriter) Write(*zng.Record) error {
+	return nil
+}
 
 func LookupWriter(format string, w io.WriteCloser, optionalFlags *zio.Flags) *zio.Writer {
 	var flags zio.Flags
@@ -24,6 +31,8 @@ func LookupWriter(format string, w io.WriteCloser, optionalFlags *zio.Flags) *zi
 	switch format {
 	default:
 		return nil
+	case "null":
+		f = zbuf.NopFlusher(&nullWriter{})
 	case "zng":
 		f = zbuf.NopFlusher(zngio.NewWriter(w))
 	case "bzng":


### PR DESCRIPTION
This commit adds functionality to print the typedefs from
input.  "-f types" allocates a types logger to print ZNG type
info to output and discard all values.  "-v" with this option
prints full type strings rather than integer type IDs.