### PR TITLE
fix bug with type context in zqd search end point

### DIFF
--- a/scanner/mapper.go
+++ b/scanner/mapper.go
@@ -1,0 +1,36 @@
+package scanner
+
+import (
+	"github.com/mccanne/zq/zbuf"
+	"github.com/mccanne/zq/zng"
+	"github.com/mccanne/zq/zng/resolver"
+)
+
+type Mapper struct {
+	zbuf.Reader
+	mapper *resolver.Mapper
+}
+
+func NewMapper(reader zbuf.Reader, zctx *resolver.Context) *Mapper {
+	return &Mapper{
+		Reader: reader,
+		mapper: resolver.NewMapper(zctx),
+	}
+}
+
+func (m *Mapper) Read() (*zng.Record, error) {
+	rec, err := m.Reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil {
+		return nil, nil
+	}
+	id := rec.Type.ID()
+	sharedType := m.mapper.Map(id)
+	if sharedType == nil {
+		sharedType = m.mapper.Enter(id, rec.Type)
+	}
+	rec.Type = sharedType
+	return rec, nil
+}

--- a/zqd/search/endpoint.go
+++ b/zqd/search/endpoint.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mccanne/zq/ast"
 	"github.com/mccanne/zq/pkg/nano"
+	"github.com/mccanne/zq/scanner"
 	"github.com/mccanne/zq/zio/detector"
 	"github.com/mccanne/zq/zng/resolver"
 	"github.com/mccanne/zq/zqd/api"
@@ -100,9 +101,10 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer f.Close()
+	zngReader := detector.LookupReader("bzng", f, resolver.NewContext())
 	zctx := resolver.NewContext()
-	zngReader := detector.LookupReader("bzng", f, zctx)
-	mux, err := launch(r.Context(), query, zngReader, zctx)
+	mapper := scanner.NewMapper(zngReader, zctx)
+	mux, err := launch(r.Context(), query, mapper, zctx)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
This commit fixes a bug where the reader's type context was used
during the search instead of a blank context causing a clash between
dynamic results and the input file types.  We fix this by allocating
a context mapper in the search path.

This is worthy of a test but we don't have a system test framework in 
place yet for zqd.