### PR TITLE
Clear up string escaping rules

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -588,10 +588,12 @@ defined by a typedef scoped to the stream in which the value appears.
 Any Unicode code point may be represented in a `string` value using
 the same `\u` syntax as Javascript.  Specifically:
 * The sequence `\uhhhh` where each `h` is a hexadecimal digit represents
-  the Unicode code point corresponding to the given 4-digit (hexadecimal) number.
+  the Unicode code point corresponding to the given
+  4-digit (hexadecimal) number, or:
 * `\u{h*}` where there are from 1 to 6 hexadecimal digits inside the
   brackets represents the Unicode code point corresponding to the given
   hexadecimal number.
+
 `\u` followed by anything that does not conform to the above syntax
 is not a valid escape sequence.
 The behavior of an implementation that encounters such

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -561,7 +561,7 @@ Here is a pseudo-grammar for typed values:
 <terminal> := <char>*
 ```
 
-A terminal value is encoded as a string of characters (encoded terminated
+A terminal value is encoded as a string of characters terminated
 by a semicolon (which must be escaped if it appears in a string-typed value).
 Container values (i.e., sets, vectors, or records) are encoded as
 * an open bracket,
@@ -607,7 +607,7 @@ to be embedded in the `bstring` data type.
 escape sequence. The behavior of an implementation that encounters such
 invalid sequences in a `bstring` type is undefined.
 
-These special characters must be hex escaped if they appear within a
+These special characters must be escaped if they appear within a
 `string` or `bstring` type:
 ```
 ; \n \\


### PR DESCRIPTION
Clarify that an entire ZNG stream must be valid utf-8, this lets us
remove a few awkward inline references to utf-8.  Also simplify the
pseudo-grammar for values and move all discussion about escape sequences
in [b]string to a separate section.  Specify that string may only use
javascript style (\u) escapes and that bstring may only use zeek style (\x)
escapes.