### PR TITLE
Separate unescaping paths for string/bstring

### DIFF
--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -56,8 +56,8 @@ func runTest(filt string, record *zng.Record, expectedResult bool) error {
 }
 
 const zngsrc = `
-#0:record[stringset:set[string]]
-#1:record[stringvec:array[string]]
+#0:record[stringset:set[bstring]]
+#1:record[stringvec:array[bstring]]
 #2:record[intset:set[int]]
 #3:record[intvec:array[int]]
 #4:record[addrset:set[addr]]
@@ -65,7 +65,7 @@ const zngsrc = `
 #6:record[nested:record[field:string]]
 #7:record[nested:array[record[field:int]]]
 #8:record[nested:record[vec:array[int]]]
-#9:record[s:string]
+#9:record[s:bstring]
 #10:record[ts:time,ts2:time,ts3:time]
 #11:record[s:string,srec:record[svec:array[string]]]
 #12:record[s:bstring]

--- a/zbuf/zval.go
+++ b/zbuf/zval.go
@@ -8,14 +8,6 @@ import (
 	"github.com/mccanne/zq/zng"
 )
 
-// ZvalFromZeekString returns the zval for the Zeek UTF-8 value described by typ
-// and val.
-func ZvalFromZeekString(typ zng.Type, val string) ([]byte, error) {
-	it := zcode.Iter(appendZvalFromZeek(nil, typ, []byte(val)))
-	v, _, err := it.Next()
-	return v, err
-}
-
 // appendZvalFromZeek appends to dst the zval for the Zeek UTF-8 value described
 // by typ and val.
 func appendZvalFromZeek(dst zcode.Bytes, typ zng.Type, val []byte) zcode.Bytes {
@@ -40,7 +32,7 @@ func appendZvalFromZeek(dst zcode.Bytes, typ zng.Type, val []byte) zcode.Bytes {
 		if bytes.Equal(val, []byte{unset}) {
 			return zcode.AppendPrimitive(dst, nil)
 		}
-		body, _ := typ.Parse(zng.Unescape(val))
+		body, _ := typ.Parse(val)
 		return zcode.AppendPrimitive(dst, body)
 	}
 }

