### PR TITLE
Add test to ensure we don't crash upon upstream error

### DIFF
--- a/tests/suite.go
+++ b/tests/suite.go
@@ -50,6 +50,7 @@ var internals = []test.Internal{
 
 var commands = []test.Exec{
 	cut.Exec,
+	errors.Exec,
 	utf8.Exec,
 }
 

--- a/tests/suite/errors/emptyinput.go
+++ b/tests/suite/errors/emptyinput.go
@@ -5,8 +5,8 @@ import (
 )
 
 var Exec = test.Exec{
-	Name:     "error upstream",
-	Command:  `zat simple.zng | zq -`,
+	Name:     "empty input",
+	Command:  `echo "" | zq -`,
 	Input:    test.Trim(input),
 	Expected: "",
 }

--- a/tests/suite/errors/emptyinput.go
+++ b/tests/suite/errors/emptyinput.go
@@ -6,12 +6,7 @@ import (
 
 var Exec = test.Exec{
 	Name:     "empty input",
-	Command:  `echo "" | zq -`,
-	Input:    test.Trim(input),
+	Command:  `zq -`,
+	Input:    "",
 	Expected: "",
 }
-
-const input = `
-#0:record[_path:string,ts:time]
-0:[conn;1425565514.419939;]
-`

--- a/tests/suite/errors/zat.go
+++ b/tests/suite/errors/zat.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"github.com/mccanne/zq/pkg/test"
+)
+
+var Exec = test.Exec{
+	Name:     "error upstream",
+	Command:  `zat simple.zng | zq -`,
+	Input:    test.Trim(input),
+	Expected: "",
+}
+
+const input = `
+#0:record[_path:string,ts:time]
+0:[conn;1425565514.419939;]
+`


### PR DESCRIPTION
zq previously crashed when run with in a shell pipeline with an error. The issue was incidentally fixed in eeb41b0c25cacb4e2b53e69427c69a5917b9eea5, and this commit adds a test to ensure we don't regress.