### PR TITLE
add stubs for zqd experiment

### DIFF
--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -1,0 +1,38 @@
+package listen
+
+import (
+	"flag"
+
+	"github.com/mccanne/charm"
+	"github.com/mccanne/zq/cmd/zqd/root"
+	"github.com/mccanne/zq/zqd"
+)
+
+var Listen = &charm.Spec{
+	Name:  "listen",
+	Usage: "listen [options]",
+	Short: "listen as a daemon and repond to zqd service requests",
+	Long: `
+The listen command launches a process to listen on the provided interface and
+`,
+	New: New,
+}
+
+func init() {
+	root.Zqd.Add(Listen)
+}
+
+type Command struct {
+	*root.Command
+	listenAddr string
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.StringVar(&c.listenAddr, "l", ":9867", "[addr]:port to listen on")
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	return zqd.Run(c.listenAddr)
+}

--- a/cmd/zqd/main.go
+++ b/cmd/zqd/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	_ "github.com/mccanne/zq/cmd/zqd/listen"
+	root "github.com/mccanne/zq/cmd/zqd/root"
+)
+
+func main() {
+	if _, err := root.Zqd.ExecRoot(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/zqd/root/command.go
+++ b/cmd/zqd/root/command.go
@@ -1,0 +1,46 @@
+package root
+
+import (
+	"flag"
+	"log"
+	"strings"
+
+	"github.com/mccanne/charm"
+)
+
+// These variables are populated via the Go linker.
+var (
+	Version    = "unknown"
+	ZqdVersion = "unknown"
+)
+
+var Zqd = &charm.Spec{
+	Name:  "zqd",
+	Usage: "zqd [global options] command [options] [arguments...]",
+	Short: "use zqd to server zq searches",
+	Long: `
+`,
+	New: New,
+}
+
+type Command struct {
+	charm.Command
+}
+
+func init() {
+	Zqd.Add(charm.Help)
+}
+
+func Servers(s string) []string {
+	return strings.Split(s, ",")
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{}
+	log.SetPrefix("zqd") // XXX switch to zapper
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	return Zqd.Exec(c, []string{"help"})
+}

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/mccanne/zq/pkg/nano"
+	"github.com/mccanne/zq/zio/zjsonio"
+)
+
+type Error struct {
+	Type    string      `json:"type"`
+	Message string      `json:"error"`
+	Info    interface{} `json:"info,omitempty"`
+}
+
+type TaskStart struct {
+	Type   string `json:"type"`
+	TaskID int64  `json:"task_id"`
+}
+
+type TaskEnd struct {
+	Type   string `json:"type"`
+	TaskID int64  `json:"task_id"`
+	Error  *Error `json:"error,omitempty"`
+}
+
+type SearchRequest struct {
+	Space string          `json:"space" validate:"required"`
+	Proc  json.RawMessage `json:"proc" validate:"required"`
+	Span  nano.Span       `json:"span"`
+	Dir   int             `json:"dir" validate:"required"`
+}
+
+type SearchRecords struct {
+	Type      string           `json:"type"`
+	ChannelID int              `json:"channel_id"`
+	Records   []zjsonio.Record `json:"records"`
+}
+
+type SearchWarnings struct {
+	Type     string   `json:"type"`
+	Warnings []string `json:"warnings"`
+}
+
+type SearchEnd struct {
+	Type      string `json:"type"`
+	ChannelID int    `json:"channel_id"`
+	Reason    string `json:"reason"`
+}
+
+type SearchStats struct {
+	Type       string  `json:"type"`
+	StartTime  nano.Ts `json:"start_time"`
+	UpdateTime nano.Ts `json:"update_time"`
+	ScannerStats
+}
+
+type ScannerStats struct {
+	CurrentTs       nano.Ts `json:"current_ts"`
+	BytesRead       int64   `json:"bytes_read"`
+	BytesMatched    int64   `json:"bytes_matched"`
+	RecordsRead     int64   `json:"records_read"`
+	RecordsMatched  int64   `json:"records_matched"`
+	RecordsReceived int64   `json:"records_received"`
+}
+
+type SpaceInfo struct {
+	Name    string   `json:"name"`
+	MinTime *nano.Ts `json:"min_time,omitempty"`
+	MaxTime *nano.Ts `json:"max_time,omitempty"`
+	Size    int64    `json:"size" unit:"bytes"`
+}
+
+type StatusResponse struct {
+	Ok      bool   `json:"ok"`
+	Version string `json:"version"`
+}

--- a/zqd/search/bzng.go
+++ b/zqd/search/bzng.go
@@ -1,0 +1,66 @@
+package search
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/mccanne/zq/zbuf"
+	"github.com/mccanne/zq/zio/bzngio"
+)
+
+// bzngOutput writes bzng encodings directly to the client via
+// binary data sent over http chunked encoding interleaved with json
+// protocol messages sent as zng comment payloads.  The simplicity of
+// this is a thing of beauty.
+type bzngOutput struct {
+	*http.Request
+	response http.ResponseWriter
+	writer   *bzngio.Writer
+}
+
+func newBzngOutput(req *http.Request, response http.ResponseWriter) *bzngOutput {
+	o := &bzngOutput{
+		Request:  req,
+		response: response,
+		writer:   bzngio.NewWriter(response),
+	}
+	return o
+}
+
+func (r *bzngOutput) flush() {
+	r.response.(http.Flusher).Flush()
+}
+
+func (r *bzngOutput) Collect() interface{} {
+	return "TBD" //XXX
+}
+
+func (r *bzngOutput) SendBatch(cid int, batch zbuf.Batch) error {
+	for _, rec := range batch.Records() {
+		// XXX need to send channel id as control payload
+		if err := r.writer.Write(rec); err != nil {
+			return err
+		}
+	}
+	batch.Unref()
+	r.flush()
+	return nil
+}
+
+func (r *bzngOutput) End(ctrl interface{}) error {
+	return r.SendControl(ctrl)
+}
+
+func (r *bzngOutput) SendControl(ctrl interface{}) error {
+	msg, err := json.Marshal(ctrl)
+	if err != nil {
+		//XXX need a better json error message
+		return err
+	}
+	b := []byte("json:")
+	if err := r.writer.WriteControl(append(b, msg...)); err != nil {
+		return err
+	}
+	r.flush()
+	return nil
+}

