### PR TITLE
Fix handling of types with "ts" in first column

### DIFF
--- a/tests/suite.go
+++ b/tests/suite.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mccanne/zq/tests/suite/input"
 	"github.com/mccanne/zq/tests/suite/regexp"
 	"github.com/mccanne/zq/tests/suite/sort"
+	"github.com/mccanne/zq/tests/suite/time"
 	"github.com/mccanne/zq/tests/suite/utf8"
 )
 
@@ -44,6 +45,7 @@ var internals = []test.Internal{
 	sort.Internal4_2,
 	sort.Internal4_3,
 	sort.Internal4_4,
+	time.Internal,
 }
 
 var commands = []test.Exec{

--- a/tests/suite/time/test.go
+++ b/tests/suite/time/test.go
@@ -1,0 +1,29 @@
+package time
+
+import (
+	"github.com/mccanne/zq/pkg/test"
+)
+
+var Internal = test.Internal{
+	Name:         "count",
+	Query:        "* | every 1d count()",
+	Input:        test.Trim(input),
+	OutputFormat: "zng",
+	Expected:     test.Trim(expected),
+}
+
+// This log is path-less in order to make "ts" the first column and
+// that verify we handle this case correctly.
+const input = `
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#fields	ts
+#types	time
+1425565514.419939
+`
+
+const expected = `
+#0:record[ts:time,count:count]
+0:[1425513600;1;]`

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -198,6 +198,6 @@ func (r *Reader) parseValue(line []byte) (*zng.Record, error) {
 	if err == nil {
 		record.Ts = ts
 	}
-	// Ignore errors, it just means the point doesn't have a ts field
+	// Ignore errors, it just means the point doesn't have a time-typed ts field
 	return record, nil
 }

--- a/zng/record.go
+++ b/zng/record.go
@@ -10,7 +10,7 @@ type TypeRecord struct {
 	id      int
 	Columns []Column
 	LUT     map[string]int
-	TsCol   int
+	TsCol   int // -1 if no time-typed "ts" field
 }
 
 func CopyTypeRecord(id int, r *TypeRecord) *TypeRecord {

--- a/zng/recordval.go
+++ b/zng/recordval.go
@@ -62,7 +62,7 @@ func NewRecordTs(typ *TypeRecord, ts nano.Ts, raw zcode.Bytes) *Record {
 
 func NewRecord(typ *TypeRecord, zv zcode.Bytes) (*Record, error) {
 	r := NewRecordTs(typ, 0, zv)
-	if typ.TsCol == 0 {
+	if typ.TsCol < 0 {
 		return r, nil
 	}
 	body, err := r.Slice(typ.TsCol)


### PR DESCRIPTION
The bug was introduced in #243, thanks to @mccanne for spotting it.