### PR TITLE
Fix issues with container formatting

### DIFF
--- a/zbuf/zval.go
+++ b/zbuf/zval.go
@@ -120,7 +120,7 @@ func ZeekStrings(r *zng.Record, precision int, fmt zng.OutFmt) ([]string, bool, 
 			}
 			field = string(ts.AppendFloat(nil, precision))
 		} else {
-			field = col.Type.StringOf(val, fmt)
+			field = col.Type.StringOf(val, fmt, false)
 		}
 		ss = append(ss, field)
 	}

--- a/zng/addr.go
+++ b/zng/addr.go
@@ -48,7 +48,7 @@ func (t *TypeOfAddr) String() string {
 	return "addr"
 }
 
-func (t *TypeOfAddr) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfAddr) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	ip, err := DecodeAddr(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/array.go
+++ b/zng/array.go
@@ -69,7 +69,7 @@ func (t *TypeArray) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 		} else {
 			b.WriteByte(separator)
 		}
-		if len(val) == 0 {
+		if val == nil {
 			b.WriteByte('-')
 		} else {
 			b.WriteString(t.Type.StringOf(val, fmt))
@@ -77,7 +77,12 @@ func (t *TypeArray) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 	}
 
 	switch fmt {
-	case OutFormatZNG, OutFormatDebug:
+	case OutFormatZNG:
+		if !first {
+			b.WriteByte(';')
+		}
+		b.WriteByte(']')
+	case OutFormatDebug:
 		b.WriteByte(']')
 	}
 	return b.String()

--- a/zng/array.go
+++ b/zng/array.go
@@ -40,7 +40,7 @@ func (t *TypeArray) Parse(in []byte) (zcode.Bytes, error) {
 	panic("zeek.TypeArray.Parse shouldn't be called")
 }
 
-func (t *TypeArray) StringOf(zv zcode.Bytes, fmt OutFmt) string {
+func (t *TypeArray) StringOf(zv zcode.Bytes, fmt OutFmt, _ bool) string {
 	if len(zv) == 0 && (fmt == OutFormatZeek || fmt == OutFormatZeekAscii) {
 		return "(empty)"
 	}
@@ -72,7 +72,7 @@ func (t *TypeArray) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 		if val == nil {
 			b.WriteByte('-')
 		} else {
-			b.WriteString(t.Type.StringOf(val, fmt))
+			b.WriteString(t.Type.StringOf(val, fmt, true))
 		}
 	}
 

--- a/zng/bool.go
+++ b/zng/bool.go
@@ -44,7 +44,7 @@ func (t *TypeOfBool) String() string {
 	return "bool"
 }
 
-func (t *TypeOfBool) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfBool) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	b, err := DecodeBool(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/bstring.go
+++ b/zng/bstring.go
@@ -39,7 +39,7 @@ func (t *TypeOfBstring) String() string {
 }
 
 func (t *TypeOfBstring) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return t.StringOf(zv, OutFormatUnescaped), nil
+	return t.StringOf(zv, OutFormatUnescaped, false), nil
 }
 
 const hexdigits = "0123456789abcdef"
@@ -50,7 +50,7 @@ const hexdigits = "0123456789abcdef"
 // In general, valid UTF-8 code points are passed through unmodified,
 // though for the ZEEK_ASCII output format, all non-ascii bytes are
 // escaped for compatibility with older versions of Zeek.
-func (t *TypeOfBstring) StringOf(data zcode.Bytes, fmt OutFmt) string {
+func (t *TypeOfBstring) StringOf(data zcode.Bytes, fmt OutFmt, inContainer bool) string {
 	if bytes.Equal(data, []byte{'-'}) {
 		return "\\x2d"
 	}
@@ -68,7 +68,7 @@ func (t *TypeOfBstring) StringOf(data zcode.Bytes, fmt OutFmt) string {
 		}
 		needEscape := r == utf8.RuneError || !unicode.IsPrint(r)
 		if !needEscape {
-			needEscape = ShouldEscape(r, fmt, i)
+			needEscape = ShouldEscape(r, fmt, i, inContainer)
 		}
 		if needEscape {
 			out = append(out, data[start:i]...)

--- a/zng/count.go
+++ b/zng/count.go
@@ -41,7 +41,7 @@ func (t *TypeOfCount) String() string {
 	return "count"
 }
 
-func (t *TypeOfCount) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfCount) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	c, err := DecodeCount(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/double.go
+++ b/zng/double.go
@@ -54,7 +54,7 @@ func (t *TypeOfDouble) String() string {
 	return "double"
 }
 
-func (t *TypeOfDouble) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfDouble) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	d, err := DecodeDouble(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/enum.go
+++ b/zng/enum.go
@@ -33,7 +33,7 @@ func (t *TypeOfEnum) String() string {
 	return "enum"
 }
 
-func (t *TypeOfEnum) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfEnum) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	e, err := DecodeEnum(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/escape.go
+++ b/zng/escape.go
@@ -8,8 +8,10 @@ import (
 // in a value should be escaped for the given output format.  This function
 // does not account for unprintable characters, its main purpose is to
 // centralize the logic about which characters are syntatically significant
-// in each output format and hence must be escaped.
-func ShouldEscape(r rune, fmt OutFmt, pos int) bool {
+// in each output format and hence must be escaped.  The inContainer parameter
+// specifies whether this values is inside a set or vector (which is needed
+// to correctly implement  zeek log escaping rules).
+func ShouldEscape(r rune, fmt OutFmt, pos int, inContainer bool) bool {
 	if fmt != OutFormatUnescaped && r == '\\' {
 		return true
 	}
@@ -18,7 +20,7 @@ func ShouldEscape(r rune, fmt OutFmt, pos int) bool {
 		return true
 	}
 
-	if (fmt == OutFormatZeek || fmt == OutFormatZeekAscii) && (r == '\t' || r == ',') {
+	if (fmt == OutFormatZeek || fmt == OutFormatZeekAscii) && (r == '\t' || (r == ',' && inContainer)) {
 		return true
 	}
 

--- a/zng/format_test.go
+++ b/zng/format_test.go
@@ -259,7 +259,7 @@ func TestFormatting(t *testing.T) {
 			[]Expect{
 				{zng.OutFormatZeek, "abc,xyz"},
 				{zng.OutFormatZeekAscii, "abc,xyz"},
-				{zng.OutFormatZNG, "[abc;xyz]"},
+				{zng.OutFormatZNG, "[abc;xyz;]"},
 			},
 		},
 
@@ -274,7 +274,7 @@ func TestFormatting(t *testing.T) {
 			},
 			[]Expect{
 				// not representable in zeek
-				{zng.OutFormatZNG, `[[a;b];[x;y]]`},
+				{zng.OutFormatZNG, `[[a;b;];[x;y;];]`},
 			},
 		},
 
@@ -311,7 +311,7 @@ func TestFormatting(t *testing.T) {
 			[]Expect{
 				{zng.OutFormatZeek, "abc,xyz"},
 				{zng.OutFormatZeekAscii, "abc,xyz"},
-				{zng.OutFormatZNG, "[abc;xyz]"},
+				{zng.OutFormatZNG, "[abc;xyz;]"},
 			},
 		},
 
@@ -326,7 +326,7 @@ func TestFormatting(t *testing.T) {
 			},
 			[]Expect{
 				// not representable in zeek
-				{zng.OutFormatZNG, `[[a;b];[x;y]]`},
+				{zng.OutFormatZNG, `[[a;b;];[x;y;];]`},
 			},
 		},
 
@@ -338,7 +338,16 @@ func TestFormatting(t *testing.T) {
 			},
 			[]Expect{
 				{zng.OutFormatZeek, `\x2d,-`},
-				{zng.OutFormatZNG, `[\x2d;-]`},
+				{zng.OutFormatZNG, `[\x2d;-;]`},
+			},
+		},
+
+		// vector containing empty string
+		{
+			zng.Value{bstringVecType, makeContainer([]byte{})},
+			[]Expect{
+				{zng.OutFormatZeek, ""},
+				{zng.OutFormatZNG, `[;]`},
 			},
 		},
 
@@ -353,7 +362,7 @@ func TestFormatting(t *testing.T) {
 				makeContainer([]byte("foo"), []byte("bar")),
 			},
 			[]Expect{
-				{zng.OutFormatZNG, `[foo;bar]`},
+				{zng.OutFormatZNG, `[foo;bar;]`},
 			},
 		},
 
@@ -361,7 +370,7 @@ func TestFormatting(t *testing.T) {
 		{
 			zng.Value{recType, makeContainer(nil, nil)},
 			[]Expect{
-				{zng.OutFormatZNG, `[-;-]`},
+				{zng.OutFormatZNG, `[-;-;]`},
 			},
 		},
 	}

--- a/zng/format_test.go
+++ b/zng/format_test.go
@@ -111,12 +111,12 @@ func TestFormatting(t *testing.T) {
 			},
 		},
 
-		// Commas are escaped in Zeek but not ZNG
+		// Commas not inside a container are not escaped
 		{
 			zng.NewBstring("a,b"),
 			[]Expect{
-				{zng.OutFormatZeek, `a\x2cb`},
-				{zng.OutFormatZeekAscii, `a\x2cb`},
+				{zng.OutFormatZeek, `a,b`},
+				{zng.OutFormatZeekAscii, `a,b`},
 				{zng.OutFormatZNG, `a,b`},
 			},
 		},
@@ -196,12 +196,12 @@ func TestFormatting(t *testing.T) {
 			},
 		},
 
-		// Commas are escaped in Zeek but not ZNG
+		// Commas not inside a container are not escaped
 		{
 			zng.NewString("a,b"),
 			[]Expect{
-				{zng.OutFormatZeek, `a\u{2c}b`},
-				{zng.OutFormatZeekAscii, `a\u{2c}b`},
+				{zng.OutFormatZeek, `a,b`},
+				{zng.OutFormatZeekAscii, `a,b`},
 				{zng.OutFormatZNG, `a,b`},
 			},
 		},
@@ -260,6 +260,14 @@ func TestFormatting(t *testing.T) {
 				{zng.OutFormatZeek, "abc,xyz"},
 				{zng.OutFormatZeekAscii, "abc,xyz"},
 				{zng.OutFormatZNG, "[abc;xyz;]"},
+			},
+		},
+
+		// A comma inside a string inside a set is escaped in Zeek.
+		{
+			zng.Value{bstringSetType, makeContainer([]byte("a,b"))},
+			[]Expect{
+				{zng.OutFormatZeek, `a\x2cb`},
 			},
 		},
 
@@ -327,6 +335,14 @@ func TestFormatting(t *testing.T) {
 			[]Expect{
 				// not representable in zeek
 				{zng.OutFormatZNG, `[[a;b;];[x;y;];]`},
+			},
+		},
+
+		// A comma inside a string inside a vector is escaped in Zeek.
+		{
+			zng.Value{bstringVecType, makeContainer([]byte("a,b"))},
+			[]Expect{
+				{zng.OutFormatZeek, `a\x2cb`},
 			},
 		},
 

--- a/zng/int.go
+++ b/zng/int.go
@@ -49,7 +49,7 @@ func (t *TypeOfInt) String() string {
 	return "int"
 }
 
-func (t *TypeOfInt) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfInt) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	i, err := DecodeInt(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/interval.go
+++ b/zng/interval.go
@@ -35,7 +35,7 @@ func (t *TypeOfInterval) String() string {
 	return "interval"
 }
 
-func (t *TypeOfInterval) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfInterval) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	i, err := DecodeInterval(zv)
 	if err != nil {
 		return badZng(err, t, zv)
@@ -48,5 +48,5 @@ func (t *TypeOfInterval) StringOf(zv zcode.Bytes, _ OutFmt) string {
 }
 
 func (t *TypeOfInterval) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return t.StringOf(zv, OutFormatUnescaped), nil
+	return t.StringOf(zv, OutFormatUnescaped, false), nil
 }