--- a/zio/zeekio/parser.go
+++ b/zio/zeekio/parser.go
@@ -93,7 +93,8 @@ func (p *Parser) ParseDirective(line []byte) error {
 		if len(tokens) != 2 {
 			return badfield("separator")
 		}
-		p.separator = string(zng.Unescape([]byte(tokens[1])))
+		// zng.UnescapeBstring handles \x format escapes
+		p.separator = string(zng.UnescapeBstring([]byte(tokens[1])))
 	case "set_separator":
 		if len(tokens) != 2 {
 			return badfield("set_separator")

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -193,7 +193,7 @@ func decodeContainer(builder *zcode.Builder, typ zng.Type, body []interface{}) e
 			if zng.IsContainerType(childType) {
 				return zng.ErrNotContainer
 			}
-			zv, err := childType.Parse(zng.Unescape([]byte(s)))
+			zv, err := childType.Parse([]byte(s))
 			if err != nil {
 				return err
 			}

--- a/zng/bstring.go
+++ b/zng/bstring.go
@@ -26,7 +26,7 @@ func DecodeBstring(zv zcode.Bytes) (string, error) {
 }
 
 func (t *TypeOfBstring) Parse(in []byte) (zcode.Bytes, error) {
-	normalized := norm.NFC.Bytes(Unescape(in))
+	normalized := norm.NFC.Bytes(UnescapeBstring(in))
 	return normalized, nil
 }
 

--- a/zng/escape.go
+++ b/zng/escape.go
@@ -30,8 +30,9 @@ func ShouldEscape(r rune, fmt OutFmt, pos int, inContainer bool) bool {
 	return false
 }
 
-// Unescape is the inverse of Escape.
-func Unescape(data []byte) []byte {
+// UnescapeBstring replaces all the escaped characters defined in the
+// for the zng spec for the bstring type with their unescaped equivalents.
+func UnescapeBstring(data []byte) []byte {
 	if bytes.IndexByte(data, '\\') < 0 {
 		return data
 	}
@@ -41,7 +42,7 @@ func Unescape(data []byte) []byte {
 		c := data[i]
 		if c == '\\' && len(data[i:]) >= 2 {
 			var n int
-			c, n = ParseEscape(data[i:])
+			c, n = parseBstringEscape(data[i:])
 			i += n
 		} else {
 			i++
@@ -51,7 +52,7 @@ func Unescape(data []byte) []byte {
 	return buf
 }
 
-func ParseEscape(data []byte) (byte, int) {
+func parseBstringEscape(data []byte) (byte, int) {
 	if len(data) >= 4 && data[1] == 'x' {
 		v1 := unhex(data[2])
 		v2 := unhex(data[3])
@@ -72,4 +73,11 @@ func unhex(b byte) byte {
 		return b - 'A' + 10
 	}
 	return 255
+}
+
+// UnescapeString replaces all the escaped characters defined in the
+// for the zng spec for the string type with their unescaped equivalents.
+func UnescapeString(data []byte) []byte {
+	// XXX implement me!
+	return data
 }

--- a/zng/escape_test.go
+++ b/zng/escape_test.go
@@ -6,30 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnescape(t *testing.T) {
-	cases := []struct {
-		unescaped string
-		escaped   string
-	}{
-		{`\`, `\\`},
-		{`\\`, `\\\\`},
-		{`ascii`, `ascii`},
-		{"\a\b\f\n\r\t\v", `\x07\x08\x0c\x0a\x0d\x09\x0b`},
-		{"\x00\x19\x20\\\x7e\x7f\xff", "\\x00\\x19\x20\\\\\x7e\\x7f\\xff"},
-	}
-	for _, c := range cases {
-		in, expected := c.escaped, c.unescaped
-
-		actual := Unescape([]byte(in))
-		require.Exactly(t, []byte(expected), actual, "case: %#v", c)
-
-		actual = Unescape([]byte("prefix" + in + "suffix"))
-		expected = "prefix" + expected + "suffix"
-		require.Exactly(t, []byte(expected), actual, "case: %#v", c)
-	}
-}
-
-func TestUnescapeUTF(t *testing.T) {
+func TestUnescapeBstring(t *testing.T) {
 	cases := []struct {
 		unescaped string
 		escaped   string
@@ -44,10 +21,10 @@ func TestUnescapeUTF(t *testing.T) {
 	for _, c := range cases {
 		in, expected := c.escaped, c.unescaped
 
-		actual := Unescape([]byte(in))
+		actual := UnescapeBstring([]byte(in))
 		require.Exactly(t, []byte(expected), actual, "case: %#v", c)
 
-		actual = Unescape([]byte("prefix" + in + "suffix"))
+		actual = UnescapeBstring([]byte("prefix" + in + "suffix"))
 		expected = "prefix" + expected + "suffix"
 		require.Exactly(t, []byte(expected), actual, "case: %#v", c)
 	}

--- a/zng/literal.go
+++ b/zng/literal.go
@@ -22,6 +22,13 @@ type Port uint32
 type Bstring []byte
 
 func ParseLiteral(literal ast.Literal) (interface{}, error) {
+	// String literals inside zql are parsed as zng bstrings
+	// (since bstrings can represent a wider range of values,
+	// specifically arrays of bytes that do not correspond to
+	// UTF-8 encoded strings).
+	if literal.Type == "string" {
+		literal = ast.Literal{"bstring", literal.Value}
+	}
 	v, err := Parse(literal)
 	if err != nil {
 		return nil, err
@@ -37,8 +44,7 @@ func ParseLiteral(literal ast.Literal) (interface{}, error) {
 	case *TypeOfSubnet:
 		// marshal doesn't work for subnet
 		return DecodeSubnet(v.Bytes)
-	case *TypeOfString:
-		// return as a native Bstring
+	case *TypeOfBstring:
 		s, err := DecodeString(v.Bytes)
 		return Bstring(s), err
 	case *TypeOfPort:

--- a/zng/string.go
+++ b/zng/string.go
@@ -29,7 +29,7 @@ func DecodeString(zv zcode.Bytes) (string, error) {
 }
 
 func (t *TypeOfString) Parse(in []byte) (zcode.Bytes, error) {
-	normalized := norm.NFC.Bytes(Unescape(in))
+	normalized := norm.NFC.Bytes(UnescapeString(in))
 	return normalized, nil
 }
 


### PR DESCRIPTION
Unescape handling for the string type is not yet in place, but this is
an incremental step toward having separate unescaping rules in place for
the string and bstring types.  Also cleaned up several places where we
were double-unescaping unnecessarily (i.e., calling Unescape() and then
Parse() on the same data).