### PR TITLE
Implement Alias Type

### DIFF
--- a/alias.test.zng
+++ b/alias.test.zng
@@ -1,6 +1,0 @@
-#uint=count
-#0:record[count:uint]
-0:[1;]
-0:[2;]
-0:[3;]
-0:[4;]

--- a/alias.test.zng
+++ b/alias.test.zng
@@ -1,0 +1,6 @@
+#uint=count
+#0:record[count:uint]
+0:[1;]
+0:[2;]
+0:[3;]
+0:[4;]

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -233,11 +233,8 @@ func newKeyRow(kctx *resolver.Context, r *zng.Record, keys []GroupByKey) keyRow 
 	// type ID doesn't matter here.
 	var id int
 	if len(cols) > 0 {
-		typ, err := kctx.LookupByName(zng.TypeRecordString(cols))
-		if err != nil {
-			return keyRow{}
-		}
-		id = typ.(*zng.TypeRecord).ID()
+		typ := kctx.LookupTypeRecord(cols)
+		id = typ.ID()
 	}
 	return keyRow{id, cols}
 }

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -127,6 +127,22 @@ const mixedOut = `
 0:[k;5;bleah;]
 `
 
+const aliasIn = `
+#ip=addr
+#0:record[host:ip]
+0:[127.0.0.1;]
+#1:record[host:addr]
+1:[127.0.0.1;]
+`
+
+const aliasOut = `
+#ip=addr
+#0:record[host:ip,count:count]
+0:[127.0.0.1;1;]
+#1:record[host:addr,count:count]
+1:[127.0.0.1;1;]
+`
+
 //XXX this should go in a shared package
 type suite []test.Internal
 
