### PR TITLE
remove mostly empty zng/varint.go

### DIFF
--- a/zng/varint.go
+++ b/zng/varint.go
@@ -1,4 +1,0 @@
-package zng
-
-// These functions are like varint but their size is known as
-// zval encoded it for them.


### PR DESCRIPTION
The actual varint logic was moved out in:
https://github.com/mccanne/zq/pull/233