--- a/zng/null.go
+++ b/zng/null.go
@@ -21,7 +21,7 @@ func (t *TypeOfNull) String() string {
 	return "null"
 }
 
-func (t *TypeOfNull) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfNull) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	return "-"
 }
 

--- a/zng/port.go
+++ b/zng/port.go
@@ -47,7 +47,7 @@ func (t *TypeOfPort) String() string {
 	return "port"
 }
 
-func (t *TypeOfPort) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfPort) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	p, err := DecodePort(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/record.go
+++ b/zng/record.go
@@ -64,7 +64,7 @@ func (t *TypeRecord) Parse(in []byte) (zcode.Bytes, error) {
 	panic("record.Parse shouldn't be called")
 }
 
-func (t *TypeRecord) StringOf(zv zcode.Bytes, fmt OutFmt) string {
+func (t *TypeRecord) StringOf(zv zcode.Bytes, fmt OutFmt, _ bool) string {
 	var b strings.Builder
 	separator := byte(',')
 	switch fmt {
@@ -92,7 +92,7 @@ func (t *TypeRecord) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 		if val == nil {
 			b.WriteByte('-')
 		} else {
-			b.WriteString(col.Type.StringOf(val, fmt))
+			b.WriteString(col.Type.StringOf(val, fmt, false))
 		}
 	}
 

--- a/zng/record.go
+++ b/zng/record.go
@@ -89,7 +89,7 @@ func (t *TypeRecord) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 		} else {
 			b.WriteByte(separator)
 		}
-		if len(val) == 0 {
+		if val == nil {
 			b.WriteByte('-')
 		} else {
 			b.WriteString(col.Type.StringOf(val, fmt))
@@ -97,7 +97,12 @@ func (t *TypeRecord) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 	}
 
 	switch fmt {
-	case OutFormatZNG, OutFormatDebug:
+	case OutFormatZNG:
+		if !first {
+			b.WriteByte(';')
+		}
+		b.WriteByte(']')
+	case OutFormatDebug:
 		b.WriteByte(']')
 	}
 	return b.String()

--- a/zng/set.go
+++ b/zng/set.go
@@ -72,7 +72,12 @@ func (t *TypeSet) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 	}
 
 	switch fmt {
-	case OutFormatZNG, OutFormatDebug:
+	case OutFormatZNG:
+		if !first {
+			b.WriteByte(';')
+		}
+		b.WriteByte(']')
+	case OutFormatDebug:
 		b.WriteByte(']')
 	}
 	return b.String()

--- a/zng/set.go
+++ b/zng/set.go
@@ -39,7 +39,7 @@ func (t *TypeSet) Parse(in []byte) (zcode.Bytes, error) {
 	panic("zeek.TypeSet.Parse shouldn't be called")
 }
 
-func (t *TypeSet) StringOf(zv zcode.Bytes, fmt OutFmt) string {
+func (t *TypeSet) StringOf(zv zcode.Bytes, fmt OutFmt, _ bool) string {
 	if len(zv) == 0 && (fmt == OutFormatZeek || fmt == OutFormatZeekAscii) {
 		return "(empty)"
 	}
@@ -68,7 +68,7 @@ func (t *TypeSet) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 		} else {
 			b.WriteByte(separator)
 		}
-		b.WriteString(t.InnerType.StringOf(val, fmt))
+		b.WriteString(t.InnerType.StringOf(val, fmt, true))
 	}
 
 	switch fmt {

--- a/zng/string.go
+++ b/zng/string.go
@@ -52,7 +52,7 @@ func uescape(r rune) []byte {
 	return []byte(s)
 }
 
-func (t *TypeOfString) StringOf(zv zcode.Bytes, fmt OutFmt) string {
+func (t *TypeOfString) StringOf(zv zcode.Bytes, fmt OutFmt, inContainer bool) string {
 	if bytes.Equal(zv, []byte{'-'}) {
 		return "\\u002d"
 	}
@@ -68,7 +68,7 @@ func (t *TypeOfString) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 			start = i
 			continue
 		}
-		if !unicode.IsPrint(r) || ShouldEscape(r, fmt, i) {
+		if !unicode.IsPrint(r) || ShouldEscape(r, fmt, i, inContainer) {
 			out = append(out, zv[start:i]...)
 			out = append(out, uescape(r)...)
 			i += l
@@ -81,5 +81,5 @@ func (t *TypeOfString) StringOf(zv zcode.Bytes, fmt OutFmt) string {
 }
 
 func (t *TypeOfString) Marshal(zv zcode.Bytes) (interface{}, error) {
-	return t.StringOf(zv, OutFormatUnescaped), nil
+	return t.StringOf(zv, OutFormatUnescaped, false), nil
 }

--- a/zng/subnet.go
+++ b/zng/subnet.go
@@ -69,7 +69,7 @@ func (t *TypeOfSubnet) String() string {
 	return "subnet"
 }
 
-func (t *TypeOfSubnet) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfSubnet) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	s, err := DecodeSubnet(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/time.go
+++ b/zng/time.go
@@ -40,7 +40,7 @@ func (t *TypeOfTime) String() string {
 	return "time"
 }
 
-func (t *TypeOfTime) StringOf(zv zcode.Bytes, _ OutFmt) string {
+func (t *TypeOfTime) StringOf(zv zcode.Bytes, _ OutFmt, _ bool) string {
 	ts, err := DecodeTime(zv)
 	if err != nil {
 		return badZng(err, t, zv)

--- a/zng/type.go
+++ b/zng/type.go
@@ -49,8 +49,10 @@ type Type interface {
 	// String returns the name of the type as defined in the ZNG spec.
 	String() string
 	// StringOf formats an arbitrary value of this type encoded as zcode.
-	// The fmt parameter controls output formatting.
-	StringOf(zv zcode.Bytes, fmt OutFmt) string
+	// The fmt parameter controls output formatting.  The inContainer
+	// parameter indicates if this value is inside a set or vector
+	// (which is needed to correctly implement  zeek log escaping rules).
+	StringOf(zv zcode.Bytes, fmt OutFmt, inContainer bool) string
 	// Marshal is used from Value.MarshalJSON(), it should turn an
 	// arbitrary value of this type encoded as zcode into something
 	// suitable for passing to json.Marshal()

--- a/zng/value.go
+++ b/zng/value.go
@@ -75,7 +75,7 @@ func (v Value) Format(fmt OutFmt) string {
 	if v.Bytes == nil {
 		return "-"
 	}
-	return v.Type.StringOf(v.Bytes, fmt)
+	return v.Type.StringOf(v.Bytes, fmt, false)
 }
 
 // String implements the fmt.Stringer interface and returns a


### PR DESCRIPTION
The previous revision had two bugs:
1. non-nil values with a 0-length zcode representation were being
   incorrectly formatted as -
2. the last element in a container was missing its trailing semicolon

This patch fixes both issues and adds tests for the above.