### PR TITLE
change avg, max, min, and sum result to unset for unset input

### DIFF
--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -106,7 +106,7 @@ const nullIn = `
 const nullOut = `
 #0:record[key:string,sum:int]
 0:[key1;5;]
-0:[key2;0;]
+0:[key2;-;]
 `
 
 const notPresentIn = `

--- a/reducer/avg.go
+++ b/reducer/avg.go
@@ -35,6 +35,9 @@ func (a *Avg) Consume(r *zng.Record) {
 		a.FieldNotFound++
 		return
 	}
+	if v.Bytes == nil {
+		return
+	}
 	d, ok := zx.CoerceToDouble(v)
 	if !ok {
 		a.TypeMismatch++
@@ -45,9 +48,8 @@ func (a *Avg) Consume(r *zng.Record) {
 }
 
 func (a *Avg) Result() zng.Value {
-	var v float64
 	if a.count > 0 {
-		v = a.sum / float64(a.count)
+		return zng.NewDouble(a.sum / float64(a.count))
 	}
-	return zng.NewDouble(v)
+	return zng.Value{Type: zng.TypeDouble}
 }

--- a/reducer/field/field.go
+++ b/reducer/field/field.go
@@ -58,7 +58,9 @@ func (fr *FieldReducer) Consume(r *zng.Record) {
 		fr.FieldNotFound++
 		return
 	}
-
+	if val.Bytes == nil {
+		return
+	}
 	if fr.fn == nil {
 		switch val.Type.(type) {
 		case *zng.TypeOfInt:
@@ -76,9 +78,7 @@ func (fr *FieldReducer) Consume(r *zng.Record) {
 			return
 		}
 	}
-
-	err = fr.fn.Consume(val)
-	if err == zng.ErrTypeMismatch {
+	if fr.fn.Consume(val) == zng.ErrTypeMismatch {
 		fr.TypeMismatch++
 	}
 }

--- a/tests/suite.go
+++ b/tests/suite.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mccanne/zq/tests/suite/filter"
 	"github.com/mccanne/zq/tests/suite/format"
 	"github.com/mccanne/zq/tests/suite/input"
+	"github.com/mccanne/zq/tests/suite/reducer"
 	"github.com/mccanne/zq/tests/suite/regexp"
 	"github.com/mccanne/zq/tests/suite/sort"
 	"github.com/mccanne/zq/tests/suite/time"
@@ -38,6 +39,14 @@ var internals = []test.Internal{
 	filter.UnescapedAsterisk,
 	filter.NullWithNonexistentField,
 	filter.NullWithUnsetField,
+	reducer.UnsetAvg,
+	reducer.UnsetCountDistinct,
+	reducer.UnsetCount,
+	reducer.UnsetFirst,
+	reducer.UnsetLast,
+	reducer.UnsetMax,
+	reducer.UnsetMin,
+	reducer.UnsetSum,
 	sort.Internal1,
 	sort.Internal2,
 	sort.Internal3,

--- a/tests/suite/reducer/unset.go
+++ b/tests/suite/reducer/unset.go
@@ -1,0 +1,100 @@
+package reducer
+
+import "github.com/mccanne/zq/pkg/test"
+
+const unset = `
+#0:record[x:count]
+0:[-;]
+
+#1:record[x:double]
+1:[-;]
+
+#2:record[x:int]
+2:[-;]
+
+#3:record[x:interval]
+3:[-;]
+
+#4:record[x:time]
+4:[-;]
+`
+
+var UnsetAvg = test.Internal{
+	Name:  "unset avg",
+	Query: "avg(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[avg:double]
+0:[-;]
+`),
+}
+
+var UnsetCount = test.Internal{
+	Name:  "unset count",
+	Query: "count(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[count:count]
+0:[5;]
+`),
+}
+
+var UnsetCountDistinct = test.Internal{
+	Name:  "unset countdistinct",
+	Query: "countdistinct(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[countdistinct:count]
+0:[1;]
+`),
+}
+
+var UnsetFirst = test.Internal{
+	Name:  "unset first",
+	Query: "first(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[first:count]
+0:[-;]
+`),
+}
+
+var UnsetLast = test.Internal{
+	Name:  "unset last",
+	Query: "last(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[last:time]
+0:[-;]
+`),
+}
+
+var UnsetMax = test.Internal{
+	Name:  "unset max",
+	Query: "max(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[max:count]
+0:[-;]
+`),
+}
+
+var UnsetMin = test.Internal{
+	Name:  "unset min",
+	Query: "min(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[min:count]
+0:[-;]
+`),
+}
+
+var UnsetSum = test.Internal{
+	Name:  "unset sum",
+	Query: "sum(x)",
+	Input: test.Trim(unset),
+	Expected: test.Trim(`
+#0:record[sum:count]
+0:[-;]
+`),
+}


### PR DESCRIPTION
Avg, max, min, and sum emit a numeric result for input comprising
exclusively unset values.  That's unintuitive.  Change them to emit an
unset result instead.