### PR TITLE
Unescape \x sequences in glob patterns

### DIFF
--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -225,5 +225,5 @@ func TestBadFilter(t *testing.T) {
 	filter := `s = \xa8*`
 	_, err := compileFilter(filter)
 	assert.Error(t, err, "Received error for bad glob")
-	assert.Contains(t, err.Error(), "non UTF-8 sequence in regexp", "Received good error message for invalid UTF-8 in a regexp")
+	assert.Contains(t, err.Error(), "invalid UTF-8", "Received good error message for invalid UTF-8 in a regexp")
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -75,7 +75,7 @@ const zngsrc = `
 #12:record[s:bstring]
 0:[[abc;xyz;]]
 1:[[abc;xyz;]]
-1:[[a\;b;xyz;]]
+1:[[a\x3bb;xyz;]]
 2:[[1;2;3;]]
 3:[[1;2;3;]]
 4:[[1.1.1.1;2.2.2.2;]]
@@ -89,7 +89,7 @@ const zngsrc = `
 9:[Buenos di\xcc\x81as sen\xcc\x83or;]
 9:[Buenos d\xc3\xadas se\xc3\xb1or;]
 12:[hello;]
-0:[[a\;b;xyz;]]
+0:[[a\x3bb;xyz;]]
 `
 
 func TestFilters(t *testing.T) {

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -610,12 +610,13 @@ to be embedded in the `bstring` data type.
 `\x` followed by anything other than two hexadecimal digits is not a valid
 escape sequence. The behavior of an implementation that encounters such
 invalid sequences in a `bstring` type is undefined.
+Additionally, the backslash character itself (U+3B) may be represented
+by a sequence of two consecutive backslash characters.  In other words,
+the bstrings `\\` and `\x3b` are equivalent and both represent a single
+backslash character.
 
 These special characters must be escaped if they appear within a
-`string` or `bstring` type:
-```
-; \n \\
-```
+`string` or `bstring` type: `;`, `\`, newline (Unicode U+0A).
 These characters are invalid in all other data types.
 
 Likewise, these characters must be escaped if they appear as the first character

--- a/zng/escape.go
+++ b/zng/escape.go
@@ -59,8 +59,12 @@ func parseBstringEscape(data []byte) (byte, int) {
 		if v1 <= 0xf || v2 <= 0xf {
 			return v1<<4 | v2, 4
 		}
+	} else if len(data) >= 2 && data[1] == '\\' {
+		return data[1], 2
 	}
-	return data[1], 2
+
+	// Not a valid escape sequence, just lleave it alone.
+	return data[0], 1
 }
 
 func unhex(b byte) byte {

--- a/zng/escape.go
+++ b/zng/escape.go
@@ -63,7 +63,7 @@ func parseBstringEscape(data []byte) (byte, int) {
 		return data[1], 2
 	}
 
-	// Not a valid escape sequence, just lleave it alone.
+	// Not a valid escape sequence, just leave it alone.
 	return data[0], 1
 }
 

--- a/zx/compare.go
+++ b/zx/compare.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"regexp/syntax"
 	"strings"
 
 	"github.com/mccanne/zq/ast"
@@ -274,8 +275,8 @@ func CompareBstring(op string, pattern zng.Bstring) (Predicate, error) {
 func compareRegexp(op, pattern string) (Predicate, error) {
 	re, err := regexp.Compile(string(zng.UnescapeBstring([]byte(pattern))))
 	if err != nil {
-		if strings.Contains(err.Error(), "invalid UTF-8") {
-			err = fmt.Errorf("non UTF-8 sequence in regexp \"%s\"", pattern)
+		if syntaxErr, ok := err.(*syntax.Error); ok {
+			syntaxErr.Expr = pattern
 		}
 		return nil, err
 	}

--- a/zx/compare.go
+++ b/zx/compare.go
@@ -268,7 +268,7 @@ func CompareBstring(op string, pattern zng.Bstring) (Predicate, error) {
 	}, nil
 }
 
-// RegexpComparison returns a Predicate that compares values that must
+// compareRegexp returns a Predicate that compares values that must
 // be a string or enum with the value's regular expression using a regex
 // match comparison based on equality or inequality based on op.
 func compareRegexp(op, pattern string) (Predicate, error) {


### PR DESCRIPTION
Since globs are converted to regexps and regexps must contain only
valid UTF-8, try to emit a helpful error for invalid globs.