--- a/zqd/search/endpoint.go
+++ b/zqd/search/endpoint.go
@@ -1,0 +1,130 @@
+package search
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/mccanne/zq/ast"
+	"github.com/mccanne/zq/pkg/nano"
+	"github.com/mccanne/zq/zio/detector"
+	"github.com/mccanne/zq/zng/resolver"
+	"github.com/mccanne/zq/zqd/api"
+)
+
+// This mtu is pretty small but it keeps the JSON object size below 64kb or so
+// so the recevier can do reasonable, interactive streaming updates.
+const defaultMTU = 100
+
+// A Query is the internal representation of search query describing a source
+// of tuples, a "search" applied to the tuples producing a set of matched
+// tuples, and a proc to the process the tuples
+type Query struct {
+	Space string
+	Dir   int
+	Span  nano.Span
+	Proc  ast.Proc
+}
+
+func parseSearchRequest(r io.Reader) (*Query, error) {
+	var b bytes.Buffer
+	const limit = 1024 * 1024
+	if _, err := b.ReadFrom(io.LimitReader(r, int64(limit))); err != nil {
+		return nil, err
+	}
+	if b.Len() == limit {
+		return nil, errors.New("request too big")
+	}
+	var req api.SearchRequest
+	if err := json.Unmarshal(b.Bytes(), &req); err != nil {
+		return nil, err
+	}
+	if req.Span.Ts < 0 {
+		return nil, errors.New("time span must have non-negative timestamp")
+	}
+	if req.Span.Dur < 0 {
+		return nil, errors.New("time span must have non-negative duration")
+	}
+	// XXX allow either direction even through we do forward only right now
+	if req.Dir != 1 && req.Dir != -1 {
+		return nil, errors.New("time direction must be 1 or -1")
+	}
+	return UnpackQuery(&req)
+}
+
+// UnpackQuery transforms a api.SearchRequest into a Query.
+func UnpackQuery(req *api.SearchRequest) (*Query, error) {
+	proc, err := ast.UnpackProc(nil, req.Proc)
+	if err != nil {
+		return nil, err
+	}
+	return &Query{
+		Space: req.Space,
+		Dir:   req.Dir,
+		Span:  req.Span,
+		Proc:  proc,
+	}, nil
+}
+
+func httpError(w http.ResponseWriter, msg string, code int) {
+	b, err := json.Marshal(&api.Error{
+		Type:    "Error",
+		Message: msg,
+	})
+	if err != nil {
+		b = []byte(err.Error())
+	}
+	http.Error(w, string(b), code)
+}
+
+func Handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "bad method", http.StatusBadRequest)
+		return
+	}
+	query, err := parseSearchRequest(r.Body)
+	if err != nil {
+		httpError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	//logger.Debug("parseSearchRequest", zap.Stringer("query", query))
+	dataPath := filepath.Join(".", query.Space, "all.bzng") //XXX need root dir param
+	f, err := os.Open(dataPath)
+	if err != nil {
+		httpError(w, "no such space: "+query.Space, http.StatusNotFound)
+		return
+	}
+	defer f.Close()
+	zctx := resolver.NewContext()
+	zngReader := detector.LookupReader("bzng", f, zctx)
+	mux, err := launch(r.Context(), query, zngReader, zctx)
+	if err != nil {
+		httpError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	format := r.URL.Query().Get("format")
+	switch format {
+	default:
+		msg := fmt.Sprintf("unsupported output format: %s", format)
+		httpError(w, msg, http.StatusBadRequest)
+		return
+	case "zjson", "json":
+		s, err := newJSON(r, w, defaultMTU)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		err = run(mux, s)
+	case "bzng":
+		s := newBzngOutput(r, w)
+		err = run(mux, s)
+	}
+	if err != nil {
+		httpError(w, err.Error(), http.StatusBadRequest)
+	}
+}

--- a/zqd/search/json.go
+++ b/zqd/search/json.go
@@ -1,0 +1,74 @@
+package search
+
+import (
+	"net/http"
+
+	"github.com/mccanne/zq/zbuf"
+	"github.com/mccanne/zq/zio/zjsonio"
+	"github.com/mccanne/zq/zng"
+	"github.com/mccanne/zq/zqd/api"
+)
+
+type JSON struct {
+	*http.Request
+	pipe   *JSONPipe
+	stream *zjsonio.Stream
+	mtu    int
+}
+
+func newJSON(req *http.Request, resp http.ResponseWriter, mtu int) (*JSON, error) {
+	return &JSON{
+		Request: req,
+		pipe:    NewJSONPipe(req, resp),
+		stream:  zjsonio.NewStream(),
+		mtu:     mtu,
+	}, nil
+}
+
+func (s *JSON) formatRecords(records []*zng.Record) ([]zjsonio.Record, error) {
+	var res = make([]zjsonio.Record, len(records))
+	for i, in := range records {
+		out, err := s.stream.Transform(in)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = *out
+	}
+	return res, nil
+}
+
+func (s *JSON) SendBatch(cid int, set zbuf.Batch) error {
+	records := set.Records()
+	n := len(records)
+	for n > 0 {
+		frag := n
+		if frag > s.mtu {
+			frag = s.mtu
+		}
+		records, err := s.formatRecords(records[0:frag])
+		if err != nil {
+			return err
+		}
+		v := &api.SearchRecords{
+			Type:      "SearchRecords",
+			ChannelID: cid,
+			Records:   records,
+		}
+		err = s.pipe.Send(v)
+		if err != nil {
+			return err
+		}
+		records = records[frag:]
+		n -= frag
+	}
+	set.Unref()
+	return nil
+}
+
+func (s *JSON) SendControl(ctrl interface{}) error {
+	return s.pipe.Send(ctrl)
+}
+
+func (s *JSON) End(ctrl interface{}) error {
+	return s.pipe.SendFinal(ctrl)
+}

--- a/zqd/search/pipe.go
+++ b/zqd/search/pipe.go
@@ -1,0 +1,58 @@
+package search
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// JSONPipe is an abstraction for sending reponses as multiple payloads over
+// a potentially long-lived connection using HTTP chunked encoding and a convention
+// to separate JSON objects using two newline characters as described in
+// https://github.com/eBay/jsonpipe
+type JSONPipe struct {
+	*http.Request
+	http.ResponseWriter
+	encoder   *json.Encoder
+	separator []byte
+}
+
+// NewJSONPipe creates a new JSONPipe object for streaming the response to
+// the indicated request.  The Start should be called to initiate the pipe.
+// Then JSON objects are transmitted by calling the Send method one or more times.
+// The pipe is closed by calling the End method.
+func NewJSONPipe(r *http.Request, w http.ResponseWriter) *JSONPipe {
+	r.Header.Add("Content-Type", "application/x-ndjson")
+	p := &JSONPipe{
+		Request:        r,
+		ResponseWriter: w,
+		encoder:        json.NewEncoder(w),
+		separator:      []byte("\n\n"),
+	}
+	return p
+}
+
+func (p *JSONPipe) flush() {
+	flusher := p.ResponseWriter.(http.Flusher)
+	flusher.Flush()
+}
+
+// Send encodes as JSON the payload and streams it as a message over the
+// underlying HTTP connection.  Returns an errorr and does not transmit the message
+// if the connection has already been set into an error state.
+func (p *JSONPipe) Send(payload interface{}) error {
+	if err := p.Context().Err(); err != nil {
+		return err
+	}
+	if err := p.encoder.Encode(payload); err != nil {
+		return err
+	}
+	if _, err := p.ResponseWriter.Write(p.separator); err != nil {
+		return err
+	}
+	p.flush()
+	return nil
+}
+
+func (p *JSONPipe) SendFinal(payload interface{}) error {
+	return p.encoder.Encode(payload)
+}

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -1,0 +1,189 @@
+// Package search provides an implementation for launching zq searches and performing
+// analytics on bzng files stored in the server's root directory.
+package search
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/mccanne/zq/ast"
+	"github.com/mccanne/zq/filter"
+	"github.com/mccanne/zq/pkg/nano"
+	"github.com/mccanne/zq/proc"
+	"github.com/mccanne/zq/scanner"
+	"github.com/mccanne/zq/zbuf"
+	"github.com/mccanne/zq/zng/resolver"
+	"github.com/mccanne/zq/zqd/api"
+	"go.uber.org/zap"
+)
+
+type Output interface {
+	SendBatch(int, zbuf.Batch) error
+	SendControl(interface{}) error
+	End(interface{}) error
+}
+
+type driver struct {
+	output    Output
+	startTime nano.Ts
+}
+
+func (d *driver) start(id int64) error {
+	return d.output.SendControl(&api.TaskStart{"TaskStart", id})
+}
+
+func (d *driver) end(id int64) error {
+	return d.output.End(&api.TaskEnd{"TaskEnd", id, nil})
+}
+
+func (d *driver) abort(id int64, err error) error {
+	verr := &api.Error{Type: "INTERNAL", Message: err.Error()}
+	return d.output.SendControl(&api.TaskEnd{"TaskEnd", id, verr})
+}
+
+// send a stats update every 500 ms XXX
+const statsInterval = time.Millisecond * 500
+
+func (d *driver) sendWarning(warning string) error {
+	v := api.SearchWarnings{
+		Type:     "SearchWarnings",
+		Warnings: []string{warning},
+	}
+	return d.output.SendControl(v)
+}
+
+func (d *driver) sendStats(stats api.ScannerStats) error {
+	v := api.SearchStats{
+		Type:         "SearchStats",
+		StartTime:    d.startTime,
+		UpdateTime:   nano.Now(),
+		ScannerStats: stats,
+	}
+	return d.output.SendControl(v)
+}
+
+func (d *driver) searchEnd(cid int, stats api.ScannerStats) error {
+	err := d.sendStats(stats)
+	if err != nil {
+		return err
+	}
+	v := &api.SearchEnd{
+		Type:      "SearchEnd",
+		ChannelID: cid,
+		Reason:    "eof",
+	}
+	return d.output.SendControl(v)
+}
+
+func run(out *proc.MuxOutput, output Output) error {
+	//XXX scanner needs to track stats, for now send zeroes
+	var stats api.ScannerStats
+	d := &driver{
+		output:    output,
+		startTime: nano.Now(),
+	}
+	d.start(0)
+	ticker := time.NewTicker(statsInterval)
+	defer ticker.Stop()
+	for !out.Complete() {
+		chunk := out.Pull(ticker.C)
+		if chunk.Err != nil {
+			if chunk.Err == proc.ErrTimeout {
+				/* not yet
+				err := d.sendStats(out.Stats())
+				if err != nil {
+					return d.abort(0, err)
+				}
+				*/
+				continue
+			}
+			if chunk.Err == context.Canceled {
+				out.Drain()
+				return d.abort(0, errors.New("search job killed"))
+			}
+			return d.abort(0, chunk.Err)
+		}
+		if chunk.Warning != "" {
+			err := d.sendWarning(chunk.Warning)
+			if err != nil {
+				return d.abort(0, err)
+			}
+		}
+		if chunk.Batch == nil {
+			// a search is done on a channel.  we send stats and
+			// a done message for each channel that finishes
+			err := d.searchEnd(chunk.ID, stats)
+			if err != nil {
+				return d.abort(0, err)
+			}
+		} else {
+			err := d.output.SendBatch(chunk.ID, chunk.Batch)
+			if err != nil {
+				return d.abort(0, err)
+			}
+		}
+	}
+	return d.end(0)
+}
+
+// from zq main - move to shared place
+func liftFilter(p ast.Proc) (*ast.FilterProc, ast.Proc) {
+	if fp, ok := p.(*ast.FilterProc); ok {
+		pass := &ast.PassProc{
+			Node: ast.Node{"PassProc"},
+		}
+		return fp, pass
+	}
+	seq, ok := p.(*ast.SequentialProc)
+	if ok && len(seq.Procs) > 0 {
+		if fp, ok := seq.Procs[0].(*ast.FilterProc); ok {
+			rest := &ast.SequentialProc{
+				Node:  ast.Node{"SequentialProc"},
+				Procs: seq.Procs[1:],
+			}
+			return fp, rest
+		}
+	}
+	return nil, nil
+}
+
+// from zq main - move to shared place
+func compile(ctx *proc.Context, program ast.Proc, reader zbuf.Reader) (*proc.MuxOutput, error) {
+	// Try to move the filter into the scanner so we can throw
+	// out unmatched records without copying their contents in the
+	// case of readers (like zio raw.Reader) that create volatile
+	// records that are kepted by the scanner only if matched.
+	// For other readers, it certainly doesn't hurt to do this.
+	var f filter.Filter
+	filterProc, rest := liftFilter(program)
+	if filterProc != nil {
+		var err error
+		f, err = filter.Compile(filterProc.Filter)
+		if err != nil {
+			return nil, err
+		}
+		program = rest
+	}
+	input := scanner.NewScanner(reader, f)
+	leaves, err := proc.CompileProc(nil, program, ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return proc.NewMuxOutput(ctx, leaves), nil
+}
+
+func launch(ctx context.Context, query *Query, reader zbuf.Reader, zctx *resolver.Context) (*proc.MuxOutput, error) {
+	span := query.Span
+	if span == (nano.Span{}) {
+		span = nano.MaxSpan
+	}
+	procCtx := &proc.Context{
+		Context:     ctx,
+		TypeContext: zctx,
+		Logger:      zap.NewNop(),
+		Reverse:     query.Dir < 0,
+		Warnings:    make(chan string, 5),
+	}
+	return compile(procCtx, query.Proc, reader)
+}

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -1,0 +1,24 @@
+package zqd
+
+import (
+	"net/http"
+
+	"github.com/mccanne/zq/zqd/search"
+	"github.com/mccanne/zq/zqd/space"
+)
+
+func Run(port string) error {
+	http.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
+		search.Handle(w, r)
+	})
+	http.HandleFunc("/space", func(w http.ResponseWriter, r *http.Request) {
+		space.HandleList(w, r)
+	})
+	http.HandleFunc("/space/", func(w http.ResponseWriter, r *http.Request) {
+		space.HandleInfo(w, r)
+	})
+	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	return http.ListenAndServe(port, nil)
+}

