### PR TITLE
implement time ranges in /search and add /version

### DIFF
--- a/cmd/zqd/main.go
+++ b/cmd/zqd/main.go
@@ -5,10 +5,17 @@ import (
 	"os"
 
 	_ "github.com/mccanne/zq/cmd/zqd/listen"
-	root "github.com/mccanne/zq/cmd/zqd/root"
+	"github.com/mccanne/zq/cmd/zqd/root"
+	"github.com/mccanne/zq/zqd"
 )
 
+// Version is set via the Go linker.
+var version = "unknown"
+
 func main() {
+	//XXX
+	zqd.Version.Zq = version
+	zqd.Version.Zqd = version
 	if _, err := root.Zqd.ExecRoot(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)

--- a/cmd/zqd/root/command.go
+++ b/cmd/zqd/root/command.go
@@ -8,12 +8,6 @@ import (
 	"github.com/mccanne/charm"
 )
 
-// These variables are populated via the Go linker.
-var (
-	Version    = "unknown"
-	ZqdVersion = "unknown"
-)
-
 var Zqd = &charm.Spec{
 	Name:  "zqd",
 	Usage: "zqd [global options] command [options] [arguments...]",

--- a/zqd/search/endpoint.go
+++ b/zqd/search/endpoint.go
@@ -121,10 +121,10 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		err = run(mux, s)
+		err = run(mux, s, query.Span)
 	case "bzng":
 		s := newBzngOutput(r, w)
-		err = run(mux, s)
+		err = run(mux, s, query.Span)
 	}
 	if err != nil {
 		httpError(w, err.Error(), http.StatusBadRequest)

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -76,7 +76,7 @@ func (d *driver) searchEnd(cid int, stats api.ScannerStats) error {
 	return d.output.SendControl(v)
 }
 
-func run(out *proc.MuxOutput, output Output) error {
+func run(out *proc.MuxOutput, output Output, span nano.Span) error {
 	//XXX scanner needs to track stats, for now send zeroes
 	var stats api.ScannerStats
 	d := &driver{
@@ -118,6 +118,9 @@ func run(out *proc.MuxOutput, output Output) error {
 				return d.abort(0, err)
 			}
 		} else {
+			if !span.Overlaps(chunk.Batch.Span()) {
+				continue
+			}
 			err := d.output.SendBatch(chunk.ID, chunk.Batch)
 			if err != nil {
 				return d.abort(0, err)

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -1,11 +1,20 @@
 package zqd
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/mccanne/zq/zqd/search"
 	"github.com/mccanne/zq/zqd/space"
 )
+
+type VersionMessage struct {
+	Zqd string `json:"boomd"` //XXX boomd -> zqd
+	Zq  string `json:"zq"`
+}
+
+// This struct filled in by main from linker setting version strings.
+var Version VersionMessage
 
 func Run(port string) error {
 	http.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
@@ -19,6 +28,10 @@ func Run(port string) error {
 	})
 	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
+	})
+	http.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(&Version)
 	})
 	return http.ListenAndServe(port, nil)
 }


### PR DESCRIPTION
This commit properly limits a search to the requested time range.
It still scans the entire file and does not handle reverse searches
and it still ignore the dir option in the search request.

It also implements the /version endpoint, returning unknown for the
version info as the version number is not yet hooked up to the linker.

We also made the space info a bit more robust to computing the proper
time range (but still have no caching of this info so the entire
file is scanned on each info request).