### PR TITLE
fix bug in scanner time range

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -11,6 +11,7 @@ import (
 type Scanner struct {
 	reader zbuf.Reader
 	filter filter.Filter
+	span   nano.Span
 }
 
 func NewScanner(reader zbuf.Reader, f filter.Filter) *Scanner {
@@ -18,6 +19,10 @@ func NewScanner(reader zbuf.Reader, f filter.Filter) *Scanner {
 		reader: reader,
 		filter: f,
 	}
+}
+
+func (s *Scanner) SetSpan(span nano.Span) {
+	s.span = span
 }
 
 const batchSize = 100
@@ -35,6 +40,9 @@ func (s *Scanner) Pull() (zbuf.Batch, error) {
 			break
 		}
 		if match != nil && !match(rec) {
+			continue
+		}
+		if s.span.Dur != 0 && !s.span.Contains(rec.Ts) {
 			continue
 		}
 		if rec.Ts < minTs {

--- a/zqd/search/endpoint.go
+++ b/zqd/search/endpoint.go
@@ -121,10 +121,10 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		err = run(mux, s, query.Span)
+		err = run(mux, s)
 	case "bzng":
 		s := newBzngOutput(r, w)
-		err = run(mux, s, query.Span)
+		err = run(mux, s)
 	}
 	if err != nil {
 		httpError(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
The time range of the query was applied to the output instead of the
input.  This fixes it to be applied to the input.