--- a/zqd/space/endpoint.go
+++ b/zqd/space/endpoint.go
@@ -1,0 +1,98 @@
+package space
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mccanne/zq/zio/detector"
+	"github.com/mccanne/zq/zng"
+	"github.com/mccanne/zq/zng/resolver"
+	"github.com/mccanne/zq/zqd/api"
+)
+
+func HandleList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "bad method", http.StatusBadRequest)
+		return
+	}
+	root := "."
+	info, err := ioutil.ReadDir(root)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var spaces []string
+	for _, subdir := range info {
+		if !subdir.IsDir() {
+			continue
+		}
+		dataFile := filepath.Join(root, subdir.Name(), "all.bzng")
+		s, err := os.Stat(dataFile)
+		if err != nil || s.IsDir() {
+			continue
+		}
+		spaces = append(spaces, subdir.Name())
+	}
+	w.Header().Add("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(spaces)
+}
+
+func spaceInfo(spaceName, path string) (*api.SpaceInfo, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	reader := detector.LookupReader("bzng", f, resolver.NewContext())
+	var first, last *zng.Record
+	for {
+		rec, err := reader.Read()
+		if err != nil {
+			return nil, err
+		}
+		if rec == nil {
+			break
+		}
+		if first == nil {
+			first = rec
+		}
+		last = rec
+	}
+	if first == nil {
+		return nil, errors.New("empty space") //XXX
+	}
+	return &api.SpaceInfo{
+		Name:    spaceName,
+		MinTime: &first.Ts,
+		MaxTime: &last.Ts,
+		Size:    info.Size(),
+	}, nil
+}
+
+func HandleInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "bad method", http.StatusBadRequest)
+		return
+	}
+	//XXX need to sanitize spaceName
+	spaceName := strings.Replace(r.URL.Path, "/space/", "", 1)
+	root := "."
+	path := filepath.Join(root, spaceName, "all.bzng")
+	// XXX this is slow.  can easily cache result rather than scanning
+	// whole file each time.
+	info, err := spaceInfo(spaceName, path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Header().Add("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(info)
+}


### PR DESCRIPTION
This is a drafty first cut at functionality for "zqd" a REST-based server for running zq queries.  It implements /search, /space, /space/:name, and /status.  Currently, any subdirectory of the directory that zqd is run in is included in the space list as long as it has a filed called "all.bzng".  The searches presented through /search are run on the corresponding all.bzng.