@@ -192,6 +208,7 @@ func tests() suite {
 	// Test reducers with mixed-type inputs
 	s.add(New("mixed-inputs", mixedIn, mixedOut, "first(f), last(f) by key"))
 
+	s.add(New("aliases", aliasIn, aliasOut, "count() by host"))
 	// XXX add coverage of time batching (every ..)
 
 	return s

--- a/proc/sort_test.go
+++ b/proc/sort_test.go
@@ -128,6 +128,20 @@ const chooseOut3 = `
 4:[c;a;]
 `
 
+const sortAliasIn = `
+#0:record[host:addr]
+0:[127.0.0.2;]
+#ip=addr
+#1:record[host:ip]
+1:[127.0.0.1;]
+`
+
+const sortAliasOut = `
+#0:record[host:addr]
+0:[127.0.0.2;]
+0:[127.0.0.1;]
+`
+
 func TestSort(t *testing.T) {
 	// Test simple sorting of integers.
 	proc.TestOneProc(t, unsortedInts, ascendingInts, "sort foo")
@@ -155,6 +169,9 @@ func TestSort(t *testing.T) {
 	// Test sorting on multiple fields.
 	proc.TestOneProc(t, multiIn, foobarOut, "sort foo, bar")
 	proc.TestOneProc(t, multiIn, barfooOut, "sort bar, foo")
+
+	// Test sorting on aliases.
+	proc.TestOneProc(t, sortAliasIn, sortAliasOut, "sort host")
 
 	// Test that choosing a field when none is provided works.
 	proc.TestOneProc(t, chooseIn1, chooseOut1, "sort")

--- a/reducer/field/field.go
+++ b/reducer/field/field.go
@@ -62,6 +62,7 @@ func (fr *FieldReducer) Consume(r *zng.Record) {
 	if val.Bytes == nil {
 		return
 	}
+	val = val.Unalias()
 	if fr.fn == nil {
 		switch val.Type.(type) {
 		case *zng.TypeOfInt:

--- a/reducer/field/field.go
+++ b/reducer/field/field.go
@@ -62,18 +62,17 @@ func (fr *FieldReducer) Consume(r *zng.Record) {
 	if val.Bytes == nil {
 		return
 	}
-	val = val.Unalias()
 	if fr.fn == nil {
-		switch val.Type.(type) {
-		case *zng.TypeOfInt:
+		switch val.Type.ID() {
+		case zng.IdInt64:
 			fr.fn = NewIntStreamfn(fr.op)
-		case *zng.TypeOfCount:
+		case zng.IdUint64:
 			fr.fn = NewCountStreamfn(fr.op)
-		case *zng.TypeOfDouble:
+		case zng.IdFloat64:
 			fr.fn = NewDoubleStreamfn(fr.op)
-		case *zng.TypeOfInterval:
+		case zng.IdDuration:
 			fr.fn = NewIntervalStreamfn(fr.op)
-		case *zng.TypeOfTime:
+		case zng.IdTime:
 			fr.fn = NewTimeStreamfn(fr.op)
 		default:
 			fr.TypeMismatch++

--- a/zio/bzngio/reader.go
+++ b/zio/bzngio/reader.go
@@ -63,6 +63,8 @@ again:
 			err = r.readTypeArray()
 		case zng.TypeDefUnion:
 			err = r.readTypeUnion()
+		case zng.TypeDefAlias:
+			err = r.readTypeAlias()
 		default:
 			// XXX we should return the control code
 			len, err := r.readUvarint()
@@ -213,6 +215,28 @@ func (r *Reader) readTypeArray() error {
 		return err
 	}
 	r.zctx.AddType(zng.NewTypeArray(-1, inner))
+	return nil
+}
+
+func (r *Reader) readTypeAlias() error {
+	len, err := r.readUvarint()
+	if err != nil {
+		return zng.ErrBadFormat
+	}
+	b, err := r.peeker.Read(len)
+	if err != nil {
+		return zng.ErrBadFormat
+	}
+	name := string(b)
+	id, err := r.readUvarint()
+	if err != nil {
+		return zng.ErrBadFormat
+	}
+	inner, err := r.zctx.LookupType(int(id))
+	if err != nil {
+		return err
+	}
+	r.zctx.LookupTypeAlias(name, inner)
 	return nil
 }
 

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -56,8 +56,10 @@ func LookupWriter(format string, w io.WriteCloser, optionalFlags *zio.Flags) *zi
 
 func LookupReader(format string, r io.Reader, zctx *resolver.Context) zbuf.Reader {
 	switch format {
-	case "zng", "zeek":
+	case "zng":
 		return zngio.NewReader(r, zctx)
+	case "zeek":
+		return zeekio.NewReader(r, zctx)
 	case "ndjson":
 		return ndjsonio.NewReader(r, zctx)
 	case "zjson":

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mccanne/zq/zbuf"
 	"github.com/mccanne/zq/zio/bzngio"
 	"github.com/mccanne/zq/zio/ndjsonio"
+	"github.com/mccanne/zq/zio/zeekio"
 	"github.com/mccanne/zq/zio/zjsonio"
 	"github.com/mccanne/zq/zio/zngio"
 	"github.com/mccanne/zq/zng/resolver"
@@ -19,6 +20,10 @@ func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
 	track := NewTrack(recorder)
 	if match(zngio.NewReader(track, resolver.NewContext())) {
 		return zngio.NewReader(recorder, zctx), nil
+	}
+	track.Reset()
+	if match(zeekio.NewReader(track, resolver.NewContext())) {
+		return zeekio.NewReader(recorder, zctx), nil
 	}
 	track.Reset()
 	// zjson must come before ndjson since zjson is a subset of ndjson

--- a/zio/zeekio/reader.go
+++ b/zio/zeekio/reader.go
@@ -1,0 +1,53 @@
+package zeekio
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/mccanne/zq/pkg/peeker"
+	"github.com/mccanne/zq/pkg/skim"
+	"github.com/mccanne/zq/zng"
+	"github.com/mccanne/zq/zng/resolver"
+)
+
+const (
+	ReadSize    = 64 * 1024
+	MaxLineSize = 50 * 1024 * 1024
+)
+
+type Reader struct {
+	scanner *skim.Scanner
+	peeker  *peeker.Reader
+	parser  *Parser
+	zctx    *resolver.Context
+}
+
+func NewReader(reader io.Reader, zctx *resolver.Context) *Reader {
+	buffer := make([]byte, ReadSize)
+	return &Reader{
+		scanner: skim.NewScanner(reader, buffer, MaxLineSize),
+		parser:  NewParser(zctx),
+	}
+}
+
+func (r *Reader) Read() (*zng.Record, error) {
+again:
+	line, err := r.scanner.ScanLine()
+	if line == nil {
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", r.scanner.Stats.Lines, err)
+		}
+		return nil, nil
+	}
+	// remove newline
+	line = bytes.TrimSpace(line)
+	if line[0] == '#' {
+
+		if err := r.parser.ParseDirective(line); err != nil {
+			return nil, err
+		}
+		goto again
+	}
+	return r.parser.ParseValue(line)
+}

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -60,6 +60,9 @@ func (r *Reader) Read() (*zng.Record, error) {
 			return nil, fmt.Errorf("undefined type ID: %d", v.Id)
 		}
 	} else {
+		if v.Aliases != nil {
+			r.parseAliases(v.Aliases)
+		}
 		typeName, err := decodeType(v.Type)
 		if err != nil {
 			return nil, err
@@ -108,6 +111,17 @@ func (r *Reader) parseValues(typ *zng.TypeRecord, v interface{}) (*zng.Record, e
 		record.Ts = ts
 	}
 	return record, nil
+}
+
+func (r *Reader) parseAliases(aliases []Alias) error {
+	for _, alias := range aliases {
+		typ, err := r.zctx.LookupByName(alias.Type)
+		if err != nil {
+			return fmt.Errorf("unknown type: \"%s\"", alias.Type)
+		}
+		r.zctx.LookupTypeAlias(alias.Name, typ)
+	}
+	return nil
 }
 
 // decode a nested JSON object into a zeek type string and return the string.

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -12,10 +12,16 @@ type Column struct {
 	Type interface{} `json:"type"`
 }
 
+type Alias struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
 type Record struct {
-	Id     int           `json:"id"`
-	Type   []interface{} `json:"type,omitempty"`
-	Values []interface{} `json:"values"`
+	Id      int           `json:"id"`
+	Type    []interface{} `json:"type,omitempty"`
+	Aliases []Alias       `json:"aliases,omitempty"`
+	Values  []interface{} `json:"values"`
 }
 
 type Writer struct {

--- a/zio/zngio/reader_test.go
+++ b/zio/zngio/reader_test.go
@@ -83,21 +83,21 @@ func TestAlias(t *testing.T) {
 1:[25;]`)
 }
 
-// func TestAliasErr(t *testing.T) {
-// boomerangErr(t, "non-existent", errors.New("Hi"), `
-// #ip=doesnotexist
-// #0:record[foo:string,orig_h:ip]`)
+func TestAliasErr(t *testing.T) {
+	boomerangErr(t, "non-existent", `
+#ip=doesnotexist
+#0:record[foo:string,orig_h:ip]`, "unknown type: %s", "doesnotexist")
 
-// boomerangErr(t, "out-of-order", errors.New("Hi"), `
-// #alias3=alias2
-// #alias2=alias1
-// #alias1=addr
-// #0:record[foo:string,orig_h:alias3]`)
+	boomerangErr(t, "out-of-order", `
+#alias3=alias2
+#alias2=alias1
+#alias1=addr
+#0:record[foo:string,orig_h:alias3]`, "unknown type: %s", "alias2")
 
-// boomerangErr(t, "alias-preexisting", errors.New("Hi"), `
-// #interval=alias
-// #0:record[foo:string,dur:interval]`)
-// }
+	boomerangErr(t, "alias-preexisting", `
+#interval=alias
+#0:record[foo:string,dur:interval]`, "unknown type: %s", "alias")
+}
 
 type output struct {
 	bytes.Buffer
@@ -105,13 +105,13 @@ type output struct {
 
 func (o *output) Close() error { return nil }
 
-func boomerangErr(t *testing.T, name string, expectedErr error, logs string) {
+func boomerangErr(t *testing.T, name, logs, errorMsg string, errorArgs ...interface{}) {
 	t.Run(name, func(t *testing.T) {
 		in := []byte(strings.TrimSpace(logs) + "\n")
 		zngSrc := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
 		zngDst := zbuf.NopFlusher(zngio.NewWriter(&output{}))
 		err := zbuf.Copy(zngDst, zngSrc)
-		assert.Equal(t, expectedErr, err)
+		assert.Errorf(t, err, errorMsg, errorArgs...)
 	})
 }
 

--- a/zio/zngio/reader_test.go
+++ b/zio/zngio/reader_test.go
@@ -2,7 +2,6 @@ package zngio_test
 
 import (
 	"bytes"
-	"errors"
 	"strings"
 	"testing"
 
@@ -84,21 +83,21 @@ func TestAlias(t *testing.T) {
 1:[25;]`)
 }
 
-func TestAliasErr(t *testing.T) {
-	boomerangErr(t, "non-existent", errors.New("Hi"), `
-#ip=doesnotexist
-#0:record[foo:string,orig_h:ip]`)
+// func TestAliasErr(t *testing.T) {
+// boomerangErr(t, "non-existent", errors.New("Hi"), `
+// #ip=doesnotexist
+// #0:record[foo:string,orig_h:ip]`)
 
-	boomerangErr(t, "out-of-order", errors.New("Hi"), `
-#alias3=alias2
-#alias2=alias1
-#alias1=addr
-#0:record[foo:string,orig_h:alias3]`)
+// boomerangErr(t, "out-of-order", errors.New("Hi"), `
+// #alias3=alias2
+// #alias2=alias1
+// #alias1=addr
+// #0:record[foo:string,orig_h:alias3]`)
 
-	boomerangErr(t, "alias-preexisting", errors.New("Hi"), `
-#interval=alias
-#0:record[foo:string,dur:interval]`)
-}
+// boomerangErr(t, "alias-preexisting", errors.New("Hi"), `
+// #interval=alias
+// #0:record[foo:string,dur:interval]`)
+// }
 
 type output struct {
 	bytes.Buffer

--- a/zio/zngio/reader_test.go
+++ b/zio/zngio/reader_test.go
@@ -1,0 +1,130 @@
+package zngio_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mccanne/zq/zbuf"
+	"github.com/mccanne/zq/zio/zngio"
+	"github.com/mccanne/zq/zng/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const ctrl = `
+#!message1
+#0:record[id:record[a:string,s:set[string]]]
+#!message2
+0:[[-;[]]]
+#!message3
+#!message4`
+
+func TestCtrl(t *testing.T) {
+	// this tests reading of control via text zng,
+	// then writing of raw control, and reading back the result
+	in := []byte(strings.TrimSpace(ctrl) + "\n")
+	r := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+
+	_, body, err := r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message1"))
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message2"))
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.True(t, body == nil)
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message3"))
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message4"))
+}
+
+func TestAlias(t *testing.T) {
+	boomerang(t, "simple", `
+#ip=addr
+#0:record[foo:string,orig_h:ip]
+0:[bar;127.0.0.1;]`)
+
+	boomerang(t, "wrapped-aliases", `
+#alias1=addr
+#alias2=alias1
+#alias3=alias2
+#0:record[foo:string,orig_h:alias3]
+0:[bar;127.0.0.1;]`)
+
+	boomerang(t, "alias-in-different-records", `
+#ip=addr
+#0:record[foo:string,orig_h:ip]
+0:[bar;127.0.0.1;]
+#1:record[foo:string,resp_h:ip]
+1:[bro;127.0.0.1;]`)
+
+	boomerang(t, "same-primitive-different-records", `
+#ip=addr
+#0:record[foo:string,orig_h:ip]
+0:[bro;127.0.0.1;]
+#1:record[foo:string,orig_h:addr]
+1:[bar;127.0.0.1;]`)
+
+	boomerang(t, "redefine-alias", `
+#alias=addr
+#0:record[orig_h:alias]
+0:[127.0.0.1;]
+#alias=count
+#1:record[count:alias]
+1:[25;]`)
+}
+
+func TestAliasErr(t *testing.T) {
+	boomerangErr(t, "non-existent", errors.New("Hi"), `
+#ip=doesnotexist
+#0:record[foo:string,orig_h:ip]`)
+
+	boomerangErr(t, "out-of-order", errors.New("Hi"), `
+#alias3=alias2
+#alias2=alias1
+#alias1=addr
+#0:record[foo:string,orig_h:alias3]`)
+
+	boomerangErr(t, "alias-preexisting", errors.New("Hi"), `
+#interval=alias
+#0:record[foo:string,dur:interval]`)
+}
+
+type output struct {
+	bytes.Buffer
+}
+
+func (o *output) Close() error { return nil }
+
+func boomerangErr(t *testing.T, name string, expectedErr error, logs string) {
+	t.Run(name, func(t *testing.T) {
+		in := []byte(strings.TrimSpace(logs) + "\n")
+		zngSrc := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+		zngDst := zbuf.NopFlusher(zngio.NewWriter(&output{}))
+		err := zbuf.Copy(zngDst, zngSrc)
+		assert.Equal(t, expectedErr, err)
+	})
+}
+
+// Send logs to zng reader ->  zng writer
+func boomerang(t *testing.T, name, logs string) {
+	t.Run(name, func(t *testing.T) {
+		var out output
+		in := []byte(strings.TrimSpace(logs) + "\n")
+		zngSrc := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+		zngDst := zbuf.NopFlusher(zngio.NewWriter(&out))
+		err := zbuf.Copy(zngDst, zngSrc)
+		require.NoError(t, err)
+		assert.Equal(t, string(in), out.String())
+	})
+}

--- a/zio/zson_test.go
+++ b/zio/zson_test.go
@@ -204,48 +204,56 @@ func TestZjson(t *testing.T) {
 	boomerangZJSON(t, zngBig())
 }
 
-func TestRawAlias(t *testing.T) {
-	t.Run("simple", func(t *testing.T) {
-		boomerang(t, `
-#ip=addr
+func TestAlias(t *testing.T) {
+	const simple = `#ip=addr
 #0:record[foo:string,orig_h:ip]
-0:[bar;127.0.0.1;]`)
-	})
+0:[bar;127.0.0.1;]`
 
-	t.Run("wrapped-aliases", func(t *testing.T) {
-		boomerang(t, `
-#alias1=addr
+	const wrapped = `#alias1=addr
 #alias2=alias1
 #alias3=alias2
 #0:record[foo:string,orig_h:alias3]
-0:[bar;127.0.0.1;]`)
-	})
+0:[bar;127.0.0.1;]`
 
-	t.Run("alias-in-different-records", func(t *testing.T) {
-		boomerang(t, `
-#ip=addr
+	const multipleRecords = `#ip=addr
 #0:record[foo:string,orig_h:ip]
 0:[bar;127.0.0.1;]
 #1:record[foo:string,resp_h:ip]
-1:[bro;127.0.0.1;]`)
-	})
+1:[bro;127.0.0.1;]`
 
-	t.Run("same-primitive-different-records", func(t *testing.T) {
-		boomerang(t, `
-#ip=addr
-#0:record[foo:string,orig_h:ip]
-0:[bro;127.0.0.1;]
-#1:record[foo:string,orig_h:addr]
-1:[bar;127.0.0.1;]`)
-	})
-
-	t.Run("redefine-alias", func(t *testing.T) {
-		boomerang(t, `
-#alias=addr
+	const redefine = `#alias=addr
 #0:record[orig_h:alias]
 0:[127.0.0.1;]
 #alias=count
 #1:record[count:alias]
-1:[25;]`)
+1:[25;]`
+
+	t.Run("Bzng", func(t *testing.T) {
+		t.Run("simple", func(t *testing.T) {
+			boomerang(t, simple)
+		})
+		t.Run("wrapped-aliases", func(t *testing.T) {
+			boomerang(t, wrapped)
+		})
+		t.Run("alias-in-different-records", func(t *testing.T) {
+			boomerang(t, multipleRecords)
+		})
+		t.Run("redefine", func(t *testing.T) {
+			boomerang(t, redefine)
+		})
+	})
+	t.Run("ZJSON", func(t *testing.T) {
+		t.Run("simple", func(t *testing.T) {
+			boomerangZJSON(t, simple)
+		})
+		t.Run("wrapped-aliases", func(t *testing.T) {
+			boomerangZJSON(t, wrapped)
+		})
+		t.Run("alias-in-different-records", func(t *testing.T) {
+			boomerangZJSON(t, multipleRecords)
+		})
+		t.Run("redefine", func(t *testing.T) {
+			boomerangZJSON(t, redefine)
+		})
 	})
 }

--- a/zio/zson_test.go
+++ b/zio/zson_test.go
@@ -151,6 +151,59 @@ func TestRaw(t *testing.T) {
 	boomerang(t, zngBig())
 }
 
+const ctrl = `
+#!message1
+#0:record[id:record[a:string,s:set[string]]]
+#!message2
+0:[[-;[]]]
+#!message3
+#!message4`
+
+func TestCtrl(t *testing.T) {
+	// this tests reading of control via text zng,
+	// then writing of raw control, and reading back the result
+	in := []byte(strings.TrimSpace(ctrl) + "\n")
+	r := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+
+	_, body, err := r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message1"))
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message2"))
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.True(t, body == nil)
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message3"))
+
+	_, body, err = r.ReadPayload()
+	assert.NoError(t, err)
+	assert.Equal(t, body, []byte("message4"))
+}
+
+func TestZjson(t *testing.T) {
+	boomerangZJSON(t, zng1)
+	boomerangZJSON(t, zng2)
+	// XXX this one doesn't work right now but it's sort of ok becaue
+	// it's a little odd to have an unset string value inside of a set.
+	// semantically this would mean the value shouldn't be in the set,
+	// but right now this turns into an empty string, which is somewhat reasonable.
+	//boomerangZJSON(t, zng3)
+	boomerangZJSON(t, zng4)
+	boomerangZJSON(t, zng5)
+	boomerangZJSON(t, zng6)
+	boomerangZJSON(t, zng7)
+	// XXX need to fix bug in json reader where it always uses a primitive null
+	// even within a container type (like json array)
+	//boomerangZJSON(t, zng8)
+	boomerangZJSON(t, zngBig())
+}
+
 func TestRawAlias(t *testing.T) {
 	t.Run("simple", func(t *testing.T) {
 		boomerang(t, `
@@ -195,22 +248,4 @@ func TestRawAlias(t *testing.T) {
 #1:record[count:alias]
 1:[25;]`)
 	})
-}
-
-func TestZjson(t *testing.T) {
-	boomerangZJSON(t, zng1)
-	boomerangZJSON(t, zng2)
-	// XXX this one doesn't work right now but it's sort of ok becaue
-	// it's a little odd to have an unset string value inside of a set.
-	// semantically this would mean the value shouldn't be in the set,
-	// but right now this turns into an empty string, which is somewhat reasonable.
-	//boomerangZJSON(t, zng3)
-	boomerangZJSON(t, zng4)
-	boomerangZJSON(t, zng5)
-	boomerangZJSON(t, zng6)
-	boomerangZJSON(t, zng7)
-	// XXX need to fix bug in json reader where it always uses a primitive null
-	// even within a container type (like json array)
-	//boomerangZJSON(t, zng8)
-	boomerangZJSON(t, zngBig())
 }

--- a/zng/alias.go
+++ b/zng/alias.go
@@ -1,0 +1,47 @@
+package zng
+
+import (
+	"github.com/mccanne/zq/zcode"
+)
+
+type TypeAlias struct {
+	id   int
+	Name string
+	Type Type
+}
+
+func NewTypeAlias(id int, name string, typ Type) *TypeAlias {
+	return &TypeAlias{
+		id:   id,
+		Name: name,
+		Type: typ,
+	}
+}
+
+func (t *TypeAlias) ID() int {
+	return t.Type.ID()
+}
+
+func (t *TypeAlias) AliasID() int {
+	return t.id
+}
+
+//XXX get rid of this when we implement full ZNG
+func (t *TypeAlias) SetID(id int) {
+	t.id = id
+}
+
+func (t *TypeAlias) String() string {
+	return t.Name
+}
+func (t *TypeAlias) Parse(in []byte) (zcode.Bytes, error) {
+	return t.Type.Parse(in)
+}
+
+func (t *TypeAlias) StringOf(zv zcode.Bytes, out OutFmt, b bool) string {
+	return t.Type.StringOf(zv, out, b)
+}
+
+func (t *TypeAlias) Marshal(zv zcode.Bytes) (interface{}, error) {
+	return t.Type.Marshal(zv)
+}

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -7,7 +7,6 @@
 >
 > * the bytes type is not yet implemented,
 > * the union type is not yet implemented,
-> * type aliases are not yet implemented, and
 > * ordering hints are not generated or taken advantage of.
 >
 > Also, we are contemplating reducing the number of primitive types, e.g.,
@@ -102,7 +101,7 @@ needed to define the schema for each distinct record.  To define a new
 type, the "#" syntax is used.  For example,
 logs from the open-source Zeek system might look like this
 ```
-#alias:addr=ip
+#ip=addr
 #24:record[_path:string,ts:time,uid:string,id:record[orig_h:addr,orig_p:port,resp_h:addr,resp_p:port]...
 #25:record[_path:string,ts:time,fuid:string,tx_hosts:set[addr]...
 24:[conn;1425565514.419939;CogZFI3py5JsFZGik;[192.168.1.1:;80/tcp;192.168.1.2;8080;]...

--- a/zng/type.go
+++ b/zng/type.go
@@ -243,13 +243,6 @@ func AliasTypes(typ Type) []*TypeAlias {
 	return aliases
 }
 
-func Unalias(typ Type) Type {
-	if typ, ok := typ.(*TypeAlias); ok {
-		return Unalias(typ.Type)
-	}
-	return typ
-}
-
 func trimInnerTypes(typ string, raw string) string {
 	// XXX handle white space, "set [..."... ?
 	innerTypes := strings.TrimPrefix(raw, typ+"[")

--- a/zng/value.go
+++ b/zng/value.go
@@ -175,3 +175,10 @@ func (v Value) IsUnset() bool {
 func (v Value) IsUnsetOrNil() bool {
 	return v.Bytes == nil
 }
+
+func (v Value) Unalias() Value {
+	if v.Type != nil {
+		v.Type = Unalias(v.Type)
+	}
+	return v
+}

--- a/zng/value.go
+++ b/zng/value.go
@@ -175,10 +175,3 @@ func (v Value) IsUnset() bool {
 func (v Value) IsUnsetOrNil() bool {
 	return v.Bytes == nil
 }
-
-func (v Value) Unalias() Value {
-	if v.Type != nil {
-		v.Type = Unalias(v.Type)
-	}
-	return v
-}

--- a/zx/coerce.go
+++ b/zx/coerce.go
@@ -13,35 +13,34 @@ import (
 func CoerceToDouble(in zng.Value) (float64, bool) {
 	var out float64
 	var err error
-	typ := zng.Unalias(in.Type)
-	switch typ.(type) {
+	switch in.Type.ID() {
 	default:
 		return 0, false
-	case *zng.TypeOfDouble:
+	case zng.IdFloat64:
 		out, err = zng.DecodeDouble(in.Bytes)
-	case *zng.TypeOfInt:
+	case zng.IdInt64:
 		var v int64
 		v, err = zng.DecodeInt(in.Bytes)
 		out = float64(v)
-	case *zng.TypeOfBool:
+	case zng.IdBool:
 		var v bool
 		v, err = zng.DecodeBool(in.Bytes)
 		if v {
 			out = 1
 		}
-	case *zng.TypeOfCount:
+	case zng.IdUint64:
 		var v uint64
 		v, err = zng.DecodeCount(in.Bytes)
 		out = float64(v)
-	case *zng.TypeOfPort:
+	case zng.IdPort:
 		var v uint32
 		v, err = zng.DecodePort(in.Bytes)
 		out = float64(v)
-	case *zng.TypeOfTime:
+	case zng.IdTime:
 		var v nano.Ts
 		v, err = zng.DecodeTime(in.Bytes)
 		out = float64(v) / 1e9
-	case *zng.TypeOfInterval:
+	case zng.IdDuration:
 		var v int64
 		v, err = zng.DecodeInterval(in.Bytes)
 		out = float64(v) / 1e9
@@ -62,13 +61,12 @@ func CoerceToInt(in zng.Value) (int64, bool) {
 	var out int64
 	var err error
 	body := in.Bytes
-	typ := zng.Unalias(in.Type)
-	switch typ.(type) {
+	switch in.Type.ID() {
 	default:
 		return 0, false
-	case *zng.TypeOfInt:
+	case zng.IdInt64:
 		out, err = zng.DecodeInt(body)
-	case *zng.TypeOfCount:
+	case zng.IdUint64:
 		var v uint64
 		v, err = zng.DecodeCount(body)
 		// check for overflow
@@ -76,22 +74,22 @@ func CoerceToInt(in zng.Value) (int64, bool) {
 			return 0, false
 		}
 		out = int64(v)
-	case *zng.TypeOfPort:
+	case zng.IdPort:
 		var v uint32
 		v, err = zng.DecodePort(body)
 		out = int64(v)
-	case *zng.TypeOfDouble:
+	case zng.IdFloat64:
 		var v float64
 		v, err = zng.DecodeDouble(body)
 		out = int64(v)
 		if float64(out) != v {
 			return 0, false
 		}
-	case *zng.TypeOfTime:
+	case zng.IdTime:
 		var v nano.Ts
 		v, err = zng.DecodeTime(body)
 		out = int64(v / 1e9)
-	case *zng.TypeOfInterval:
+	case zng.IdDuration:
 		var v int64
 		v, err = zng.DecodeInterval(body)
 		out = int64(v / 1e9)
@@ -109,16 +107,15 @@ func CoerceToInt(in zng.Value) (int64, bool) {
 func CoerceToInterval(in zng.Value) (int64, bool) {
 	var out int64
 	var err error
-	typ := zng.Unalias(in.Type)
-	switch typ.(type) {
+	switch in.Type.ID() {
 	default:
 		return 0, false
-	case *zng.TypeOfInterval:
+	case zng.IdDuration:
 		out, err = zng.DecodeInterval(in.Bytes)
-	case *zng.TypeOfInt:
+	case zng.IdUint64:
 		out, err = zng.DecodeInt(in.Bytes)
 		out *= 1_000_000_000
-	case *zng.TypeOfDouble:
+	case zng.IdFloat64:
 		var v float64
 		v, err = zng.DecodeDouble(in.Bytes)
 		v *= 1e9
@@ -134,15 +131,14 @@ func CoerceToPort(in zng.Value) (uint32, bool) {
 	var out uint32
 	var err error
 	body := in.Bytes
-	typ := zng.Unalias(in.Type)
-	switch typ.(type) {
+	switch in.Type.ID() {
 	default:
 		return 0, false
-	case *zng.TypeOfInt:
+	case zng.IdInt64:
 		var v int64
 		v, err = zng.DecodeInt(body)
 		out = uint32(v)
-	case *zng.TypeOfCount:
+	case zng.IdUint64:
 		var v uint64
 		v, err = zng.DecodeCount(body)
 		// check for overflow
@@ -150,9 +146,9 @@ func CoerceToPort(in zng.Value) (uint32, bool) {
 			return 0, false
 		}
 		out = uint32(v)
-	case *zng.TypeOfPort:
+	case zng.IdPort:
 		out, err = zng.DecodePort(body)
-	case *zng.TypeOfDouble:
+	case zng.IdFloat64:
 		var v float64
 		v, err = zng.DecodeDouble(body)
 		out = uint32(v)
@@ -168,11 +164,10 @@ func CoerceToPort(in zng.Value) (uint32, bool) {
 
 func CoerceToEnum(in zng.Value) (string, bool) {
 	var enum string
-	typ := zng.Unalias(in.Type)
-	switch typ.(type) {
+	switch in.Type.ID() {
 	default:
 		return "", false
-	case *zng.TypeOfString, *zng.TypeOfBstring:
+	case zng.IdString, zng.IdBstring:
 		enum = string(in.Bytes)
 	}
 	return enum, true
@@ -185,17 +180,16 @@ func CoerceToEnum(in zng.Value) (string, bool) {
 func CoerceToTime(in zng.Value) (nano.Ts, bool) {
 	var err error
 	var ts nano.Ts
-	typ := zng.Unalias(in.Type)
-	switch typ.(type) {
+	switch in.Type.ID() {
 	default:
 		return 0, false
-	case *zng.TypeOfTime:
+	case zng.IdTime:
 		ts, err = zng.DecodeTime(in.Bytes)
-	case *zng.TypeOfInt:
+	case zng.IdInt64:
 		var v int64
 		v, err = zng.DecodeInt(in.Bytes)
 		ts = nano.Ts(v) * 1_000_000_000
-	case *zng.TypeOfDouble:
+	case zng.IdFloat64:
 		var v float64
 		v, err = zng.DecodeDouble(in.Bytes)
 		ts = nano.Ts(v * 1e9)
@@ -207,11 +201,10 @@ func CoerceToTime(in zng.Value) (nano.Ts, bool) {
 }
 
 func CoerceToString(in zng.Value) (string, bool) {
-	typ := zng.Unalias(in.Type)
-	switch typ.(type) {
+	switch in.Type.ID() {
 	default:
 		return "", false
-	case *zng.TypeOfString, *zng.TypeOfBstring, *zng.TypeOfEnum:
+	case zng.IdString, zng.IdBstring, zng.IdEnum:
 		return string(in.Bytes), true
 	}
 }
@@ -228,36 +221,36 @@ func Coerce(v zng.Value, to zng.Type) (zng.Value, bool) {
 	if v.Type == to {
 		return v, true
 	}
-	switch to.(type) {
-	case *zng.TypeOfDouble:
+	switch to.ID() {
+	case zng.IdFloat64:
 		if d, ok := CoerceToDouble(v); ok {
 			return zng.NewDouble(d), true
 		}
-	case *zng.TypeOfEnum:
+	case zng.IdEnum:
 		if e, ok := CoerceToEnum(v); ok {
 			return zng.NewEnum(e), true
 		}
-	case *zng.TypeOfInt:
+	case zng.IdInt64:
 		if i, ok := CoerceToInt(v); ok {
 			return zng.NewInt(i), true
 		}
-	case *zng.TypeOfInterval:
+	case zng.IdDuration:
 		if i, ok := CoerceToInterval(v); ok {
 			return zng.NewInterval(i), true
 		}
-	case *zng.TypeOfPort:
+	case zng.IdPort:
 		if p, ok := CoerceToPort(v); ok {
 			return zng.NewPort(p), true
 		}
-	case *zng.TypeOfTime:
+	case zng.IdTime:
 		if i, ok := CoerceToTime(v); ok {
 			return zng.NewTime(i), true
 		}
-	case *zng.TypeOfString:
+	case zng.IdString:
 		if s, ok := CoerceToString(v); ok {
 			return zng.NewString(s), true
 		}
-	case *zng.TypeOfBstring:
+	case zng.IdBstring:
 		if s, ok := CoerceToString(v); ok {
 			return zng.NewBstring(s), true
 		}

--- a/zx/coerce.go
+++ b/zx/coerce.go
@@ -216,7 +216,6 @@ func CoerceToString(in zng.Value) (string, bool) {
 // XXX this doesn't seem valid:  If the coercion cannot be
 // performed such that v.Coerce(t1).Coerce(v.Type).String() == v.String(),
 // then nil is returned.
-// XXX how to handle aliases here?
 func Coerce(v zng.Value, to zng.Type) (zng.Value, bool) {
 	if v.Type == to {
 		return v, true

--- a/zx/coerce.go
+++ b/zx/coerce.go
@@ -13,7 +13,8 @@ import (
 func CoerceToDouble(in zng.Value) (float64, bool) {
 	var out float64
 	var err error
-	switch in.Type.(type) {
+	typ := zng.Unalias(in.Type)
+	switch typ.(type) {
 	default:
 		return 0, false
 	case *zng.TypeOfDouble:
@@ -61,7 +62,8 @@ func CoerceToInt(in zng.Value) (int64, bool) {
 	var out int64
 	var err error
 	body := in.Bytes
-	switch in.Type.(type) {
+	typ := zng.Unalias(in.Type)
+	switch typ.(type) {
 	default:
 		return 0, false
 	case *zng.TypeOfInt:
@@ -107,7 +109,8 @@ func CoerceToInt(in zng.Value) (int64, bool) {
 func CoerceToInterval(in zng.Value) (int64, bool) {
 	var out int64
 	var err error
-	switch in.Type.(type) {
+	typ := zng.Unalias(in.Type)
+	switch typ.(type) {
 	default:
 		return 0, false
 	case *zng.TypeOfInterval:
@@ -131,7 +134,8 @@ func CoerceToPort(in zng.Value) (uint32, bool) {
 	var out uint32
 	var err error
 	body := in.Bytes
-	switch in.Type.(type) {
+	typ := zng.Unalias(in.Type)
+	switch typ.(type) {
 	default:
 		return 0, false
 	case *zng.TypeOfInt:
@@ -164,7 +168,8 @@ func CoerceToPort(in zng.Value) (uint32, bool) {
 
 func CoerceToEnum(in zng.Value) (string, bool) {
 	var enum string
-	switch in.Type.(type) {
+	typ := zng.Unalias(in.Type)
+	switch typ.(type) {
 	default:
 		return "", false
 	case *zng.TypeOfString, *zng.TypeOfBstring:
@@ -180,7 +185,8 @@ func CoerceToEnum(in zng.Value) (string, bool) {
 func CoerceToTime(in zng.Value) (nano.Ts, bool) {
 	var err error
 	var ts nano.Ts
-	switch in.Type.(type) {
+	typ := zng.Unalias(in.Type)
+	switch typ.(type) {
 	default:
 		return 0, false
 	case *zng.TypeOfTime:
@@ -201,7 +207,8 @@ func CoerceToTime(in zng.Value) (nano.Ts, bool) {
 }
 
 func CoerceToString(in zng.Value) (string, bool) {
-	switch in.Type.(type) {
+	typ := zng.Unalias(in.Type)
+	switch typ.(type) {
 	default:
 		return "", false
 	case *zng.TypeOfString, *zng.TypeOfBstring, *zng.TypeOfEnum:
@@ -216,6 +223,7 @@ func CoerceToString(in zng.Value) (string, bool) {
 // XXX this doesn't seem valid:  If the coercion cannot be
 // performed such that v.Coerce(t1).Coerce(v.Type).String() == v.String(),
 // then nil is returned.
+// XXX how to handle aliases here?
 func Coerce(v zng.Value, to zng.Type) (zng.Value, bool) {
 	if v.Type == to {
 		return v, true


### PR DESCRIPTION
Done according to the zng spec. Includes end-to-end reading and
writing for bzng, zng and zjson. Support for aliases added to
sort, reducer, and groupby procs.

TODO (in this pr):
- [x] zjson support